### PR TITLE
Revert switch to git urls rather than npm repo for dependencies

### DIFF
--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -72,7 +72,7 @@ if (!servicePackageExists) {
   const defaultPackage = `
 {
   "dependencies": {
-    "@ministryofjustice/fb-components-core": "https://github.com/ministryofjustice/fb-components-core.git"
+    "@ministryofjustice/fb-components-core": "latest"
   }
 }
 `

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/fb-runner-node",
-  "version": "0.0.141-alpha",
+  "version": "0.0.142-alpha",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5122,7 +5122,7 @@
           "dev": true
         },
         "handlebars": {
-          "version": "4.1.2",
+          "version": "4.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -5258,7 +5258,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "handlebars": "^4.1.2"
+            "handlebars": "^4.1.0"
           }
         },
         "json-parse-better-errors": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/fb-runner-node",
-  "version": "0.0.141-alpha",
+  "version": "0.0.142-alpha",
   "description": "Form Builder Runner (Node version)",
   "main": "lib/server/server.js",
   "repository": {


### PR DESCRIPTION
Attempting to use git urls to install the dependencies causes the editor console to barf if the user does not have sufficient privileges.

When the app is signed, we'll be able to switch back to urls representing git tags