### PR TITLE
Fixed property to get error returned by Request from

### DIFF
--- a/lib/page/process-uploads/store-uploaded-files.js
+++ b/lib/page/process-uploads/store-uploaded-files.js
@@ -44,7 +44,7 @@ const storeUploadedFiles = async (userData, uploadedResults) => {
         return Object.assign({file}, result)
       })
       .catch(err => {
-        return Object.assign({file}, err)
+        return Object.assign({file, error: err})
       })
   })
 

--- a/lib/page/process-uploads/store-uploaded-files.unit.spec.js
+++ b/lib/page/process-uploads/store-uploaded-files.unit.spec.js
@@ -140,11 +140,8 @@ test('When storeUploadedFiles encounters an error uploading a file', async t => 
   FBUserFileStoreClientStub.restore()
   FBUserFileStoreClientStub = stub(FBUserFileStoreClient, 'storeFromPath')
   FBUserFileStoreClientStub.callsFake(async (file) => {
-    const requestError = new Error()
-    requestError.error = {
-      code: 500,
-      message: 'AWS Bill not paid'
-    }
+    const requestError = new Error('AWS Bill not paid')
+    requestError.code = 500
     throw requestError
   })
   setUserDataPropertyStub.resetHistory()
@@ -156,7 +153,7 @@ test('When storeUploadedFiles encounters an error uploading a file', async t => 
       originalname: 'originalname',
       errorMessage: 'AWS Bill not paid',
       errorCode: 500,
-      errorType: 'Object',
+      errorType: 'Error',
       maxSize: 10 * 1024 * 1024,
       size: 6000,
       type: 'image/monkey'


### PR DESCRIPTION
The test incorrectly asserted that Request would return an error object that had an error property which contained the necessary information. Instead that information can be found as properties of the error object itself.

Updated incorrect test to match.

(NB. the test caused us to remove exactly the wrong part of the method call when we reviewed the file upload)