### PR TITLE
Prevent useAsync inadvertently passing return value 

### DIFF
--- a/lib/middleware/use-async/use-async.js
+++ b/lib/middleware/use-async/use-async.js
@@ -9,8 +9,8 @@ function useAsync (middleware) {
     }
 
     middleware(req, res)
-      .then(callNext)
-      .catch(callNext)
+      .then(() => { callNext() })
+      .catch((err) => { callNext(err) })
   }
 }
 

--- a/lib/middleware/use-async/use-async.unit.spec.js
+++ b/lib/middleware/use-async/use-async.unit.spec.js
@@ -4,7 +4,7 @@ const useAsync = require('./use-async')
 
 const invokeMiddleware = async (options = {}) => {
   const wrappedRoute = useAsync((req, res) => {
-    return options.error ? Promise.reject(options.error) : Promise.resolve()
+    return options.error ? Promise.reject(options.error) : Promise.resolve(options.value)
   })
   const req = {}
   const res = {}
@@ -28,10 +28,11 @@ const invokeMiddleware = async (options = {}) => {
 }
 
 test('When async wrapped middleware executes successfully and headers have not been sent', async t => {
-  t.plan(1)
+  t.plan(2)
 
   const nextStub = await invokeMiddleware()
   t.equal(nextStub.calledOnce, true, 'it should invoke the next middleware')
+  t.equal(nextStub.calledOnceWithExactly(undefined), true, 'it should not pass any value returned by the middleware to next')
 })
 
 test('When async wrapped middleware executes successfully and headers have been sent', async t => {


### PR DESCRIPTION
as quasi-error to wrapped next method