### PR TITLE
Tag docker images with an additional Git SHA1 tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,14 +24,14 @@ target:
 ifeq ($(TARGETDEFINED), "true")
 	$(eval export env_stub=${TARGET})
 	@true
-else 
+else
 	$(info Must set TARGET)
 	@false
 endif
 
 init:
-	$(eval export ECR_REPO_NAME=fb-runner-node)
-	$(eval export ECR_REPO_URL_ROOT=754256621582.dkr.ecr.eu-west-2.amazonaws.com/formbuilder)
+	$(eval export ECR_REPO_URL=754256621582.dkr.ecr.eu-west-2.amazonaws.com/formbuilder/fb-runner-node)
+	$(eval export TAG=`git rev-parse HEAD`)
 
 # install aws cli w/o sudo
 install_build_dependencies: init
@@ -39,17 +39,15 @@ install_build_dependencies: init
 	pip install --user awscli
 	$(eval export PATH=${PATH}:${HOME}/.local/bin/)
 
-
-# Needs ECR_REPO_NAME & ECR_REPO_URL env vars
 build: install_build_dependencies
-	docker build -t ${ECR_REPO_NAME}:latest-${env_stub} -f ./Dockerfile . && \
-		docker tag ${ECR_REPO_NAME}:latest-${env_stub} ${ECR_REPO_URL_ROOT}/${ECR_REPO_NAME}:latest-${env_stub}
+	docker build -t ${ECR_REPO_URL}:latest-${env_stub} -t ${ECR_REPO_URL}:${TAG} -f ./Dockerfile .
 
 login: init
 	@eval $(shell aws ecr get-login --no-include-email --region eu-west-2)
 
 push: login
-	docker push ${ECR_REPO_URL_ROOT}/${ECR_REPO_NAME}:latest-${env_stub}
+	docker push ${ECR_REPO_URL}:latest-${env_stub}
+	docker push ${ECR_REPO_URL}:${TAG}
 
 build_and_push: build push
 


### PR DESCRIPTION
Currently when deploying user forms through the Publisher, it results in downtime.
To do rolling deployments, we need to have a dynamic tag value that can be
referenced.

A future pull request in the Publisher will use this tag in the deployment manifests.