### PR TITLE
Downgrade node.js

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.4.0-slim
+FROM node:10.15-slim
 
 # derived from https://github.com/alekzonder/docker-puppeteer/blob/master/Dockerfile
 RUN apt-get update && \


### PR DESCRIPTION
Let's see if this helps with the puppeteer related errors we're seeing in our error tracker 