### PR TITLE
Catch duplicated input names

### DIFF
--- a/lib/page/process-input/process-input.js
+++ b/lib/page/process-input/process-input.js
@@ -1,11 +1,15 @@
 const jp = require('jsonpath')
 const {default: produce} = require('immer')
+const {FBError} = require('@ministryofjustice/fb-utils-node')
 const {getServiceSchema} = require('../../service-data/service-data')
 const redact = require('../../redact/redact')
-
 const {getInstanceController} = require('../../controller/controller')
+class FBProcessInputError extends FBError {}
+
+const {PLATFORM_ENV} = require('../../constants/constants')
 
 const processInput = (pageInstance, userData) => {
+  const logger = userData.logger
   const input = userData.getBodyInput()
 
   pageInstance = produce(pageInstance, draft => {
@@ -102,6 +106,22 @@ const processInput = (pageInstance, userData) => {
           }
         } else {
           if (nameValue) {
+            if (Array.isArray(nameValue)) {
+              logger.error({name}, 'Input name is not unique for the request')
+              let renderError
+              if (!PLATFORM_ENV) {
+                renderError = {
+                  heading: `Input name ${name} is not unique`,
+                  lede: 'The form will not work correctly unless you fix this problem'
+                }
+              }
+              throw new FBProcessInputError(`Input name ${name} is not unique`, {
+                error: {
+                  code: 'EDUPLICATEINPUTNAME',
+                  renderError
+                }
+              })
+            }
             nameValue = nameValue.trim()
           }
           if (nameValue === '') {


### PR DESCRIPTION
Providing more useful feedback if not in a deployed environment