### PR TITLE
Reduce amount of changes made to multer's make-middleware 

### DIFF
--- a/lib/page/process-uploads/multer/lib/counter.js
+++ b/lib/page/process-uploads/multer/lib/counter.js
@@ -1,0 +1,2 @@
+const Counter = require('multer/lib/counter')
+module.exports = Counter

--- a/lib/page/process-uploads/multer/lib/file-appender.js
+++ b/lib/page/process-uploads/multer/lib/file-appender.js
@@ -1,0 +1,2 @@
+const FileAppender = require('multer/lib/file-appender')
+module.exports = FileAppender

--- a/lib/page/process-uploads/multer/lib/make-middleware.js
+++ b/lib/page/process-uploads/multer/lib/make-middleware.js
@@ -1,13 +1,15 @@
-let is = require('type-is')
-let Busboy = require('busboy')
-let extend = require('xtend')
-let onFinished = require('on-finished')
-let appendField = require('append-field')
+/* eslint-disable no-var */
+/* eslint-disable object-curly-spacing */
+var is = require('type-is')
+var Busboy = require('busboy')
+var extend = require('xtend')
+var onFinished = require('on-finished')
+var appendField = require('append-field')
 
-let Counter = require('multer/lib/counter')
-let MulterError = require('multer/lib/multer-error')
-let FileAppender = require('multer/lib/file-appender')
-let removeUploadedFiles = require('multer/lib/remove-uploaded-files')
+var Counter = require('./counter')
+var MulterError = require('./multer-error')
+var FileAppender = require('./file-appender')
+var removeUploadedFiles = require('./remove-uploaded-files')
 
 function drainStream (stream) {
   stream.on('readable', stream.read.bind(stream))
@@ -17,15 +19,16 @@ function makeMiddleware (setup) {
   return function multerMiddleware (req, res, next) {
     if (!is(req, ['multipart'])) return next()
 
-    let options = setup()
+    var options = setup()
 
-    let limits = options.limits
-    let storage = options.storage
-    let fileFilter = options.fileFilter
-    let fileStrategy = options.fileStrategy
-    let preservePath = options.preservePath
+    var limits = options.limits
+    var storage = options.storage
+    var fileFilter = options.fileFilter
+    var fileStrategy = options.fileStrategy
+    var preservePath = options.preservePath
 
     req.body = Object.create(null)
+    // FB addition - add bodyErrors prop to req and addFilesError method
     req.bodyErrors = Object.create(null)
     const addFilesError = (fieldname, err, file) => {
       req.bodyErrors.files = req.bodyErrors.files || Object.create(null)
@@ -33,21 +36,22 @@ function makeMiddleware (setup) {
       req.bodyErrors.files[code] = req.bodyErrors.files[code] || []
       req.bodyErrors.files[code].push(file)
     }
+    // FB addition ends
 
-    let busboy
+    var busboy
 
     try {
-      busboy = new Busboy({headers: req.headers, limits: limits, preservePath: preservePath})
+      busboy = new Busboy({ headers: req.headers, limits: limits, preservePath: preservePath })
     } catch (err) {
       return next(err)
     }
 
-    let appender = new FileAppender(fileStrategy, req)
-    let isDone = false
-    let readFinished = false
-    let errorOccured = false
-    let pendingWrites = new Counter()
-    let uploadedFiles = []
+    var appender = new FileAppender(fileStrategy, req)
+    var isDone = false
+    var readFinished = false
+    var errorOccured = false
+    var pendingWrites = new Counter()
+    var uploadedFiles = []
 
     function done (err) {
       if (isDone) return
@@ -109,18 +113,20 @@ function makeMiddleware (setup) {
         if (fieldname.length > limits.fieldNameSize) return abortWithCode('LIMIT_FIELD_KEY')
       }
 
-      let file = {
+      var file = {
         fieldname: fieldname,
         originalname: filename,
         encoding: encoding,
         mimetype: mimetype
       }
 
-      let placeholder = appender.insertPlaceholder(file)
+      var placeholder = appender.insertPlaceholder(file)
 
       fileFilter(req, file, function (err, includeFile) {
         if (err) {
+          // FB addition
           addFilesError(fieldname, err, file)
+          // FB addition ends
           appender.removePlaceholder(placeholder)
           return abortWithError(err)
         }
@@ -130,7 +136,7 @@ function makeMiddleware (setup) {
           return fileStream.resume()
         }
 
-        let aborting = false
+        var aborting = false
         pendingWrites.increment()
 
         Object.defineProperty(file, 'stream', {
@@ -140,15 +146,20 @@ function makeMiddleware (setup) {
         })
 
         fileStream.on('error', function (err) {
+          // FB addition
           addFilesError(fieldname, err, file)
+          // FB addition ends
           pendingWrites.decrement()
           abortWithError(err)
         })
 
         fileStream.on('limit', function () {
+          // FB addition
           addFilesError(fieldname, 'LIMIT_FILE_SIZE', file)
+          // FB addition ends
           aborting = true
-          abortWithCode('LIMIT_FILE_SIZE', fieldname)
+          // FB deletion
+          // abortWithCode('LIMIT_FILE_SIZE', fieldname)
         })
 
         storage._handleFile(req, file, function (err, info) {
@@ -159,13 +170,15 @@ function makeMiddleware (setup) {
           }
 
           if (err) {
+            // FB addition
             addFilesError(fieldname, err, file)
+            // FB addition ends
             appender.removePlaceholder(placeholder)
             pendingWrites.decrement()
             return abortWithError(err)
           }
 
-          let fileInfo = extend(file, info)
+          var fileInfo = extend(file, info)
 
           appender.replacePlaceholder(placeholder, fileInfo)
           uploadedFiles.push(fileInfo)

--- a/lib/page/process-uploads/multer/lib/make-middleware.js-1.4.2-patch
+++ b/lib/page/process-uploads/multer/lib/make-middleware.js-1.4.2-patch
@@ -1,0 +1,34 @@
+0a1,2
+> /* eslint-disable no-var */
+> /* eslint-disable object-curly-spacing */
+28a31,39
+>     // FB addition - add bodyErrors prop to req and addFilesError method
+>     req.bodyErrors = Object.create(null)
+>     const addFilesError = (fieldname, err, file) => {
+>       req.bodyErrors.files = req.bodyErrors.files || Object.create(null)
+>       const code = typeof err === 'string' ? err : err.code || 'UNKNOWN_ERROR'
+>       req.bodyErrors.files[code] = req.bodyErrors.files[code] || []
+>       req.bodyErrors.files[code].push(file)
+>     }
+>     // FB addition ends
+115a127,129
+>           // FB addition
+>           addFilesError(fieldname, err, file)
+>           // FB addition ends
+134a149,151
+>           // FB addition
+>           addFilesError(fieldname, err, file)
+>           // FB addition ends
+139a157,159
+>           // FB addition
+>           addFilesError(fieldname, 'LIMIT_FILE_SIZE', file)
+>           // FB addition ends
+141c161,162
+<           abortWithCode('LIMIT_FILE_SIZE', fieldname)
+---
+>           // FB deletion
+>           // abortWithCode('LIMIT_FILE_SIZE', fieldname)
+151a173,175
+>             // FB addition
+>             addFilesError(fieldname, err, file)
+>             // FB addition ends

--- a/lib/page/process-uploads/multer/lib/multer-error.js
+++ b/lib/page/process-uploads/multer/lib/multer-error.js
@@ -1,0 +1,2 @@
+const MulterError = require('multer/lib/multer-error')
+module.exports = MulterError

--- a/lib/page/process-uploads/multer/lib/remove-uploaded-files.js
+++ b/lib/page/process-uploads/multer/lib/remove-uploaded-files.js
@@ -1,0 +1,2 @@
+const removeUploadedFiles = require('multer/lib/remove-uploaded-files')
+module.exports = removeUploadedFiles


### PR DESCRIPTION
to enable easier updating.

- retain use of `var` as per original and spacing around curly-brackets
- add comments around additions and delettions