### PR TITLE
Add recipientType for submitter to identify type of email

### DIFF
--- a/lib/submission/submitter-payload.js
+++ b/lib/submission/submitter-payload.js
@@ -1,5 +1,6 @@
 const generateEmail = (recipientType, from, subject, url, submissionId, addAttachment = true) => {
   const email = {
+    recipientType: recipientType,
     type: 'email',
     from,
     subject,

--- a/lib/submission/submitter-payload.unit.spec.js
+++ b/lib/submission/submitter-payload.unit.spec.js
@@ -13,6 +13,7 @@ test('Generating a user submission email with an attachment', async t => {
   const result = generateEmail('user', from, subject, url, submissionId, addAttachment)
 
   const expectedResult = {
+    recipientType: 'user',
     type: 'email',
     from,
     subject,
@@ -43,6 +44,7 @@ test('Generating a team submission email', async t => {
   const addAttachment = true
   const result = generateEmail('team', from, subject, url, submissionId, addAttachment)
 
+  t.deepEquals(result.recipientType, 'team', 'it should populate the recipient type')
   t.deepEquals(result.body_parts['text/plain'], 'some-url/foo/team/abc123-team', 'it should have a body with a link for the team')
   t.deepEquals(result.attachments[0].url, '/api/submitter/pdf/default/team/abc123-team.pdf', 'it should have an attachment with a link for the team')
   t.end()


### PR DESCRIPTION
We will be using Notify for user emails and SES for team emails.
To make the distinction between the two, we need an extra property.

This could be derived from other values but would be fragile in case of an
unrelated change.