### PR TITLE
Optional user form submission email attachments

### DIFF
--- a/lib/constants/constants.js
+++ b/lib/constants/constants.js
@@ -131,7 +131,7 @@ const CONSTANTS = Object.assign({
   SERVICE_TOKEN: '<NONE>',
   SERVICE_SECRET: '<NONE>',
   COMPONENTS_MODULE: '@ministryofjustice/fb-components-core',
-  COMPONENTS_VERSION: '~3.0.0-1'
+  COMPONENTS_VERSION: '~3.0.0-2'
 },
 processEnv,
 insertions,

--- a/lib/constants/constants.unit.spec.js
+++ b/lib/constants/constants.unit.spec.js
@@ -20,7 +20,7 @@ test('When constants is called', t => {
     SERVICE_TOKEN: '<NONE>',
     SERVICE_SECRET: '<NONE>',
     COMPONENTS_MODULE: '@ministryofjustice/fb-components-core',
-    COMPONENTS_VERSION: '~3.0.0-1',
+    COMPONENTS_VERSION: '~3.0.0-2',
     RUNNER_DIR: runnerDir,
     APP_DIR: runnerDir,
     UPLOADS_DIR: '/tmp/uploads',

--- a/lib/controller/page/type/page.summary/page.summary.controller.js
+++ b/lib/controller/page/type/page.summary/page.summary.controller.js
@@ -16,11 +16,9 @@ const {
   getInstanceProperty,
   getString
 } = require('../../../../service-data/service-data')
-const {
-  getUrl,
-  getNextPage
-} = require('../../../../route/route')
+const {getUrl} = require('../../../../route/route')
 const redirectNextPage = require('../../../../page/redirect-next-page/redirect-next-page')
+const {checkSubmits} = require('../../../../page/check-submits/check-submits')
 
 const {format} = require('../../../../format/format')
 
@@ -29,16 +27,6 @@ const {generateEmail} = require('../../../../submission/submitter-payload')
 const submitterClient = require('../../../../client/submitter/submitter')
 
 const SummaryController = {}
-
-const checkSubmits = (pageInstance, userData) => {
-  const nextPage = getNextPage({_id: pageInstance._id, params: userData.getUserParams()}, userData)
-  // Check page actually submits
-  if (!nextPage) {
-    return false
-  }
-  const nextType = getInstanceProperty(nextPage._id, '_type')
-  return nextType === 'page.confirmation'
-}
 
 SummaryController.preFlight = async (instance, userData) => {
   const pageInstance = instance
@@ -169,7 +157,8 @@ SummaryController.postValidation = async (pageInstance, userData) => {
       if (userEmail) {
         const userSubject = getInstanceProperty('service', 'emailSubjectUser') || `Your ${serviceName} submission`
         const subject = formatEmail(userSubject)
-        const userSubmission = generateEmail('user', from, subject, emailUrlStub, submissionId)
+        const addAttachment = getInstanceProperty('service', 'attachUserSubmission') || false
+        const userSubmission = generateEmail('user', from, subject, emailUrlStub, submissionId, addAttachment)
 
         const toUserParts = userEmail.split(/,\s*/)
         toUserParts.forEach(to => {

--- a/lib/controller/page/type/page.summary/page.summary.controller.unit.spec.js
+++ b/lib/controller/page/type/page.summary/page.summary.controller.unit.spec.js
@@ -1,5 +1,6 @@
 const test = require('tape')
-const {stub} = require('sinon')
+const submitterClient = require('../../../../client/submitter/submitter')
+const {stub, spy} = require('sinon')
 
 const proxyquire = require('proxyquire')
 
@@ -13,10 +14,15 @@ const getNextPageStub = stub(route, 'getNextPage')
 
 const redirectNextPageStub = stub()
 
+const submitterClientSpy = spy(submitterClient, 'submit')
+
+const checkSubmitsStub = (_instanceData, _userData) => true
+
 const pageSummaryController = proxyquire('./page.summary.controller', {
   '../../../../route/route': route,
   '../../../../service-data/service-data': serviceData,
-  '../../../../page/redirect-next-page/redirect-next-page': redirectNextPageStub
+  '../../../../page/redirect-next-page/redirect-next-page': redirectNextPageStub,
+  '../../../../client/submitter/submitter': {submitterClient: submitterClientSpy}
 })
 
 getInstancePropertyStub.callsFake((_id, type) => {
@@ -24,6 +30,7 @@ getInstancePropertyStub.callsFake((_id, type) => {
     isConfirmation: 'page.confirmation',
     fauxConfirmation: 'page.content'
   }
+
   return type === '_type' ? matches[_id] : undefined
 })
 
@@ -119,5 +126,37 @@ test('When all previous required questions have been answered - and a url is ret
   })
   const expectedInstance = await pageSummaryController.preFlight(instance, userData)
   t.equals(expectedInstance.redirect, undefined, 'it should not return an unanswered page to redirect to')
+  t.end()
+})
+
+test('it attaches a user submission when the property is set to true', async t => {
+  getInstancePropertyStub.withArgs('service', 'attachUserSubmission').returns(true)
+
+  const pageSummaryController = proxyquire('./page.summary.controller', {
+    '../../../../page/check-submits/check-submits': {checkSubmits: checkSubmitsStub}
+  })
+
+  await pageSummaryController.postValidation({}, userData)
+
+  const submissions = submitterClientSpy.getCall(0).args[0].submissions
+  t.equals(submissions[0]['recipientType'], 'user')
+  t.equals(submissions[0].attachments.length, 1)
+  submitterClientSpy.resetHistory()
+  t.end()
+})
+
+test('it does not attach a user submission when the property is set to false', async t => {
+  getInstancePropertyStub.withArgs('service', 'attachUserSubmission').returns(false)
+  const pageSummaryController = proxyquire('./page.summary.controller', {
+    '../../../../page/check-submits/check-submits': {checkSubmits: checkSubmitsStub}
+  })
+
+  await pageSummaryController.postValidation({}, userData)
+
+  const submissions = submitterClientSpy.getCall(0).args[0].submissions
+
+  t.equals(submissions[0]['recipientType'], 'user')
+  t.equals(submissions[0].attachments.length, 0)
+  submitterClientSpy.resetHistory()
   t.end()
 })

--- a/lib/page/check-submits/check-submits.js
+++ b/lib/page/check-submits/check-submits.js
@@ -1,0 +1,16 @@
+const {getNextPage} = require('../../route/route')
+const {getInstanceProperty} = require('../../service-data/service-data')
+
+const checkSubmits = (pageInstance, userData) => {
+  const nextPage = getNextPage({_id: pageInstance._id, params: userData.getUserParams()}, userData)
+  // Check page actually submits
+  if (!nextPage) {
+    return false
+  }
+  const nextType = getInstanceProperty(nextPage._id, '_type')
+  return nextType === 'page.confirmation'
+}
+
+module.exports = {
+  checkSubmits
+}


### PR DESCRIPTION
Not all users would like to receive attachments of their form submissions.
A config param can be set in the submitter to turn this on, default is off.