### PR TITLE
circleci image building

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,18 @@ jobs:
       - run:
           name: Build integration image
           command: scripts/circleci_build.sh integration
+  build_to_live:
+    docker:
+      - image: asmega/fb-builder:latest
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: npm install
+          command: npm install
+      - run:
+          name: Build live image
+          command: scripts/circleci_build.sh live
 
 workflows:
   version: 2
@@ -45,9 +57,9 @@ workflows:
       - build_to_test:
           requires:
             - test
-#           filters:
-#             branches:
-#               only: master
+          filters:
+            branches:
+              only: master
       - confirm_integration_build:
           type: approval
           requires:
@@ -55,10 +67,10 @@ workflows:
       - build_to_integration:
           requires:
             - confirm_integration_build
-#      - confirm_live_build:
-#          type: approval
-#          requires:
-#            - build_to_integration
-#      - build_to_live:
-#          requires:
-#            - confirm_live_build
+      - confirm_live_build:
+          type: approval
+          requires:
+            - build_to_integration
+      - build_to_live:
+          requires:
+            - confirm_live_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,18 @@ jobs:
       - run:
           name: Build test image
           command: scripts/circleci_build.sh test
+  build_to_integration:
+    docker:
+      - image: asmega/fb-builder:latest
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: npm install
+          command: npm install
+      - run:
+          name: Build integration image
+          command: scripts/circleci_build.sh integration
 
 workflows:
   version: 2
@@ -36,13 +48,13 @@ workflows:
 #           filters:
 #             branches:
 #               only: master
-#      - confirm_integration_build:
-#          type: approval
-#          requires:
-#            - build_to_test
-#      - build_to_integration:
-#          requires:
-#            - confirm_integration_build
+      - confirm_integration_build:
+          type: approval
+          requires:
+            - build_to_test
+      - build_to_integration:
+          requires:
+            - confirm_integration_build
 #      - confirm_live_build:
 #          type: approval
 #          requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 jobs:
-  lint_and_test:
+  test:
     docker:
       - image: circleci/node:12.4.0
     steps:
@@ -12,9 +12,41 @@ jobs:
       - run:
           name: Runs ESLint on the JavaScript code and tests
           command: npm run test
-
+  build_to_test:
+    docker:
+      - image: asmega/fb-builder:latest
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: npm install
+          command: npm install
+      - run:
+          name: Build test image
+          command: scripts/circleci_build.sh test
 
 workflows:
-  commit-workflow:
+  version: 2
+  test_and_build:
     jobs:
-      - lint_and_test
+      - test
+      - build_to_test:
+          requires:
+            - test
+#           filters:
+#             branches:
+#               only: master
+#      - confirm_integration_build:
+#          type: approval
+#          requires:
+#            - build_to_test
+#      - build_to_integration:
+#          requires:
+#            - confirm_integration_build
+#      - confirm_live_build:
+#          type: approval
+#          requires:
+#            - build_to_integration
+#      - build_to_live:
+#          requires:
+#            - confirm_live_build

--- a/scripts/circleci_build.sh
+++ b/scripts/circleci_build.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env sh
+
+set -e -u -o pipefail
+
+echo "KUBE_CERTIFICATE_AUTHORITY to disk"
+echo -n "$KUBE_CERTIFICATE_AUTHORITY" | base64 -d > /root/.kube_certificate_authority
+
+echo "kubectl configure cluster"
+kubectl config set-cluster "$KUBE_CLUSTER" --certificate-authority="/root/.kube_certificate_authority" --server="$KUBE_SERVER"
+
+echo "kubectl configure credentials"
+kubectl config set-credentials "circleci" --token="$KUBE_TOKEN"
+
+echo "kubectl configure context"
+kubectl config set-context "circleci" --cluster="$KUBE_CLUSTER" --user="circleci" --namespace="formbuilder-repos"
+
+echo "kubectl use circleci context"
+kubectl config use-context circleci
+
+echo "build and push docker images"
+cd ~/project && ./scripts/build_platform_images.sh -p $1


### PR DESCRIPTION
- on merge to master circleci now runs tests, builds the image and pushes image to test
- no deployment of runner occurs. forms still need to be redeployed to pick up latest image
- with approval within circleci, image can also be built and pushed to integration then live
- circleci-sha is not incorporated in this PR. this will happen in another PR. this PR simply gains parity of circleci doing the steps that would currently happen on a dev machine