### PR TITLE
Circleci sha

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,18 @@ jobs:
       - run:
           name: Build integration image
           command: scripts/circleci_build.sh integration
+  build_to_live:
+    docker:
+      - image: asmega/fb-builder:latest
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: npm install
+          command: npm install
+      - run:
+          name: Build live image
+          command: scripts/circleci_build.sh live
 
 workflows:
   version: 2
@@ -45,9 +57,9 @@ workflows:
       - build_to_test:
           requires:
             - test
-#           filters:
-#             branches:
-#               only: master
+          filters:
+            branches:
+              only: master
       - confirm_integration_build:
           type: approval
           requires:
@@ -55,10 +67,10 @@ workflows:
       - build_to_integration:
           requires:
             - confirm_integration_build
-#      - confirm_live_build:
-#          type: approval
-#          requires:
-#            - build_to_integration
-#      - build_to_live:
-#          requires:
-#            - confirm_live_build
+      - confirm_live_build:
+          type: approval
+          requires:
+            - build_to_integration
+      - build_to_live:
+          requires:
+            - confirm_live_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,18 @@ jobs:
       - run:
           name: Build test image
           command: scripts/circleci_build.sh test
+  build_to_integration:
+    docker:
+      - image: asmega/fb-builder:latest
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: npm install
+          command: npm install
+      - run:
+          name: Build integration image
+          command: scripts/circleci_build.sh integration
 
 workflows:
   version: 2
@@ -36,13 +48,13 @@ workflows:
 #           filters:
 #             branches:
 #               only: master
-#      - confirm_integration_build:
-#          type: approval
-#          requires:
-#            - build_to_test
-#      - build_to_integration:
-#          requires:
-#            - confirm_integration_build
+      - confirm_integration_build:
+          type: approval
+          requires:
+            - build_to_test
+      - build_to_integration:
+          requires:
+            - confirm_integration_build
 #      - confirm_live_build:
 #          type: approval
 #          requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 jobs:
-  lint_and_test:
+  test:
     docker:
       - image: circleci/node:12.4.0
     steps:
@@ -12,9 +12,41 @@ jobs:
       - run:
           name: Runs ESLint on the JavaScript code and tests
           command: npm run test
-
+  build_to_test:
+    docker:
+      - image: asmega/fb-builder:latest
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: npm install
+          command: npm install
+      - run:
+          name: Build test image
+          command: scripts/circleci_build.sh test
 
 workflows:
-  commit-workflow:
+  version: 2
+  test_and_build:
     jobs:
-      - lint_and_test
+      - test
+      - build_to_test:
+          requires:
+            - test
+#           filters:
+#             branches:
+#               only: master
+#      - confirm_integration_build:
+#          type: approval
+#          requires:
+#            - build_to_test
+#      - build_to_integration:
+#          requires:
+#            - confirm_integration_build
+#      - confirm_live_build:
+#          type: approval
+#          requires:
+#            - build_to_integration
+#      - build_to_live:
+#          requires:
+#            - confirm_live_build

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN npm install
 COPY bin ./bin
 COPY lib ./lib
 COPY .eslintrc ./
-COPY APP_GIT_COMMIT ./
+COPY APP_SHA ./
 
 ENTRYPOINT ["dumb-init", "--"]
 EXPOSE 3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN npm install
 COPY bin ./bin
 COPY lib ./lib
 COPY .eslintrc ./
+COPY APP_GIT_COMMIT ./
 
 ENTRYPOINT ["dumb-init", "--"]
 EXPOSE 3000

--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,7 @@ else
 endif
 
 init:
-	$(eval export ECR_REPO_NAME=fb-runner-node)
-	$(eval export ECR_REPO_URL_ROOT=754256621582.dkr.ecr.eu-west-2.amazonaws.com/formbuilder)
+	$(eval export ECR_REPO_URL=754256621582.dkr.ecr.eu-west-2.amazonaws.com/formbuilder/fb-runner-node)
 
 # install aws cli w/o sudo
 install_build_dependencies: init
@@ -39,17 +38,15 @@ install_build_dependencies: init
 	pip install --user awscli
 	$(eval export PATH=${PATH}:${HOME}/.local/bin/)
 
-
-# Needs ECR_REPO_NAME & ECR_REPO_URL env vars
 build: install_build_dependencies
-	docker build -t ${ECR_REPO_NAME}:latest-${env_stub} -f ./Dockerfile . && \
-		docker tag ${ECR_REPO_NAME}:latest-${env_stub} ${ECR_REPO_URL_ROOT}/${ECR_REPO_NAME}:latest-${env_stub}
+	docker build -t ${ECR_REPO_URL}:latest-${env_stub} -t ${ECR_REPO_URL}:${CIRCLE_SHA1} -f ./Dockerfile .
 
 login: init
 	@eval $(shell aws ecr get-login --no-include-email --region eu-west-2)
 
 push: login
-	docker push ${ECR_REPO_URL_ROOT}/${ECR_REPO_NAME}:latest-${env_stub}
+	docker push ${ECR_REPO_URL}:latest-${env_stub}
+	docker push ${ECR_REPO_URL}:${CIRCLE_SHA1}
 
 build_and_push: build push
 

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ install_build_dependencies: init
 	$(eval export PATH=${PATH}:${HOME}/.local/bin/)
 
 build: install_build_dependencies
-	echo ${CIRCLE_SHA1} > APP_GIT_COMMIT
+	echo ${CIRCLE_SHA1} > APP_SHA
 	docker build -t ${ECR_REPO_URL}:latest-${env_stub} -t ${ECR_REPO_URL}:${CIRCLE_SHA1} -f ./Dockerfile .
 
 login: init

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ install_build_dependencies: init
 	$(eval export PATH=${PATH}:${HOME}/.local/bin/)
 
 build: install_build_dependencies
+	echo ${CIRCLE_SHA1} > APP_GIT_COMMIT
 	docker build -t ${ECR_REPO_URL}:latest-${env_stub} -t ${ECR_REPO_URL}:${CIRCLE_SHA1} -f ./Dockerfile .
 
 login: init

--- a/scripts/circleci_build.sh
+++ b/scripts/circleci_build.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env sh
+
+set -e -u -o pipefail
+
+echo "KUBE_CERTIFICATE_AUTHORITY to disk"
+echo -n "$KUBE_CERTIFICATE_AUTHORITY" | base64 -d > /root/.kube_certificate_authority
+
+echo "kubectl configure cluster"
+kubectl config set-cluster "$KUBE_CLUSTER" --certificate-authority="/root/.kube_certificate_authority" --server="$KUBE_SERVER"
+
+echo "kubectl configure credentials"
+kubectl config set-credentials "circleci" --token="$KUBE_TOKEN"
+
+echo "kubectl configure context"
+kubectl config set-context "circleci" --cluster="$KUBE_CLUSTER" --user="circleci" --namespace="formbuilder-repos"
+
+echo "kubectl use circleci context"
+kubectl config use-context circleci
+
+echo "build and push docker images"
+cd ~/project && ./scripts/build_platform_images.sh -p $1


### PR DESCRIPTION
- on merge to master circleci now runs tests, builds the image and pushes image to test
- these images are still tagged with latest which is the current behaviour, this will remain to support backwards compatibility. images are also tagged with the git sha
- no deployment of runner occurs. forms still need to be redeployed to pick up latest image
- with approval within circleci, image can also be built and pushed to integration then live
- circleci-sha is also written to file as part of the build. this can later be read at boot time to be injected in to the application