### PR TITLE
Validate save and return telephone number

### DIFF
--- a/lib/module/savereturn/metadata/page/return.setup.mobile.json
+++ b/lib/module/savereturn/metadata/page/return.setup.mobile.json
@@ -11,8 +11,7 @@
       "widthClassInput": "one-half",
       "errors": {
         "pattern": {
-          "summary": "Enter a telephone number in the correct format",
-          "inline": "Enter a telephone number without spaces, like 01632960001, 07700900982 or +4408081570192"
+          "any": "Enter a telephone number without spaces, like 01632960001, 07700900982 or +4408081570192"
         }
       },
       "validation": {

--- a/lib/module/savereturn/metadata/page/return.setup.mobile.json
+++ b/lib/module/savereturn/metadata/page/return.setup.mobile.json
@@ -1,4 +1,3 @@
-
 {
   "_id": "return.setup.mobile",
   "_type": "page.form",

--- a/lib/module/savereturn/metadata/page/return.setup.mobile.json
+++ b/lib/module/savereturn/metadata/page/return.setup.mobile.json
@@ -1,3 +1,4 @@
+
 {
   "_id": "return.setup.mobile",
   "_type": "page.form",
@@ -6,9 +7,18 @@
     {
       "_id": "return.setup.mobile--text.mobile",
       "_type": "text",
-      "label": "Mobile number",
+      "label": "Mobile number (without spaces)",
       "name": "mobile",
-      "widthClassInput": "one-half"
+      "widthClassInput": "one-half",
+      "errors": {
+        "pattern": {
+          "summary": "Enter a telephone number in the correct format",
+          "inline": "Enter a telephone number without spaces, like 01632960001, 07700900982 or +4408081570192"
+        }
+      },
+      "validation": {
+        "pattern": "^\\+{0,1}\\d{9,16}$"
+      }
     }
   ],
   "enableSteps": true,

--- a/lib/module/savereturn/metadata/page/return.setup.mobile.validate.json
+++ b/lib/module/savereturn/metadata/page/return.setup.mobile.validate.json
@@ -8,8 +8,7 @@
       "_type": "text",
       "errors": {
         "pattern": {
-          "inline": "The code should be 5 digits",
-          "summary": "The code should be 5 digits"
+          "any": "The code should be 5 digits"
         }
       },
       "label": "Security code",


### PR DESCRIPTION
Currently a telephone number rejected by Notify, will raise a 500 error message
to the user without explanation what happened.

Guard against this by validating the phone number entered.
Having optional spaces in the regular expression makes it complex and fragile.

Error messages as per GDS recommendations:
https://design-system.service.gov.uk/patterns/telephone-numbers/#error-messages