### PR TITLE
JSON submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ Run unit tests only
 npm run test:unit
 ```
 
+Run a single unit test
+
+```
+./node_modules/.bin/multi-tape lib/controller/page/type/page.summary/page.summary.controller.unit.spec.js
+```
+
 Run linting only
 ```
 npm run lint

--- a/lib/controller/page/type/page.summary/page.summary.controller.js
+++ b/lib/controller/page/type/page.summary/page.summary.controller.js
@@ -9,7 +9,11 @@ const uuidv4 = require('uuid/v4')
 const {deepClone} = require('@ministryofjustice/fb-utils-node')
 
 const CONSTANTS = require('../../../../constants/constants')
-const {SERVICE_OUTPUT_EMAIL} = CONSTANTS
+const {
+  SERVICE_OUTPUT_EMAIL,
+  SERVICE_OUTPUT_JSON_ENDPOINT,
+  SERVICE_OUTPUT_JSON_KEY
+} = CONSTANTS
 
 const {
   getInstance,
@@ -156,6 +160,20 @@ SummaryController.attachEmailSubmissions = async (submissionId, userData, submis
   }
 }
 
+SummaryController.attachJsonSubmission = async (submissions) => {
+  if (SERVICE_OUTPUT_JSON_ENDPOINT === undefined) {
+    return
+  }
+
+  const submission = {
+    type: 'json',
+    url: SERVICE_OUTPUT_JSON_ENDPOINT,
+    encryption_key: SERVICE_OUTPUT_JSON_KEY
+  }
+
+  submissions.push(submission)
+}
+
 SummaryController.postValidation = async (pageInstance, userData) => {
   const performsSubmit = checkSubmits(pageInstance, userData)
   if (!performsSubmit) {
@@ -171,6 +189,7 @@ SummaryController.postValidation = async (pageInstance, userData) => {
     const submissions = []
 
     SummaryController.attachEmailSubmissions(submissionId, userData, submissions)
+    SummaryController.attachJsonSubmission(submissions)
 
     try {
       await submitterClient.submit({userId, userToken, submissions}, userData.logger)

--- a/lib/controller/page/type/page.summary/page.summary.controller.js
+++ b/lib/controller/page/type/page.summary/page.summary.controller.js
@@ -62,6 +62,100 @@ SummaryController.setContents = (pageInstance, userData, res, hideChangeAction) 
   return pageInstance
 }
 
+SummaryController.attachEmailSubmissions = async (submissionId, userData, submissions) => {
+  const formatEmail = (str, markdown = false) => {
+    try {
+      str = format(str, userData.getScopedUserData(), {markdown, lang: userData.contentLang})
+    } catch (e) {
+      //
+    }
+    return str
+  }
+  const serviceName = getInstanceProperty('service', 'name')
+  let subject = getInstanceProperty('service', 'emailSubjectTeam') || `${serviceName} submission`
+  subject = formatEmail(subject)
+  const defaultEmailAddress = getString('email.address.from')
+  const from = defaultEmailAddress ? formatEmail(defaultEmailAddress) : '"Form Builder" <form-builder@digital.justice.gov.uk>'
+  let to = SERVICE_OUTPUT_EMAIL || ''
+  try {
+    to = formatEmail(to)
+  } catch (e) {
+    //
+  }
+  let toTeamParts = to.split(/,\s*/)
+  toTeamParts = toTeamParts.map(address => {
+    address = address.trim()
+    if (!address.match(/^e\[.+\]$/)) {
+      return address
+    }
+    const addressLookup = address.replace(/^e\[(.+)\]$/, '$1')
+    return CONSTANTS[addressLookup] || address
+  })
+    .filter(address => address)
+    .map(address => address.split(/,\s*/))
+
+  // flatten
+  toTeamParts = [].concat(...toTeamParts)
+  toTeamParts = [...new Set(toTeamParts)]
+
+  // const timestamp = new Date().getTime()
+  const emailUrlStub = '/api/submitter/email/default'
+
+  const teamSubmission = generateEmail('team', from, subject, emailUrlStub, submissionId)
+  const data = userData.getOutputData()
+  let uploadedFiles = []
+  const findUploadedFiles = (data) => {
+    if (Array.isArray(data) || typeof data !== 'object') {
+      return
+    }
+    Object.keys(data).forEach(key => {
+      const arr = data[key]
+      if (Array.isArray(arr)) {
+        const actualFiles = arr.filter(item => {
+          return item.fingerprint && item.url
+        }).map(item => ({
+          url: item.url,
+          mimetype: item.mimetype,
+          filename: item.originalname,
+          type: 'filestore'
+        }))
+        uploadedFiles = uploadedFiles.concat(actualFiles)
+      } else if (typeof arr === 'object') {
+        findUploadedFiles(arr)
+      }
+    })
+  }
+  findUploadedFiles(data)
+  uploadedFiles.forEach(upload => {
+    teamSubmission.attachments.push(upload)
+  })
+
+  // TODO: set up alternative output formats
+  // `/api/submitter/json/default/${submissionId}.json`,
+  // `/api/submitter/csv/default/${submissionId}.csv`
+
+  toTeamParts.forEach(to => {
+    const toTeamSubmission = Object.assign({}, teamSubmission, {to})
+    submissions.push(toTeamSubmission)
+  })
+  const emailUserInputName = getInstanceProperty('service', 'emailInputNameUser') || 'email'
+  if (emailUserInputName) {
+    const userEmail = userData.getUserDataProperty(emailUserInputName)
+    if (userEmail) {
+      const userSubject = getInstanceProperty('service', 'emailSubjectUser') || `Your ${serviceName} submission`
+      const subject = formatEmail(userSubject)
+      const addAttachment = getInstanceProperty('service', 'attachUserSubmission') || false
+      const userSubmission = generateEmail('user', from, subject, emailUrlStub, submissionId, addAttachment)
+
+      const toUserParts = userEmail.split(/,\s*/)
+      toUserParts.forEach(to => {
+        const toUserSubmission = Object.assign({}, userSubmission, {to})
+        submissions.push(toUserSubmission)
+      })
+    }
+  }
+}
+
 SummaryController.postValidation = async (pageInstance, userData) => {
   const performsSubmit = checkSubmits(pageInstance, userData)
   if (!performsSubmit) {
@@ -73,100 +167,10 @@ SummaryController.postValidation = async (pageInstance, userData) => {
   userData.setUserDataProperty('submissionDate', submissionDate)
   const userId = userData.getUserId()
   const userToken = userData.getUserToken()
-  const formatEmail = (str, markdown = false) => {
-    try {
-      str = format(str, userData.getScopedUserData(), {markdown, lang: userData.contentLang})
-    } catch (e) {
-      //
-    }
-    return str
-  }
   if (submitterClient) {
     const submissions = []
 
-    const serviceName = getInstanceProperty('service', 'name')
-    let subject = getInstanceProperty('service', 'emailSubjectTeam') || `${serviceName} submission`
-    subject = formatEmail(subject)
-    const defaultEmailAddress = getString('email.address.from')
-    const from = defaultEmailAddress ? formatEmail(defaultEmailAddress) : '"Form Builder" <form-builder@digital.justice.gov.uk>'
-    let to = SERVICE_OUTPUT_EMAIL || ''
-    try {
-      to = formatEmail(to)
-    } catch (e) {
-      //
-    }
-    let toTeamParts = to.split(/,\s*/)
-    toTeamParts = toTeamParts.map(address => {
-      address = address.trim()
-      if (!address.match(/^e\[.+\]$/)) {
-        return address
-      }
-      const addressLookup = address.replace(/^e\[(.+)\]$/, '$1')
-      return CONSTANTS[addressLookup] || address
-    })
-      .filter(address => address)
-      .map(address => address.split(/,\s*/))
-
-    // flatten
-    toTeamParts = [].concat(...toTeamParts)
-    toTeamParts = [...new Set(toTeamParts)]
-
-    // const timestamp = new Date().getTime()
-    const emailUrlStub = '/api/submitter/email/default'
-
-    const teamSubmission = generateEmail('team', from, subject, emailUrlStub, submissionId)
-    const data = userData.getOutputData()
-    let uploadedFiles = []
-    const findUploadedFiles = (data) => {
-      if (Array.isArray(data) || typeof data !== 'object') {
-        return
-      }
-      Object.keys(data).forEach(key => {
-        const arr = data[key]
-        if (Array.isArray(arr)) {
-          const actualFiles = arr.filter(item => {
-            return item.fingerprint && item.url
-          }).map(item => ({
-            url: item.url,
-            mimetype: item.mimetype,
-            filename: item.originalname,
-            type: 'filestore'
-          }))
-          uploadedFiles = uploadedFiles.concat(actualFiles)
-        } else if (typeof arr === 'object') {
-          findUploadedFiles(arr)
-        }
-      })
-    }
-    findUploadedFiles(data)
-    uploadedFiles.forEach(upload => {
-      teamSubmission.attachments.push(upload)
-    })
-
-    // TODO: set up alternative output formats
-    // `/api/submitter/json/default/${submissionId}.json`,
-    // `/api/submitter/csv/default/${submissionId}.csv`
-
-    toTeamParts.forEach(to => {
-      const toTeamSubmission = Object.assign({}, teamSubmission, {to})
-      submissions.push(toTeamSubmission)
-    })
-    const emailUserInputName = getInstanceProperty('service', 'emailInputNameUser') || 'email'
-    if (emailUserInputName) {
-      const userEmail = userData.getUserDataProperty(emailUserInputName)
-      if (userEmail) {
-        const userSubject = getInstanceProperty('service', 'emailSubjectUser') || `Your ${serviceName} submission`
-        const subject = formatEmail(userSubject)
-        const addAttachment = getInstanceProperty('service', 'attachUserSubmission') || false
-        const userSubmission = generateEmail('user', from, subject, emailUrlStub, submissionId, addAttachment)
-
-        const toUserParts = userEmail.split(/,\s*/)
-        toUserParts.forEach(to => {
-          const toUserSubmission = Object.assign({}, userSubmission, {to})
-          submissions.push(toUserSubmission)
-        })
-      }
-    }
+    SummaryController.attachEmailSubmissions(submissionId, userData, submissions)
 
     try {
       await submitterClient.submit({userId, userToken, submissions}, userData.logger)

--- a/lib/controller/page/type/page.summary/page.summary.controller.unit.spec.js
+++ b/lib/controller/page/type/page.summary/page.summary.controller.unit.spec.js
@@ -170,3 +170,39 @@ test('it does not attach a user submission when the property is set to false', a
   submitterClientSpy.resetHistory()
   t.end()
 })
+
+test('it attaches json to submission when env var present', async t => {
+  getUserDataPropertyStub.resetHistory()
+
+  const pageSummaryController = proxyquire('./page.summary.controller', {
+    '../../../../page/check-submits/check-submits': {checkSubmits: checkSubmitsStub},
+    '../../../../constants/constants': {
+      SERVICE_OUTPUT_JSON_ENDPOINT: 'https://example.com/adaptor',
+      SERVICE_OUTPUT_JSON_KEY: 'shared_key'
+    }
+  })
+
+  await pageSummaryController.postValidation({}, userData)
+
+  const submissions = submitterClientSpy.getCall(0).args[0].submissions
+  t.equals(submissions[1].type, 'json')
+  t.equals(submissions[1].url, 'https://example.com/adaptor')
+  t.equals(submissions[1].encryption_key, 'shared_key')
+  submitterClientSpy.resetHistory()
+  t.end()
+})
+
+test('it does not attach json to submission when env var not present', async t => {
+  getUserDataPropertyStub.resetHistory()
+
+  const pageSummaryController = proxyquire('./page.summary.controller', {
+    '../../../../page/check-submits/check-submits': {checkSubmits: checkSubmitsStub}
+  })
+
+  await pageSummaryController.postValidation({}, userData)
+
+  const submissions = submitterClientSpy.getCall(0).args[0].submissions
+  t.equals(submissions[1], undefined)
+  submitterClientSpy.resetHistory()
+  t.end()
+})


### PR DESCRIPTION
- This adds JSON submission to submission payload
- This feature is optional and enabled when `SERVICE_OUTPUT_JSON_ENDPOINT` env var is present
- The payload is missing the callback location which will generate the form representation in JSON. This will be added in a later piece of work
- This is a breaking change and cannot be merged until submitter implements this or performs a no-op as a minimum