### PR TITLE
Prevent unnecessary attempts to update non-existent references to str…

### DIFF
--- a/lib/service-data/service-data.js
+++ b/lib/service-data/service-data.js
@@ -573,7 +573,8 @@ external.setInstanceProperty = (id, property, value) => {
   let newInstance = external.getSourceInstance(id, instance.$source)
   const oldProp = newInstance[property]
   set(newInstance, property, value)
-  if (property === 'name' || property === 'value') {
+  // Update any instances which reference the instance's property (unless the instance is itself a string instance)
+  if (!newInstance._type.includes('string') && (property === 'name' || property === 'value')) {
     const updatePropertyReferences = (propName, query, applyFn) => {
       const allInstances = external.getServiceInstances()
       const updateIdentifier = (instId) => {


### PR DESCRIPTION
When updating `value` and `name` properties, we look to see if those properties are referenced elsewhere and update the instances referencing them if necessary. This allows for renaming of controls without breaking any conditionals that have been set up using them.

String instances also have `value` properties. But those are just that and do not (indeed should not) trigger any updates. Worse, the string values could contain arbitrary characters that could cause the jsonpath query to fail.