### PR TITLE
remove document uploads from JSON API callback

### DIFF
--- a/lib/controller/page/type/page.summary/page.summary.controller.unit.spec.js
+++ b/lib/controller/page/type/page.summary/page.summary.controller.unit.spec.js
@@ -68,7 +68,7 @@ const userData = {
   getUserParams: () => ({}),
   getUserId: () => 'userId',
   getUserToken: () => 'userToken',
-  getOutputData: () => ({}),
+  getOutputAnswers: () => ({}),
   uploadedFiles: () => {
     return []
   }
@@ -79,7 +79,7 @@ const userDataWithFiles = {
   getUserParams: () => ({}),
   getUserId: () => 'userId',
   getUserToken: () => 'userToken',
-  getOutputData: () => ({}),
+  getOutputAnswers: () => ({}),
   uploadedFiles: () => {
     return [{
       url: 'SUBMITTER_URL/service/SERVICE_SLUG/user/36c1af3e-a213-4293-8a82-f26ae7a23215/1568971532923',

--- a/lib/middleware/routes-output/routes-output.js
+++ b/lib/middleware/routes-output/routes-output.js
@@ -142,13 +142,13 @@ const generateOutput = async (req, res) => {
     email = formatEmail(email)
     res.send(email)
   } else if (outputType === 'json') {
-    const jsonData = userData.getOutputData()
+    const jsonData = userData.getOutputAnswers()
     res.setHeader('Content-Type', 'application/json')
     res.setHeader('Content-Disposition', `attachment; filename=${filename}`)
     res.send(JSON.stringify(jsonData, null, 2))
     // res.json(jsonData)
   } else if (outputType === 'csv') {
-    const jsonData = flatten(userData.getOutputData())
+    const jsonData = flatten(userData.getOutputAnswers())
     const outputData = {}
     Object.keys(jsonData).reverse().forEach(key => {
       let normalisedKey = key

--- a/lib/middleware/user-data/user-data.js
+++ b/lib/middleware/user-data/user-data.js
@@ -83,6 +83,12 @@ const external = {}
 external.getInstanceByPropertyValue = getInstanceByPropertyValue
 external.getInstanceProperty = getInstanceProperty
 
+const removeUploads = (obj) => {
+  delete obj.document_upload
+
+  return obj
+}
+
 const removeNullEntries = (obj) => {
   Object.keys(obj).forEach(key => {
     const objProp = obj[key]
@@ -219,10 +225,11 @@ external.getUserDataMethods = (data = {}, params, additional = {}) => {
     getUserData,
     getUserDataInput: () => data.input,
     getUserDataInputProperty: (path, def) => getUserDataProperty(path, def, 'input'),
-    getOutputData: (scope) => {
+    getOutputAnswers: (scope) => {
       let output = deepClone(getDataScope(scope))
       delete output.COMPOSITE
       output = removeNullEntries(output)
+      output = removeUploads(output)
       return output
     },
     setUserDataProperty: (path, value, scope) => setBracketNotationPath(getDataScope(scope), path, value),

--- a/lib/middleware/user-data/user-data.unit.spec.js
+++ b/lib/middleware/user-data/user-data.unit.spec.js
@@ -211,7 +211,7 @@ test('when there are uploaded files', async t => {
     },
     getUserId: () => '',
     getUserToken: () => '',
-    getOutputData: () => {
+    getOutputAnswers: () => {
 
     }
   }
@@ -227,5 +227,46 @@ test('when there are uploaded files', async t => {
   }]
 
   t.deepEqual(uploadedFiles(), expected, 'it returns array of file objects')
+  t.end()
+})
+
+test('getOutputAnswers() when there are uploaded files', async t => {
+  const req = {
+    session: {
+      input: {
+        a: {
+          b: true
+        },
+        document_upload: [
+          {
+            fieldname: 'document_upload[1]',
+            originalname: 'image.png',
+            encoding: '7bit',
+            mimetype: 'image/png',
+            destination: '/tmp/uploads',
+            filename: '2706490942c9ca43b8e1fa01e7dace77',
+            path: '/tmp/uploads/2706490942c9ca43b8e1fa01e7dace76',
+            size: 74200,
+            maxSize: 5242880,
+            fingerprint: 1568971532923,
+            date: 1568971532922,
+            timestamp: 'Fri Sep 20 2019 10:25:32 GMT+0100 (British Summer Time)',
+            url: 'SUBMITTER_URL/service/SERVICE_SLUG/user/36c1af3e-a213-4293-8a82-f26ae7a23215/1568971532923',
+            uuid: '442e4c33-a364-42a0-9d70-6875ee0c50bc'
+          }
+        ]
+      }
+    },
+    getUserId: () => '',
+    getUserToken: () => ''
+  }
+
+  const res = {}
+  await loadUserData(req, res)
+  const {getOutputAnswers} = req.user
+
+  const expected = {a: {b: true}}
+
+  t.deepEqual(getOutputAnswers(), expected, 'returns only answers')
   t.end()
 })


### PR DESCRIPTION
- This makes the JSON callback API endpoint only return answers
- All uploads have been stripped out as this is provided to the submitter before the callback