### PR TITLE
file upload set policy from accept property

### DIFF
--- a/lib/page/process-uploads/process-uploaded-files.js
+++ b/lib/page/process-uploads/process-uploaded-files.js
@@ -12,7 +12,7 @@ const processUploadedFiles = async (processedResults, uploadControls) => {
     }).map(uploadControl => {
       file.maxSize = uploadControl.maxSize
       file.expires = uploadControl.expires
-      file.allowed_types = uploadControl.allowed_types
+      file.allowed_types = uploadControl.accept
       return uploadControl.maxSize
     })[0]
 

--- a/lib/page/process-uploads/process-uploaded-files.unit.spec.js
+++ b/lib/page/process-uploads/process-uploaded-files.unit.spec.js
@@ -8,6 +8,86 @@ const uploadControls = [{
   maxSize: 10 * 1024 * 1024
 }]
 
+test('when there is no accept property present', async t => {
+  const processedResults = {
+    files: {
+      'test[1]': [
+        {
+          fieldname: 'test[1]',
+          originalname: 'originalname',
+          size: 10 * 1024 * 1024,
+          maxSize: 10485760,
+          expires: undefined
+        }
+      ]
+    }
+  }
+
+  const {files} = await processUploadedFiles(processedResults, uploadControls)
+
+  t.deepEqual(files.allowed_types, undefined, 'allowed types is undefined')
+
+  t.end()
+})
+
+test('when accept property present is empty array', async t => {
+  const uploadControls = [{
+    _type: 'fileupload',
+    name: 'test',
+    maxSize: 10 * 1024 * 1024,
+    accept: []
+  }]
+
+  const processedResults = {
+    files: {
+      'test[1]': [
+        {
+          fieldname: 'test[1]',
+          originalname: 'originalname',
+          size: 10 * 1024 * 1024,
+          maxSize: 10485760,
+          expires: undefined
+        }
+      ]
+    }
+  }
+
+  const {files} = await processUploadedFiles(processedResults, uploadControls)
+
+  t.deepEqual(files.allowed_types, undefined, 'allowed types is undefined')
+
+  t.end()
+})
+
+test('when accept property is array of mime types', async t => {
+  const uploadControls = [{
+    _type: 'fileupload',
+    name: 'test',
+    maxSize: 10 * 1024 * 1024,
+    accept: ['application/pdf', 'image/png']
+  }]
+
+  const processedResults = {
+    files: {
+      'test[1]': [
+        {
+          fieldname: 'test[1]',
+          originalname: 'originalname',
+          size: 10 * 1024 * 1024,
+          maxSize: 10485760,
+          expires: undefined
+        }
+      ]
+    }
+  }
+
+  const {files} = await processUploadedFiles(processedResults, uploadControls)
+
+  t.deepEqual(files.allowed_types, uploadControls.accept, 'allowed types is array of mimetypes')
+
+  t.end()
+})
+
 test('When processUploadedFiles is passed an upload that is valid', async t => {
   const processedResults = {
     files: {


### PR DESCRIPTION
specification says accept is array of mimetypes we accept
now passing this thru to allowed_types for the policy
policy is sent to server to determine if mime type is permitted