### PR TITLE
Pdf payload

### DIFF
--- a/lib/middleware/routes-output/routes-output.js
+++ b/lib/middleware/routes-output/routes-output.js
@@ -13,6 +13,9 @@ const nunjucksConfiguration = require('../nunjucks-configuration/nunjucks-config
 const {getInstanceProperty} = require('../../service-data/service-data')
 const {format} = require('../../format/format')
 
+const pdfPayload = require('../../presenter/pdf-payload')
+const submissionDataWithLabels = require('./submission-data-with-labels')
+
 const {getController} = require('../../controller/controller')
 
 const jp = require('jsonpath')
@@ -52,6 +55,14 @@ const generateOutput = async (req, res) => {
   }
 
   if (outputType === 'pdf') {
+    if (process.env.PDF_SERVICE_FLAG) {
+      const payload = pdfPayload(
+        submissionDataWithLabels(submission, heading, subHeading, destination, userData)
+      )
+      res.send(payload)
+      return
+    }
+
     let pageInstance = {
       _type: 'output.pdf',
       title: submission,

--- a/lib/middleware/routes-output/submission-data-with-labels.js
+++ b/lib/middleware/routes-output/submission-data-with-labels.js
@@ -1,0 +1,28 @@
+const {getInstanceController} = require('../../controller/controller')
+const {formatProperties} = require('../../page/page')
+
+const submissionDataWithLabels = (title, heading, subHeading, destination, userData) => {
+  const answersComponent = {
+    _id: 'page.summary.answers',
+    _type: 'answers',
+    onlyShowCompletedAnswers: false
+  }
+
+  const pageInstance = {
+    _type: 'output.pdf',
+    title: title,
+    sectionHeading: subHeading,
+    heading,
+    columns: 'full',
+    isPdf: true,
+    skipRedact: destination === 'team',
+    components: [answersComponent]
+  }
+
+  const answersController = getInstanceController(answersComponent)
+  answersController.preUpdateContents(answersComponent, userData, pageInstance)
+
+  return formatProperties(pageInstance, userData)
+}
+
+module.exports = submissionDataWithLabels

--- a/lib/presenter/pdf-payload.js
+++ b/lib/presenter/pdf-payload.js
@@ -1,0 +1,29 @@
+const pdfPayload = (submission) => {
+  return {
+    submission_id: submission.title,
+    pdf_heading: submission.heading,
+    pdf_subheading: submission.sectionHeading,
+    sections: sections(submission.components[0])
+  }
+}
+
+const sections = (section) => {
+  return section.answers.map(sectionAnswer => {
+    return {
+      heading: sectionAnswer.heading || '',
+      summary_heading: sectionAnswer.summaryHeading || '',
+      questions: questions(sectionAnswer)
+    }
+  })
+}
+
+const questions = (section) => {
+  return (section.answers || []).map(answer => {
+    return {
+      label: answer.key.html,
+      answer: answer.value.text
+    }
+  })
+}
+
+module.exports = pdfPayload

--- a/lib/presenter/pdf-payload.unit.spec.js
+++ b/lib/presenter/pdf-payload.unit.spec.js
@@ -1,0 +1,129 @@
+const test = require('tape')
+const pdfPayload = require('./pdf-payload')
+const expectedPayload = {
+  submission_id: '1786c427-246e-4bb7-90b9-a2e6cfae003f / Tue, 08 Oct 2019 12:44:33 GMT',
+  pdf_heading: 'Complain about a court or tribunal',
+  pdf_subheading: '(Optional) Some section heading',
+  sections: [
+    {
+      heading: 'Whats your name',
+      summary_heading: 'WIP',
+      questions: []
+    }, {
+      heading: '',
+      summary_heading: '',
+      questions: [
+        {
+          label: 'First name',
+          answer: 'Bob'
+        },
+        {
+          label: 'Last name',
+          answer: 'Smith'
+        }
+      ]
+    }, {
+      heading: '',
+      summary_heading: '',
+      questions: [
+        {
+          label: 'Your email address',
+          answer: 'bob.smith@gov.uk'
+        }, {
+
+          label: 'Your complaint',
+          answer: 'tester content'
+        }, {
+          label: 'Court or tribunal your complaint is about',
+          answer: 'Aberdeen Employment Tribunal'
+        }
+      ]
+    }
+  ]
+}
+
+const payload = {
+  title: '1786c427-246e-4bb7-90b9-a2e6cfae003f / Tue, 08 Oct 2019 12:44:33 GMT',
+  sectionHeading: '(Optional) Some section heading',
+  heading: 'Complain about a court or tribunal',
+  columns: 'full',
+  isPdf: true,
+  skipRedact: true,
+  components: [
+    {
+      _id: 'page.summary.answers',
+      _type: 'answers',
+      hideChangeAction: true,
+      onlyShowCompletedAnswers: false,
+      answers: [
+        {
+          heading: 'Whats your name',
+          summaryHeading: 'WIP',
+          repeatable: undefined,
+          level: 2
+        }, {
+          answers: [
+            {
+              page: 'page.name',
+              component: 'first_name',
+              key: {
+                html: 'First name'
+              },
+              value: {
+                text: 'Bob'
+              }
+            },
+            {
+              page: 'page.name',
+              component: 'last_name',
+              key: {
+                html: 'Last name'
+              },
+              value: {
+                text: 'Smith'
+              }
+            }
+          ]
+        }, {
+          answers: [
+            {
+              page: 'page.email-address',
+              component: 'email_address',
+              key: {
+                html: 'Your email address'
+              },
+              value: {
+                text: 'bob.smith@gov.uk'
+              }
+            },
+            {
+              page: 'page.complaint',
+              component: 'complaint_details',
+              key: {
+                html: 'Your complaint'
+              },
+              value: {
+                text: 'tester content'
+              }
+            },
+            {
+              page: 'page.location',
+              component: 'complaint_location',
+              key: {
+                html: 'Court or tribunal your complaint is about'
+              },
+              value: {
+                text: 'Aberdeen Employment Tribunal'
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+
+test('creates a presentable payload', function (t) {
+  t.deepEqual(pdfPayload(payload), expectedPayload, 'it should present the formbuilder payload')
+  t.end()
+})


### PR DESCRIPTION
We are extracting PDF generation out of this app into a standalone
microservice.  This application will return the JSON required to
generate this PDF.

This is currently feature flagged and can be turned on by setting a
config variable in the submitter:

PDF_SERVICE_FLAG true

If this flag is not set, it will fall back to the old PDF generating
functionality.