### PR TITLE
Include PDF data on initial submit

### DIFF
--- a/lib/controller/page/type/page.summary/page.summary.controller.js
+++ b/lib/controller/page/type/page.summary/page.summary.controller.js
@@ -24,6 +24,8 @@ const {
 const {getUrl} = require('../../../../route/route')
 const redirectNextPage = require('../../../../page/redirect-next-page/redirect-next-page')
 const {checkSubmits} = require('../../../../page/check-submits/check-submits')
+const {pdfPayload} = require('../../../../presenter/pdf-payload')
+const {submissionDataWithLabels} = require('../../../../middleware/routes-output/submission-data-with-labels')
 
 const {format} = require('../../../../format/format')
 
@@ -139,6 +141,19 @@ SummaryController.attachEmailSubmissions = async (submissionId, userData, submis
   }
 }
 
+SummaryController.attachPdfSubmission = async (submissions, userData, submissionId) => {
+  const title = submissionId
+  const heading = getInstanceProperty('service', 'pdfHeading')
+  const subHeading = getInstanceProperty('service', 'pdfSubHeading')
+  const destination = 'team'
+
+  const result = pdfPayload(
+    submissionDataWithLabels(title, heading, subHeading, destination, userData)
+  )
+
+  submissions.push({pdf_payload: result})
+}
+
 SummaryController.attachJsonSubmission = async (submissions, userData) => {
   if (SERVICE_OUTPUT_JSON_ENDPOINT === undefined) {
     return
@@ -173,6 +188,7 @@ SummaryController.postValidation = async (pageInstance, userData) => {
 
     SummaryController.attachEmailSubmissions(submissionId, userData, submissions)
     SummaryController.attachJsonSubmission(submissions, userData)
+    SummaryController.attachPdfSubmission(submissions, userData, submissionId)
 
     try {
       await submitterClient.submit({userId, userToken, submissions}, userData.logger)

--- a/lib/controller/page/type/page.summary/page.summary.controller.unit.spec.js
+++ b/lib/controller/page/type/page.summary/page.summary.controller.unit.spec.js
@@ -18,11 +18,17 @@ const submitterClientSpy = spy(submitterClient, 'submit')
 
 const checkSubmitsStub = (_instanceData, _userData) => true
 
+const pdfPayload = {some: 'PDF contents'}
+const pdfPayloadStub = (_rawFormData) => pdfPayload
+const submissionDataWithLabelsStub = stub()
+
 const pageSummaryController = proxyquire('./page.summary.controller', {
   '../../../../route/route': route,
   '../../../../service-data/service-data': serviceData,
   '../../../../page/redirect-next-page/redirect-next-page': redirectNextPageStub,
-  '../../../../client/submitter/submitter': {submitterClient: submitterClientSpy}
+  '../../../../client/submitter/submitter': {submitterClient: submitterClientSpy},
+  '../../../../presenter/pdf-payload': {pdfPayload: pdfPayloadStub},
+  '../../../../middleware/routes-output/submission-data-with-labels': {submissionDataWithLabels: submissionDataWithLabelsStub}
 })
 
 getInstancePropertyStub.callsFake((_id, type) => {
@@ -160,7 +166,9 @@ test('it attaches a user submission when the property is set to true', async t =
   getInstancePropertyStub.withArgs('service', 'attachUserSubmission').returns(true)
 
   const pageSummaryController = proxyquire('./page.summary.controller', {
-    '../../../../page/check-submits/check-submits': {checkSubmits: checkSubmitsStub}
+    '../../../../page/check-submits/check-submits': {checkSubmits: checkSubmitsStub},
+    '../../../../presenter/pdf-payload': {pdfPayload: pdfPayloadStub},
+    '../../../../middleware/routes-output/submission-data-with-labels': {submissionDataWithLabels: submissionDataWithLabelsStub}
   })
 
   await pageSummaryController.postValidation({}, userData)
@@ -172,12 +180,30 @@ test('it attaches a user submission when the property is set to true', async t =
   t.end()
 })
 
+test('it attaches the PDF submission data', async t => {
+  getUserDataPropertyStub.resetHistory()
+  const pageSummaryController = proxyquire('./page.summary.controller', {
+    '../../../../page/check-submits/check-submits': {checkSubmits: checkSubmitsStub},
+    '../../../../presenter/pdf-payload': {pdfPayload: pdfPayloadStub},
+    '../../../../middleware/routes-output/submission-data-with-labels': {submissionDataWithLabels: submissionDataWithLabelsStub}
+  })
+
+  await pageSummaryController.postValidation({}, userData)
+
+  const submissions = submitterClientSpy.getCall(0).args[0].submissions
+  t.deepEquals(submissions[1].pdf_payload, pdfPayload)
+  submitterClientSpy.resetHistory()
+  t.end()
+})
+
 test('it does not attach a user submission when the property is set to false', async t => {
   getUserDataPropertyStub.resetHistory()
   getUserDataPropertyStub.withArgs('email').returns('user@example.com')
   getInstancePropertyStub.withArgs('service', 'attachUserSubmission').returns(false)
   const pageSummaryController = proxyquire('./page.summary.controller', {
-    '../../../../page/check-submits/check-submits': {checkSubmits: checkSubmitsStub}
+    '../../../../page/check-submits/check-submits': {checkSubmits: checkSubmitsStub},
+    '../../../../presenter/pdf-payload': {pdfPayload: pdfPayloadStub},
+    '../../../../middleware/routes-output/submission-data-with-labels': {submissionDataWithLabels: submissionDataWithLabelsStub}
   })
 
   await pageSummaryController.postValidation({}, userData)
@@ -195,6 +221,8 @@ test('it attaches json to submission when env var present', async t => {
 
   const pageSummaryController = proxyquire('./page.summary.controller', {
     '../../../../page/check-submits/check-submits': {checkSubmits: checkSubmitsStub},
+    '../../../../presenter/pdf-payload': {pdfPayload: pdfPayloadStub},
+    '../../../../middleware/routes-output/submission-data-with-labels': {submissionDataWithLabels: submissionDataWithLabelsStub},
     '../../../../constants/constants': {
       SERVICE_OUTPUT_JSON_ENDPOINT: 'https://example.com/adaptor',
       SERVICE_OUTPUT_JSON_KEY: 'shared_key',
@@ -219,6 +247,8 @@ test('when there are files it attaches them to json submission', async t => {
 
   const pageSummaryController = proxyquire('./page.summary.controller', {
     '../../../../page/check-submits/check-submits': {checkSubmits: checkSubmitsStub},
+    '../../../../presenter/pdf-payload': {pdfPayload: pdfPayloadStub},
+    '../../../../middleware/routes-output/submission-data-with-labels': {submissionDataWithLabels: submissionDataWithLabelsStub},
     '../../../../constants/constants': {
       SERVICE_OUTPUT_JSON_ENDPOINT: 'https://example.com/adaptor',
       SERVICE_OUTPUT_JSON_KEY: 'shared_key',
@@ -242,13 +272,17 @@ test('it does not attach json to submission when env var not present', async t =
   getUserDataPropertyStub.resetHistory()
 
   const pageSummaryController = proxyquire('./page.summary.controller', {
+    '../../../../presenter/pdf-payload': {pdfPayload: pdfPayloadStub},
+    '../../../../middleware/routes-output/submission-data-with-labels': {submissionDataWithLabels: submissionDataWithLabelsStub},
     '../../../../page/check-submits/check-submits': {checkSubmits: checkSubmitsStub}
   })
 
   await pageSummaryController.postValidation({}, userData)
 
   const submissions = submitterClientSpy.getCall(0).args[0].submissions
-  t.equals(submissions[1], undefined)
+  const jsonEntries = submissions.filter(s => s.type === 'json')
+
+  t.deepEquals(jsonEntries, [])
   submitterClientSpy.resetHistory()
   t.end()
 })

--- a/lib/middleware/routes-output/routes-output.js
+++ b/lib/middleware/routes-output/routes-output.js
@@ -13,9 +13,6 @@ const nunjucksConfiguration = require('../nunjucks-configuration/nunjucks-config
 const {getInstanceProperty} = require('../../service-data/service-data')
 const {format} = require('../../format/format')
 
-const pdfPayload = require('../../presenter/pdf-payload')
-const submissionDataWithLabels = require('./submission-data-with-labels')
-
 const {getController} = require('../../controller/controller')
 
 const jp = require('jsonpath')
@@ -55,14 +52,6 @@ const generateOutput = async (req, res) => {
   }
 
   if (outputType === 'pdf') {
-    if (process.env.PDF_SERVICE_FLAG) {
-      const payload = pdfPayload(
-        submissionDataWithLabels(submission, heading, subHeading, destination, userData)
-      )
-      res.send(payload)
-      return
-    }
-
     let pageInstance = {
       _type: 'output.pdf',
       title: submission,

--- a/lib/middleware/routes-output/submission-data-with-labels.js
+++ b/lib/middleware/routes-output/submission-data-with-labels.js
@@ -25,4 +25,6 @@ const submissionDataWithLabels = (title, heading, subHeading, destination, userD
   return formatProperties(pageInstance, userData)
 }
 
-module.exports = submissionDataWithLabels
+module.exports = {
+  submissionDataWithLabels
+}

--- a/lib/presenter/pdf-payload.js
+++ b/lib/presenter/pdf-payload.js
@@ -26,4 +26,6 @@ const questions = (section) => {
   })
 }
 
-module.exports = pdfPayload
+module.exports = {
+  pdfPayload
+}

--- a/lib/presenter/pdf-payload.unit.spec.js
+++ b/lib/presenter/pdf-payload.unit.spec.js
@@ -1,5 +1,5 @@
 const test = require('tape')
-const pdfPayload = require('./pdf-payload')
+const {pdfPayload} = require('./pdf-payload')
 const expectedPayload = {
   submission_id: '1786c427-246e-4bb7-90b9-a2e6cfae003f / Tue, 08 Oct 2019 12:44:33 GMT',
   pdf_heading: 'Complain about a court or tribunal',


### PR DESCRIPTION
This eliminates the need for the callback into the pdf endpoint.
We will use this PDF data to forward it to the new API from the submitter, which
will generate the PDF for us.

This will then be sent as attachments in the confirmation email(s).