### PR TITLE
PDF content sits within the context of a recipient email attachment

### DIFF
--- a/lib/controller/page/type/page.summary/page.summary.controller.js
+++ b/lib/controller/page/type/page.summary/page.summary.controller.js
@@ -107,8 +107,8 @@ SummaryController.attachEmailSubmissions = async (submissionId, userData, submis
 
   // const timestamp = new Date().getTime()
   const emailUrlStub = '/api/submitter/email/default'
-
-  const teamSubmission = generateEmail('team', from, subject, emailUrlStub, submissionId)
+  const pdfData = SummaryController.generatePDFPayload(userData, submissionId, 'team')
+  const teamSubmission = generateEmail('team', from, subject, emailUrlStub, submissionId, true, pdfData)
 
   const uploadedFiles = userData.uploadedFiles()
   uploadedFiles.forEach(upload => {
@@ -130,7 +130,8 @@ SummaryController.attachEmailSubmissions = async (submissionId, userData, submis
       const userSubject = getInstanceProperty('service', 'emailSubjectUser') || `Your ${serviceName} submission`
       const subject = formatEmail(userSubject)
       const addAttachment = getInstanceProperty('service', 'attachUserSubmission') || false
-      const userSubmission = generateEmail('user', from, subject, emailUrlStub, submissionId, addAttachment)
+      const pdfData = SummaryController.generatePDFPayload(userData, submissionId, 'user')
+      const userSubmission = generateEmail('user', from, subject, emailUrlStub, submissionId, addAttachment, pdfData)
 
       const toUserParts = userEmail.split(/,\s*/)
       toUserParts.forEach(to => {
@@ -141,25 +142,14 @@ SummaryController.attachEmailSubmissions = async (submissionId, userData, submis
   }
 }
 
-SummaryController.attachPdfSubmissions = async (submissions, userData, submissionId) => {
-  const shouldAttachUserPdf = getInstanceProperty('service', 'attachUserSubmission')
+SummaryController.generatePDFPayload = (userData, submissionId, recipient) => {
   const title = submissionId
   const heading = getInstanceProperty('service', 'pdfHeading')
   const subHeading = getInstanceProperty('service', 'pdfSubHeading')
-  const destinations = shouldAttachUserPdf ? ['team', 'user'] : ['team']
 
-  destinations.forEach(function (destination) {
-    const payload = pdfPayload(
-      submissionDataWithLabels(title, heading, subHeading, destination, userData)
-    )
-
-    const pdfSubmission = {
-      type: 'pdf',
-      submission: payload
-    }
-
-    submissions.push(pdfSubmission)
-  })
+  return pdfPayload(
+    submissionDataWithLabels(title, heading, subHeading, recipient, userData)
+  )
 }
 
 SummaryController.attachJsonSubmission = async (submissions, userData) => {
@@ -196,7 +186,6 @@ SummaryController.postValidation = async (pageInstance, userData) => {
 
     SummaryController.attachEmailSubmissions(submissionId, userData, submissions)
     SummaryController.attachJsonSubmission(submissions, userData)
-    SummaryController.attachPdfSubmissions(submissions, userData, submissionId)
 
     try {
       await submitterClient.submit({userId, userToken, submissions}, userData.logger)

--- a/lib/controller/page/type/page.summary/page.summary.controller.unit.spec.js
+++ b/lib/controller/page/type/page.summary/page.summary.controller.unit.spec.js
@@ -180,48 +180,6 @@ test('it attaches a user submission when the property is set to true', async t =
   t.end()
 })
 
-test('it attaches the team PDF submission data', async t => {
-  getUserDataPropertyStub.resetHistory()
-  getInstancePropertyStub.withArgs('service', 'attachUserSubmission').returns(false)
-
-  const pageSummaryController = proxyquire('./page.summary.controller', {
-    '../../../../page/check-submits/check-submits': {checkSubmits: checkSubmitsStub},
-    '../../../../presenter/pdf-payload': {pdfPayload: pdfPayloadStub},
-    '../../../../middleware/routes-output/submission-data-with-labels': {submissionDataWithLabels: submissionDataWithLabelsStub}
-  })
-
-  await pageSummaryController.postValidation({}, userData)
-
-  const submissions = submitterClientSpy.getCall(0).args[0].submissions
-  t.deepEquals(submissions[1].submission, pdfPayload)
-  t.deepEquals(submissions[1].type, 'pdf')
-  t.deepEquals(submissions.length, 2)
-  submitterClientSpy.resetHistory()
-  t.end()
-})
-
-test('it attaches the team and user PDF submission data', async t => {
-  getUserDataPropertyStub.resetHistory()
-  getInstancePropertyStub.withArgs('service', 'attachUserSubmission').returns(true)
-
-  const pageSummaryController = proxyquire('./page.summary.controller', {
-    '../../../../page/check-submits/check-submits': {checkSubmits: checkSubmitsStub},
-    '../../../../presenter/pdf-payload': {pdfPayload: pdfPayloadStub},
-    '../../../../middleware/routes-output/submission-data-with-labels': {submissionDataWithLabels: submissionDataWithLabelsStub}
-  })
-
-  await pageSummaryController.postValidation({}, userData)
-
-  const submissions = submitterClientSpy.getCall(0).args[0].submissions
-  t.deepEquals(submissions[1].submission, pdfPayload)
-  t.deepEquals(submissions[1].type, 'pdf')
-  t.deepEquals(submissions[2].submission, pdfPayload)
-  t.deepEquals(submissions[2].type, 'pdf')
-  t.deepEquals(submissions.length, 3)
-  submitterClientSpy.resetHistory()
-  t.end()
-})
-
 test('it does not attach a user submission when the property is set to false', async t => {
   getUserDataPropertyStub.resetHistory()
   getUserDataPropertyStub.withArgs('email').returns('user@example.com')
@@ -309,6 +267,54 @@ test('it does not attach json to submission when env var not present', async t =
   const jsonEntries = submissions.filter(s => s.type === 'json')
 
   t.deepEquals(jsonEntries, [])
+  submitterClientSpy.resetHistory()
+  t.end()
+})
+
+test('TEAM PDF: it attaches PDF contents to email submission attachments', async t => {
+  getUserDataPropertyStub.resetHistory()
+
+  const pageSummaryController = proxyquire('./page.summary.controller', {
+    '../../../../presenter/pdf-payload': {pdfPayload: pdfPayloadStub},
+    '../../../../middleware/routes-output/submission-data-with-labels': {submissionDataWithLabels: submissionDataWithLabelsStub},
+    '../../../../page/check-submits/check-submits': {checkSubmits: checkSubmitsStub},
+    '../../../../constants/constants': {
+      SERVICE_OUTPUT_EMAIL: 'bob@gov.uk'
+    }
+  })
+
+  await pageSummaryController.postValidation({}, userDataWithFiles)
+
+  const submissions = submitterClientSpy.getCall(0).args[0].submissions
+  const emailEntries = submissions.filter(s => s.type === 'email')
+  const pdfData = emailEntries[0].attachments[0].pdf_data
+
+  t.deepEquals(pdfData, {some: 'PDF contents'})
+  submitterClientSpy.resetHistory()
+  t.end()
+})
+
+test('USER PDF: it attaches PDF contents to email submission attachments', async t => {
+  getUserDataPropertyStub.resetHistory()
+
+  getUserDataPropertyStub.withArgs('attachUserSubmission').returns(true)
+
+  const pageSummaryController = proxyquire('./page.summary.controller', {
+    '../../../../presenter/pdf-payload': {pdfPayload: pdfPayloadStub},
+    '../../../../middleware/routes-output/submission-data-with-labels': {submissionDataWithLabels: submissionDataWithLabelsStub},
+    '../../../../page/check-submits/check-submits': {checkSubmits: checkSubmitsStub},
+    '../../../../constants/constants': {
+      SERVICE_OUTPUT_EMAIL: 'bob@gov.uk'
+    }
+  })
+
+  await pageSummaryController.postValidation({}, userDataWithFiles)
+
+  const submissions = submitterClientSpy.getCall(0).args[0].submissions
+  const emailEntries = submissions.filter(s => s.type === 'email')
+  const pdfData = emailEntries[0].attachments[0].pdf_data
+
+  t.deepEquals(pdfData, {some: 'PDF contents'})
   submitterClientSpy.resetHistory()
   t.end()
 })

--- a/lib/submission/submitter-payload.js
+++ b/lib/submission/submitter-payload.js
@@ -1,4 +1,4 @@
-const generateEmail = (recipientType, from, subject, url, submissionId, addAttachment = true) => {
+const generateEmail = (recipientType, from, subject, url, submissionId, addAttachment = true, pdfData = {}) => {
   const email = {
     recipientType: recipientType,
     type: 'email',
@@ -15,7 +15,8 @@ const generateEmail = (recipientType, from, subject, url, submissionId, addAttac
       url: `/api/submitter/pdf/default/${recipientType}/${submissionId}-${recipientType}.pdf`,
       filename: `${submissionId}.pdf`,
       mimetype: 'application/pdf',
-      type: 'output'
+      type: 'output',
+      pdf_data: pdfData
     })
   }
 

--- a/lib/submission/submitter-payload.unit.spec.js
+++ b/lib/submission/submitter-payload.unit.spec.js
@@ -24,7 +24,8 @@ test('Generating a user submission email with an attachment', async t => {
       url: '/api/submitter/pdf/default/user/abc123-user.pdf',
       filename: 'abc123.pdf',
       mimetype: 'application/pdf',
-      type: 'output'
+      type: 'output',
+      pdf_data: {}
     }]
   }
 
@@ -47,5 +48,14 @@ test('Generating a team submission email', async t => {
   t.deepEquals(result.recipientType, 'team', 'it should populate the recipient type')
   t.deepEquals(result.body_parts['text/plain'], 'some-url/foo/team/abc123-team', 'it should have a body with a link for the team')
   t.deepEquals(result.attachments[0].url, '/api/submitter/pdf/default/team/abc123-team.pdf', 'it should have an attachment with a link for the team')
+  t.end()
+})
+
+test('Adding PDF data', async t => {
+  const pdfData = {some: 'pdf data'}
+  const result = generateEmail('user', from, subject, url, submissionId, true, pdfData)
+
+  console.log(result.attachments[0])
+  t.deepEquals(result.attachments[0].pdf_data, pdfData, 'it should attach the PDF Data')
   t.end()
 })


### PR DESCRIPTION
It is difficult to derive the recipient of the pdf in the submitter if the pdf
data we send over sits on the root.

Instead scope this pdf data to the recipient, within the attachments.