### PR TITLE
Ensure `text` value is present and strip any html tags from it

### DIFF
--- a/lib/controller/component/type/answers/answers-test-data-1.js
+++ b/lib/controller/component/type/answers/answers-test-data-1.js
@@ -18,6 +18,7 @@ const expected = {
             html: undefined
           },
           value: {
+            html: '<p>answer</p>',
             text: 'answer'
           },
           actions: {
@@ -45,6 +46,7 @@ const expected = {
             html: undefined
           },
           value: {
+            html: '<p>answer</p>',
             text: 'answer'
           },
           actions: {
@@ -64,6 +66,7 @@ const expected = {
             html: undefined
           },
           value: {
+            html: '<p>answer</p>',
             text: 'answer'
           },
           actions: {
@@ -83,7 +86,8 @@ const expected = {
             html: undefined
           },
           value: {
-            html: 'answer'
+            html: '<p>answer</p>',
+            text: 'answer'
           },
           actions: {
             items: [
@@ -102,7 +106,8 @@ const expected = {
             html: undefined
           },
           value: {
-            html: 'answer'
+            html: '<p>answer</p>',
+            text: 'answer'
           },
           actions: {
             items: [

--- a/lib/controller/component/type/answers/answers.controller.js
+++ b/lib/controller/component/type/answers/answers.controller.js
@@ -1,5 +1,6 @@
 const jp = require('jsonpath')
 const get = require('lodash.get')
+const striptags = require('striptags')
 const {getUrl} = require('../../../../route/route')
 
 const {
@@ -241,20 +242,15 @@ answersComponent.preUpdateContents = async (componentInstance, userData, pageIns
             }
           }
         }
-        const {_type, name} = nameInstance
+        const {name} = nameInstance
 
         const question = formatQuestion(nameInstance)
 
         const answer = getDisplayValue(pageInstance, userData, nameInstance)
 
-        const multiline = nameInstance.multiline || _type === 'fileupload' || _type === 'checkboxes'
-
         const value = {}
-        if (multiline) {
-          value.html = answer
-        } else {
-          value.text = answer
-        }
+        value.html = answer
+        value.text = striptags(answer)
 
         const lang = userData.contentLang
         let changeText

--- a/lib/controller/component/type/answers/answers.controller.unit.spec.js
+++ b/lib/controller/component/type/answers/answers.controller.unit.spec.js
@@ -1,5 +1,6 @@
 const test = require('tape')
 const sinon = require('sinon')
+const striptags = require('striptags')
 const rewiremock = require('rewiremock/node')
 
 function initStubs () {
@@ -50,7 +51,7 @@ function initStubs () {
   }
 
   stubs.answersRepeatableStub.returns({})
-  stubs.pageStub.getDisplayValue.returns('answer')
+  stubs.pageStub.getDisplayValue.returns('<p>answer</p>')
 
   rewiremock.enable()
 
@@ -60,6 +61,7 @@ function initStubs () {
 
   const stubConfig = {
     jsonpath: stubs.jsonpathStub,
+    striptags: striptags,
     'lodash.get': stubs.lodashgetStub,
     bytes: stubs.bytesStub,
     '../../../../route/route': stubs.routeStub,

--- a/package-lock.json
+++ b/package-lock.json
@@ -8998,6 +8998,11 @@
       "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
       "dev": true
     },
+    "striptags": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/striptags/-/striptags-3.1.1.tgz",
+      "integrity": "sha1-yMPn/db7S7OjKjt1LltePjgJPr0="
+    },
     "superagent": {
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "serve-favicon": "^2.5.0",
     "shorthash": "0.0.2",
     "sort-keys": "^4.0.0",
+    "striptags": "^3.1.1",
     "uuid": "^3.3.2",
     "write-file-atomic": "^3.0.0"
   }


### PR DESCRIPTION
This value can sometimes be undefined depending on a `multiline` setting.
This breaks data in our JSON payload.

Ensure this value is always present.