### PR TITLE
remove url from generated pdf attachments

### DIFF
--- a/lib/submission/submitter-payload.js
+++ b/lib/submission/submitter-payload.js
@@ -12,7 +12,6 @@ const generateEmail = (recipientType, from, subject, url, submissionId, addAttac
 
   if (addAttachment === true) {
     email.attachments.push({
-      url: `/api/submitter/pdf/default/${recipientType}/${submissionId}-${recipientType}.pdf`,
       filename: `${submissionId}.pdf`,
       mimetype: 'application/pdf',
       type: 'output',

--- a/lib/submission/submitter-payload.unit.spec.js
+++ b/lib/submission/submitter-payload.unit.spec.js
@@ -21,7 +21,6 @@ test('Generating a user submission email with an attachment', async t => {
       'text/plain': 'some-url/foo/user/abc123-user'
     },
     attachments: [{
-      url: '/api/submitter/pdf/default/user/abc123-user.pdf',
       filename: 'abc123.pdf',
       mimetype: 'application/pdf',
       type: 'output',
@@ -47,7 +46,8 @@ test('Generating a team submission email', async t => {
 
   t.deepEquals(result.recipientType, 'team', 'it should populate the recipient type')
   t.deepEquals(result.body_parts['text/plain'], 'some-url/foo/team/abc123-team', 'it should have a body with a link for the team')
-  t.deepEquals(result.attachments[0].url, '/api/submitter/pdf/default/team/abc123-team.pdf', 'it should have an attachment with a link for the team')
+  t.deepEquals(result.attachments[0].url, undefined, 'it should not have a url as will use pdf_data')
+  t.deepEquals(result.attachments[0].pdf_data, {}, 'it should have an pdf_data')
   t.end()
 })
 
@@ -55,7 +55,6 @@ test('Adding PDF data', async t => {
   const pdfData = {some: 'pdf data'}
   const result = generateEmail('user', from, subject, url, submissionId, true, pdfData)
 
-  console.log(result.attachments[0])
   t.deepEquals(result.attachments[0].pdf_data, pdfData, 'it should attach the PDF Data')
   t.end()
 })


### PR DESCRIPTION
this is now superseded by pdf_data used by pdf generator