### PR TITLE
Allow overriding the Runner callback URL

### DIFF
--- a/lib/constants/constants.js
+++ b/lib/constants/constants.js
@@ -148,7 +148,7 @@ insertions,
   ASSET_SRC_PATH: '/assets'
 })
 
-CONSTANTS.RUNNER_URL = `http://${SERVICE_SLUG}.formbuilder-services-${PLATFORM_ENV}-${DEPLOYMENT_ENV}:${CONSTANTS.PORT}`
+CONSTANTS.RUNNER_URL = getEnv().RUNNER_OVERRIDE_URL || `http://${SERVICE_SLUG}.formbuilder-services-${PLATFORM_ENV}-${DEPLOYMENT_ENV}:${CONSTANTS.PORT}`
 
 Object.freeze(CONSTANTS)
 

--- a/lib/constants/constants.unit.spec.js
+++ b/lib/constants/constants.unit.spec.js
@@ -37,3 +37,16 @@ test('When constants is called', t => {
   }, 'it should set the correct values')
   t.end()
 })
+
+test('Overriding the callback URL', t => {
+  const getEnvStub = stubModule('getEnv', () => ({
+    RUNNER_OVERRIDE_URL: 'some-url.com'
+  }))
+
+  const constants = proxyquire('./constants', {
+    './get-env': getEnvStub
+  })
+
+  t.deepEqual(constants.RUNNER_URL, 'some-url.com', 'it should override the Runner callback URL')
+  t.end()
+})


### PR DESCRIPTION
This URL is currently derived from the sub-domain and environments.
This won't be accessible to local stack testing.
To get callbacks working locally, we need something like 'runner-app:3000' for
this URL.