### PR TITLE
Add user_answers type json attachments

### DIFF
--- a/lib/controller/page/type/page.summary/page.summary.controller.js
+++ b/lib/controller/page/type/page.summary/page.summary.controller.js
@@ -159,14 +159,14 @@ SummaryController.attachJsonSubmission = async (submissions, userData) => {
 
   const dataUrl = `${RUNNER_URL}/api/submitter/json/default/userId.json`
 
-  const user_answers = userData.getOutputData()
+  const userAnswers = userData.getOutputData()
 
   const submission = {
     type: 'json',
     url: SERVICE_OUTPUT_JSON_ENDPOINT,
     encryption_key: SERVICE_OUTPUT_JSON_KEY,
     data_url: dataUrl,
-    user_answers: user_answers,
+    user_answers: userAnswers,
     attachments: userData.uploadedFiles()
   }
 

--- a/lib/controller/page/type/page.summary/page.summary.controller.js
+++ b/lib/controller/page/type/page.summary/page.summary.controller.js
@@ -159,11 +159,14 @@ SummaryController.attachJsonSubmission = async (submissions, userData) => {
 
   const dataUrl = `${RUNNER_URL}/api/submitter/json/default/userId.json`
 
+  const user_answers = userData.getOutputData()
+
   const submission = {
     type: 'json',
     url: SERVICE_OUTPUT_JSON_ENDPOINT,
     encryption_key: SERVICE_OUTPUT_JSON_KEY,
     data_url: dataUrl,
+    user_answers: user_answers,
     attachments: userData.uploadedFiles()
   }
 

--- a/lib/controller/page/type/page.summary/page.summary.controller.unit.spec.js
+++ b/lib/controller/page/type/page.summary/page.summary.controller.unit.spec.js
@@ -76,7 +76,7 @@ const userData = {
   getUserId: () => 'userId',
   getUserToken: () => 'userToken',
   getOutputData: () => ({
-    "mock_question_1": 'mock_answer_1'
+    mock_question_1: 'mock_answer_1'
   }),
   uploadedFiles: () => {
     return []
@@ -226,7 +226,7 @@ test('it attaches json to submission when env var present', async t => {
   t.equals(submissions[1].data_url, 'http://service-slug.formbuilder-services-test-dev:3000/api/submitter/json/default/userId.json')
 
   t.deepEquals(submissions[1].user_answers, {
-    "mock_question_1": 'mock_answer_1'
+    mock_question_1: 'mock_answer_1'
   })
   t.deepEquals(submissions[1].attachments, [])
   submitterClientSpy.resetHistory()

--- a/lib/controller/page/type/page.summary/page.summary.controller.unit.spec.js
+++ b/lib/controller/page/type/page.summary/page.summary.controller.unit.spec.js
@@ -68,13 +68,16 @@ getNextPageStub.callsFake(args => {
 })
 
 const getUserDataPropertyStub = stub()
+
 const userData = {
   getUserDataProperty: getUserDataPropertyStub,
   setUserDataProperty: () => {},
   getUserParams: () => ({}),
   getUserId: () => 'userId',
   getUserToken: () => 'userToken',
-  getOutputData: () => ({}),
+  getOutputData: () => ({
+    "mock_question_1": 'mock_answer_1'
+  }),
   uploadedFiles: () => {
     return []
   }
@@ -221,6 +224,10 @@ test('it attaches json to submission when env var present', async t => {
   t.equals(submissions[1].url, 'https://example.com/adaptor')
   t.equals(submissions[1].encryption_key, 'shared_key')
   t.equals(submissions[1].data_url, 'http://service-slug.formbuilder-services-test-dev:3000/api/submitter/json/default/userId.json')
+
+  t.deepEquals(submissions[1].user_answers, {
+    "mock_question_1": 'mock_answer_1'
+  })
   t.deepEquals(submissions[1].attachments, [])
   submitterClientSpy.resetHistory()
   t.end()


### PR DESCRIPTION
This is to avoid having to use the runner callback URL for JSON webhooks

we add the user answers in the original payload