### PR TITLE
Add email_body to submission payload

### DIFF
--- a/lib/submission/submitter-payload.js
+++ b/lib/submission/submitter-payload.js
@@ -1,4 +1,18 @@
+const {getInstanceProperty} = require('../service-data/service-data')
+
 const generateEmail = (recipientType, from, subject, url, submissionId, addAttachment = true, pdfData = {}) => {
+  const emailBody = recipientType => {
+    let body
+    if (recipientType === 'team') {
+      body = getInstanceProperty('service', 'emailTemplateTeam') || 'Please find an application attached'
+    } else if (recipientType === 'user') {
+      body = getInstanceProperty('service', 'emailTemplateUser') || 'A copy of your application is attached'
+    } else {
+      body = 'A copy of the application is attached'
+    }
+    return body
+  }
+
   const email = {
     recipientType: recipientType,
     type: 'email',
@@ -7,6 +21,7 @@ const generateEmail = (recipientType, from, subject, url, submissionId, addAttac
     body_parts: {
       'text/plain': `${url}/${recipientType}/${submissionId}-${recipientType}`
     },
+    email_body: emailBody(recipientType),
     attachments: []
   }
 

--- a/lib/submission/submitter-payload.unit.spec.js
+++ b/lib/submission/submitter-payload.unit.spec.js
@@ -20,6 +20,7 @@ test('Generating a user submission email with an attachment', async t => {
     body_parts: {
       'text/plain': 'some-url/foo/user/abc123-user'
     },
+    email_body: 'A copy of your application is attached',
     attachments: [{
       filename: 'abc123.pdf',
       mimetype: 'application/pdf',


### PR DESCRIPTION
Adds the `email_body` key to the submission payload. Leaves the existing email callback in place for now until we switch the submitter to use this new payload.