### PR TITLE
Fix email body templates

### DIFF
--- a/lib/controller/page/type/page.summary/page.summary.controller.js
+++ b/lib/controller/page/type/page.summary/page.summary.controller.js
@@ -28,7 +28,7 @@ const {submissionDataWithLabels} = require('../../../../middleware/routes-output
 
 const {format} = require('../../../../format/format')
 
-const {generateEmail} = require('../../../../submission/submitter-payload')
+const {generateEmail, composeEmailBody, emailTypes} = require('../../../../submission/submitter-payload')
 
 const submitterClient = require('../../../../client/submitter/submitter')
 
@@ -107,7 +107,9 @@ SummaryController.attachEmailSubmissions = async (submissionId, userData, submis
   // const timestamp = new Date().getTime()
   const emailUrlStub = '/api/submitter/email/default'
   const pdfData = SummaryController.generatePDFPayload(userData, submissionId, 'team')
-  const teamSubmission = generateEmail('team', from, subject, emailUrlStub, submissionId, true, pdfData)
+
+  const emailBody = composeEmailBody(userData, userData.contentLang, emailTypes.TEAM)
+  const teamSubmission = generateEmail('team', from, subject, emailUrlStub, submissionId, true, pdfData, emailBody)
 
   const uploadedFiles = userData.uploadedFiles()
   uploadedFiles.forEach(upload => {
@@ -130,7 +132,8 @@ SummaryController.attachEmailSubmissions = async (submissionId, userData, submis
       const subject = formatEmail(userSubject)
       const addAttachment = getInstanceProperty('service', 'attachUserSubmission') || false
       const pdfData = SummaryController.generatePDFPayload(userData, submissionId, 'user')
-      const userSubmission = generateEmail('user', from, subject, emailUrlStub, submissionId, addAttachment, pdfData)
+      const emailBody = composeEmailBody(userData, userData.contentLang, emailTypes.USER)
+      const userSubmission = generateEmail('user', from, subject, emailUrlStub, submissionId, addAttachment, pdfData, emailBody)
 
       const toUserParts = userEmail.split(/,\s*/)
       toUserParts.forEach(to => {

--- a/lib/controller/page/type/page.summary/page.summary.controller.unit.spec.js
+++ b/lib/controller/page/type/page.summary/page.summary.controller.unit.spec.js
@@ -72,11 +72,14 @@ const getUserDataPropertyStub = stub()
 const userData = {
   getUserDataProperty: getUserDataPropertyStub,
   setUserDataProperty: () => {},
-  getUserParams: () => ({}),
+  getUserParams: () => ({
+      firstname: 'Bob'
+  }),
   getUserId: () => 'userId',
   getUserToken: () => 'userToken',
   getOutputData: () => ({
-    mock_question_1: 'mock_answer_1'
+    mock_question_1: 'mock_answer_1',
+    firstname: 'Bob'
   }),
   uploadedFiles: () => {
     return []
@@ -277,6 +280,9 @@ test('it does not attach json to submission when env var not present', async t =
 
 test('TEAM PDF: it attaches PDF contents to email submission attachments', async t => {
   getUserDataPropertyStub.resetHistory()
+  getUserDataPropertyStub.resetBehavior()
+
+  getInstancePropertyStub.withArgs('service', 'emailTemplateTeam').returns('{firstname} submitted!')
 
   const pageSummaryController = proxyquire('./page.summary.controller', {
     '../../../../presenter/pdf-payload': {pdfPayload: pdfPayloadStub},
@@ -291,16 +297,23 @@ test('TEAM PDF: it attaches PDF contents to email submission attachments', async
 
   const submissions = submitterClientSpy.getCall(0).args[0].submissions
   const emailEntries = submissions.filter(s => s.type === 'email')
-  const pdfData = emailEntries[0].attachments[0].pdf_data
 
+
+  debugger
+  t.equals(emailEntries[0].email_body, 'Bob submitted!')
+
+  const pdfData = emailEntries[0].attachments[0].pdf_data
   t.deepEquals(pdfData, {some: 'PDF contents'})
+
   submitterClientSpy.resetHistory()
   t.end()
 })
 
 test('USER PDF: it attaches PDF contents to email submission attachments', async t => {
   getUserDataPropertyStub.resetHistory()
+  getUserDataPropertyStub.resetBehavior()
 
+  getInstancePropertyStub.withArgs('service', 'emailTemplateTeam').returns('user {firstname} submitted!')
   getUserDataPropertyStub.withArgs('attachUserSubmission').returns(true)
 
   const pageSummaryController = proxyquire('./page.summary.controller', {
@@ -317,6 +330,9 @@ test('USER PDF: it attaches PDF contents to email submission attachments', async
   const submissions = submitterClientSpy.getCall(0).args[0].submissions
   const emailEntries = submissions.filter(s => s.type === 'email')
   const pdfData = emailEntries[0].attachments[0].pdf_data
+
+  debugger
+  t.equals(emailEntries[0].email_body, 'user bob submitted!')
 
   t.deepEquals(pdfData, {some: 'PDF contents'})
   submitterClientSpy.resetHistory()

--- a/lib/controller/page/type/page.summary/page.summary.controller.unit.spec.js
+++ b/lib/controller/page/type/page.summary/page.summary.controller.unit.spec.js
@@ -70,22 +70,21 @@ getNextPageStub.callsFake(args => {
 const getUserDataPropertyStub = stub()
 
 const userData = {
+  firstname: 'bob',
   getUserDataProperty: getUserDataPropertyStub,
   setUserDataProperty: () => {},
-  getUserParams: () => ({
-      firstname: 'Bob'
-  }),
+  getUserParams: () => ({}),
   getUserId: () => 'userId',
   getUserToken: () => 'userToken',
   getOutputData: () => ({
     mock_question_1: 'mock_answer_1',
-    firstname: 'Bob'
   }),
   uploadedFiles: () => {
     return []
   }
 }
 const userDataWithFiles = {
+  firstname: 'bob',
   getUserDataProperty: getUserDataPropertyStub,
   setUserDataProperty: () => {},
   getUserParams: () => ({}),
@@ -298,9 +297,7 @@ test('TEAM PDF: it attaches PDF contents to email submission attachments', async
   const submissions = submitterClientSpy.getCall(0).args[0].submissions
   const emailEntries = submissions.filter(s => s.type === 'email')
 
-
-  debugger
-  t.equals(emailEntries[0].email_body, 'Bob submitted!')
+  t.equals(emailEntries[0].email_body, 'bob submitted!')
 
   const pdfData = emailEntries[0].attachments[0].pdf_data
   t.deepEquals(pdfData, {some: 'PDF contents'})
@@ -331,7 +328,6 @@ test('USER PDF: it attaches PDF contents to email submission attachments', async
   const emailEntries = submissions.filter(s => s.type === 'email')
   const pdfData = emailEntries[0].attachments[0].pdf_data
 
-  debugger
   t.equals(emailEntries[0].email_body, 'user bob submitted!')
 
   t.deepEquals(pdfData, {some: 'PDF contents'})

--- a/lib/controller/page/type/page.summary/page.summary.controller.unit.spec.js
+++ b/lib/controller/page/type/page.summary/page.summary.controller.unit.spec.js
@@ -77,7 +77,7 @@ const userData = {
   getUserId: () => 'userId',
   getUserToken: () => 'userToken',
   getOutputData: () => ({
-    mock_question_1: 'mock_answer_1',
+    mock_question_1: 'mock_answer_1'
   }),
   uploadedFiles: () => {
     return []

--- a/lib/submission/compose-email-body.unit.spec.js
+++ b/lib/submission/compose-email-body.unit.spec.js
@@ -6,7 +6,7 @@ const {stub, spy} = require('sinon')
 const serviceData = require('../service-data/service-data')
 const getInstancePropertyStub = stub(serviceData, 'getInstanceProperty')
 
-const {composeEmailBody, emailType} = require('./submitter-payload')
+const {composeEmailBody, emailTypes} = require('./submitter-payload')
 
 getInstancePropertyStub.callsFake((_id, type) => {
   const matches = {
@@ -24,12 +24,12 @@ const url = 'some-url/foo'
 const submissionId = 'abc123'
 
 test('Composing the default email body for Team recipient', function (t) {
-  t.equals(composeEmailBody({}, 'en', emailType.TEAM), 'Please find an application attached', 'returns the default string')
+  t.equals(composeEmailBody({}, 'en', emailTypes.TEAM), 'Please find an application attached', 'returns the default string')
   t.end()
 })
 
 test('Composing the default email body for User recipient', function (t) {
-  t.equals(composeEmailBody({}, 'en', emailType.USER), 'A copy of your application is attached', 'returns the default string')
+  t.equals(composeEmailBody({}, 'en', emailTypes.USER), 'A copy of your application is attached', 'returns the default string')
   t.end()
 })
 
@@ -37,7 +37,7 @@ test('Composing the email body with variables in the content', function (t) {
   const editorDefinedBody = "Dear {fullname}. A copy of your IoJ application is attached."
   getInstancePropertyStub.withArgs('service', 'emailTemplateUser').returns(editorDefinedBody)
 
-  t.equals(composeEmailBody({fullname: 'Bob'}, 'en', emailType.USER), 'Dear Bob. A copy of your IoJ application is attached.', 'returns the formated string')
+  t.equals(composeEmailBody({fullname: 'Bob'}, 'en', emailTypes.USER), 'Dear Bob. A copy of your IoJ application is attached.', 'returns the formated string')
   t.end()
 })
 
@@ -45,6 +45,6 @@ test('Composing the email body with variables in the content', function (t) {
   const editorDefinedBody = "{fullname} has submitted a new applcation"
   getInstancePropertyStub.withArgs('service', 'emailTemplateTeam').returns(editorDefinedBody)
 
-  t.equals(composeEmailBody({fullname: 'ALice'}, 'en', emailType.TEAM), 'ALice has submitted a new applcation', 'returns the formated string')
+  t.equals(composeEmailBody({fullname: 'ALice'}, 'en', emailTypes.TEAM), 'ALice has submitted a new applcation', 'returns the formated string')
   t.end()
 })

--- a/lib/submission/compose-email-body.unit.spec.js
+++ b/lib/submission/compose-email-body.unit.spec.js
@@ -1,0 +1,50 @@
+'use strict'
+
+const test = require('tape')
+const {stub, spy} = require('sinon')
+
+const serviceData = require('../service-data/service-data')
+const getInstancePropertyStub = stub(serviceData, 'getInstanceProperty')
+
+const {composeEmailBody, emailType} = require('./submitter-payload')
+
+getInstancePropertyStub.callsFake((_id, type) => {
+  const matches = {
+    isConfirmation: 'page.confirmation',
+    fauxConfirmation: 'page.content'
+  }
+
+  return type === '_type' ? matches[_id] : undefined
+})
+
+
+const from = 'bob@example.com'
+const subject = 'some subject'
+const url = 'some-url/foo'
+const submissionId = 'abc123'
+
+test('Composing the default email body for Team recipient', function (t) {
+  t.equals(composeEmailBody({}, 'en', emailType.TEAM), 'Please find an application attached', 'returns the default string')
+  t.end()
+})
+
+test('Composing the default email body for User recipient', function (t) {
+  t.equals(composeEmailBody({}, 'en', emailType.USER), 'A copy of your application is attached', 'returns the default string')
+  t.end()
+})
+
+test('Composing the email body with variables in the content', function (t) {
+  const editorDefinedBody = "Dear {fullname}. A copy of your IoJ application is attached."
+  getInstancePropertyStub.withArgs('service', 'emailTemplateUser').returns(editorDefinedBody)
+
+  t.equals(composeEmailBody({fullname: 'Bob'}, 'en', emailType.USER), 'Dear Bob. A copy of your IoJ application is attached.', 'returns the formated string')
+  t.end()
+})
+
+test('Composing the email body with variables in the content', function (t) {
+  const editorDefinedBody = "{fullname} has submitted a new applcation"
+  getInstancePropertyStub.withArgs('service', 'emailTemplateTeam').returns(editorDefinedBody)
+
+  t.equals(composeEmailBody({fullname: 'ALice'}, 'en', emailType.TEAM), 'ALice has submitted a new applcation', 'returns the formated string')
+  t.end()
+})

--- a/lib/submission/compose-email-body.unit.spec.js
+++ b/lib/submission/compose-email-body.unit.spec.js
@@ -8,6 +8,11 @@ const getInstancePropertyStub = stub(serviceData, 'getInstanceProperty')
 
 const {composeEmailBody, emailTypes} = require('./submitter-payload')
 
+test('supplying a invlid email type will thow an error', function (t) {
+  t.throws(composeEmailBody, new Error())
+  t.end()
+})
+
 test('Composing the default email body for Team recipient', function (t) {
   t.equals(composeEmailBody({}, 'en', emailTypes.TEAM), 'Please find an application attached', 'returns the default string')
   t.end()

--- a/lib/submission/compose-email-body.unit.spec.js
+++ b/lib/submission/compose-email-body.unit.spec.js
@@ -1,27 +1,12 @@
 'use strict'
 
 const test = require('tape')
-const {stub, spy} = require('sinon')
+const {stub} = require('sinon')
 
 const serviceData = require('../service-data/service-data')
 const getInstancePropertyStub = stub(serviceData, 'getInstanceProperty')
 
 const {composeEmailBody, emailTypes} = require('./submitter-payload')
-
-getInstancePropertyStub.callsFake((_id, type) => {
-  const matches = {
-    isConfirmation: 'page.confirmation',
-    fauxConfirmation: 'page.content'
-  }
-
-  return type === '_type' ? matches[_id] : undefined
-})
-
-
-const from = 'bob@example.com'
-const subject = 'some subject'
-const url = 'some-url/foo'
-const submissionId = 'abc123'
 
 test('Composing the default email body for Team recipient', function (t) {
   t.equals(composeEmailBody({}, 'en', emailTypes.TEAM), 'Please find an application attached', 'returns the default string')
@@ -34,7 +19,7 @@ test('Composing the default email body for User recipient', function (t) {
 })
 
 test('Composing the email body with variables in the content', function (t) {
-  const editorDefinedBody = "Dear {fullname}. A copy of your IoJ application is attached."
+  const editorDefinedBody = 'Dear {fullname}. A copy of your IoJ application is attached.'
   getInstancePropertyStub.withArgs('service', 'emailTemplateUser').returns(editorDefinedBody)
 
   t.equals(composeEmailBody({fullname: 'Bob'}, 'en', emailTypes.USER), 'Dear Bob. A copy of your IoJ application is attached.', 'returns the formated string')
@@ -42,7 +27,7 @@ test('Composing the email body with variables in the content', function (t) {
 })
 
 test('Composing the email body with variables in the content', function (t) {
-  const editorDefinedBody = "{fullname} has submitted a new applcation"
+  const editorDefinedBody = '{fullname} has submitted a new applcation'
   getInstancePropertyStub.withArgs('service', 'emailTemplateTeam').returns(editorDefinedBody)
 
   t.equals(composeEmailBody({fullname: 'ALice'}, 'en', emailTypes.TEAM), 'ALice has submitted a new applcation', 'returns the formated string')

--- a/lib/submission/submitter-payload.js
+++ b/lib/submission/submitter-payload.js
@@ -42,7 +42,6 @@ const composeEmailBody = (userData, language, recipientType) => {
   return format(body, userData, {markdown: false, lang: language})
 }
 
-
 module.exports = {
   generateEmail, composeEmailBody, emailTypes
 }

--- a/lib/submission/submitter-payload.js
+++ b/lib/submission/submitter-payload.js
@@ -1,4 +1,5 @@
 const {getInstanceProperty} = require('../service-data/service-data')
+const {format} = require('../format/format')
 
 const generateEmail = (recipientType, from, subject, url, submissionId, addAttachment = true, pdfData = {}) => {
   const emailBody = recipientType => {
@@ -37,6 +38,23 @@ const generateEmail = (recipientType, from, subject, url, submissionId, addAttac
   return email
 }
 
+const emailType = {
+  USER: 'user',
+  TEAM: 'team'
+}
+
+const composeEmailBody = (userData, language, recipientType) => {
+  let body
+  if (recipientType === emailType.TEAM) {
+    body = getInstanceProperty('service', 'emailTemplateTeam') || 'Please find an application attached'
+  } else if (recipientType === emailType.USER) {
+    body = getInstanceProperty('service', 'emailTemplateUser') || 'A copy of your application is attached'
+  }
+
+  return format(body, userData, {markdown: false, lang: language})
+}
+
+
 module.exports = {
-  generateEmail
+  generateEmail, composeEmailBody, emailType
 }

--- a/lib/submission/submitter-payload.js
+++ b/lib/submission/submitter-payload.js
@@ -33,10 +33,15 @@ const emailTypes = {
 
 const composeEmailBody = (userData, language, recipientType) => {
   let body
-  if (recipientType === emailTypes.TEAM) {
-    body = getInstanceProperty('service', 'emailTemplateTeam') || 'Please find an application attached'
-  } else if (recipientType === emailTypes.USER) {
-    body = getInstanceProperty('service', 'emailTemplateUser') || 'A copy of your application is attached'
+  switch (recipientType) {
+    case emailTypes.TEAM:
+      body = getInstanceProperty('service', 'emailTemplateTeam') || 'Please find an application attached'
+      break
+    case emailTypes.USER:
+      body = getInstanceProperty('service', 'emailTemplateUser') || 'A copy of your application is attached'
+      break
+    default:
+      throw new Error(`unknown emailType. Valid types are: ${JSON.stringify(emailTypes)}`)
   }
 
   return format(body, userData, {markdown: false, lang: language})

--- a/lib/submission/submitter-payload.js
+++ b/lib/submission/submitter-payload.js
@@ -1,19 +1,7 @@
 const {getInstanceProperty} = require('../service-data/service-data')
 const {format} = require('../format/format')
 
-const generateEmail = (recipientType, from, subject, url, submissionId, addAttachment = true, pdfData = {}) => {
-  const emailBody = recipientType => {
-    let body
-    if (recipientType === 'team') {
-      body = getInstanceProperty('service', 'emailTemplateTeam') || 'Please find an application attached'
-    } else if (recipientType === 'user') {
-      body = getInstanceProperty('service', 'emailTemplateUser') || 'A copy of your application is attached'
-    } else {
-      body = 'A copy of the application is attached'
-    }
-    return body
-  }
-
+const generateEmail = (recipientType, from, subject, url, submissionId, addAttachment = true, pdfData = {}, emailBody) => {
   const email = {
     recipientType: recipientType,
     type: 'email',
@@ -22,7 +10,7 @@ const generateEmail = (recipientType, from, subject, url, submissionId, addAttac
     body_parts: {
       'text/plain': `${url}/${recipientType}/${submissionId}-${recipientType}`
     },
-    email_body: emailBody(recipientType),
+    email_body: emailBody,
     attachments: []
   }
 
@@ -38,16 +26,16 @@ const generateEmail = (recipientType, from, subject, url, submissionId, addAttac
   return email
 }
 
-const emailType = {
+const emailTypes = {
   USER: 'user',
   TEAM: 'team'
 }
 
 const composeEmailBody = (userData, language, recipientType) => {
   let body
-  if (recipientType === emailType.TEAM) {
+  if (recipientType === emailTypes.TEAM) {
     body = getInstanceProperty('service', 'emailTemplateTeam') || 'Please find an application attached'
-  } else if (recipientType === emailType.USER) {
+  } else if (recipientType === emailTypes.USER) {
     body = getInstanceProperty('service', 'emailTemplateUser') || 'A copy of your application is attached'
   }
 
@@ -56,5 +44,5 @@ const composeEmailBody = (userData, language, recipientType) => {
 
 
 module.exports = {
-  generateEmail, composeEmailBody, emailType
+  generateEmail, composeEmailBody, emailTypes
 }

--- a/lib/submission/submitter-payload.unit.spec.js
+++ b/lib/submission/submitter-payload.unit.spec.js
@@ -7,10 +7,12 @@ const from = 'bob@example.com'
 const subject = 'some subject'
 const url = 'some-url/foo'
 const submissionId = 'abc123'
+const emailBody = 'a email body'
+const pdfData = {some_test_queston: 'some_test_answer'}
 
 test('Generating a user submission email with an attachment', async t => {
   const addAttachment = true
-  const result = generateEmail('user', from, subject, url, submissionId, addAttachment)
+  const result = generateEmail('user', from, subject, url, submissionId, addAttachment, pdfData, emailBody)
 
   const expectedResult = {
     recipientType: 'user',
@@ -20,12 +22,12 @@ test('Generating a user submission email with an attachment', async t => {
     body_parts: {
       'text/plain': 'some-url/foo/user/abc123-user'
     },
-    email_body: 'A copy of your application is attached',
+    email_body: emailBody,
     attachments: [{
       filename: 'abc123.pdf',
       mimetype: 'application/pdf',
       type: 'output',
-      pdf_data: {}
+      pdf_data: pdfData
     }]
   }
 
@@ -35,7 +37,7 @@ test('Generating a user submission email with an attachment', async t => {
 
 test('Generating a user submission email without an attachment', async t => {
   const addAttachment = false
-  const result = generateEmail('user', from, subject, url, submissionId, addAttachment)
+  const result = generateEmail('user', from, subject, url, submissionId, addAttachment, pdfData, emailBody)
 
   t.deepEquals(result.attachments, [], 'it should have empty attachments')
   t.end()
@@ -43,18 +45,17 @@ test('Generating a user submission email without an attachment', async t => {
 
 test('Generating a team submission email', async t => {
   const addAttachment = true
-  const result = generateEmail('team', from, subject, url, submissionId, addAttachment)
+  const result = generateEmail('team', from, subject, url, submissionId, addAttachment, pdfData, emailBody)
 
   t.deepEquals(result.recipientType, 'team', 'it should populate the recipient type')
   t.deepEquals(result.body_parts['text/plain'], 'some-url/foo/team/abc123-team', 'it should have a body with a link for the team')
   t.deepEquals(result.attachments[0].url, undefined, 'it should not have a url as will use pdf_data')
-  t.deepEquals(result.attachments[0].pdf_data, {}, 'it should have an pdf_data')
+  t.deepEquals(result.attachments[0].pdf_data, pdfData, 'it should have an pdf_data')
   t.end()
 })
 
 test('Adding PDF data', async t => {
-  const pdfData = {some: 'pdf data'}
-  const result = generateEmail('user', from, subject, url, submissionId, true, pdfData)
+  const result = generateEmail('user', from, subject, url, submissionId, true, pdfData, emailBody)
 
   t.deepEquals(result.attachments[0].pdf_data, pdfData, 'it should attach the PDF Data')
   t.end()


### PR DESCRIPTION
The body of emails can be overridden by a field in the form.json

This adds that behaviour to our new email_body field (and tests it)