### PR TITLE
Add flag for including PDF and attachments in payload

### DIFF
--- a/lib/controller/page/type/page.summary/page.summary.controller.js
+++ b/lib/controller/page/type/page.summary/page.summary.controller.js
@@ -130,10 +130,10 @@ SummaryController.attachEmailSubmissions = async (submissionId, userData, submis
     if (userEmail) {
       const userSubject = getInstanceProperty('service', 'emailSubjectUser') || `Your ${serviceName} submission`
       const subject = formatEmail(userSubject)
-      const addAttachment = getInstanceProperty('service', 'attachUserSubmission') || false
+      const includePdf = getInstanceProperty('service', 'attachUserSubmission') || false
       const pdfData = SummaryController.generatePDFPayload(userData, submissionId, 'user')
       const emailBody = composeEmailBody(userData.getUserData(), userData.contentLang, emailTypes.USER)
-      const userSubmission = generateEmail('user', from, subject, emailUrlStub, submissionId, addAttachment, pdfData, emailBody)
+      const userSubmission = generateEmail('user', from, subject, emailUrlStub, submissionId, includePdf, pdfData, emailBody)
 
       const toUserParts = userEmail.split(/,\s*/)
       toUserParts.forEach(to => {

--- a/lib/submission/submitter-payload.js
+++ b/lib/submission/submitter-payload.js
@@ -1,7 +1,7 @@
 const {getInstanceProperty} = require('../service-data/service-data')
 const {format} = require('../format/format')
 
-const generateEmail = (recipientType, from, subject, url, submissionId, addAttachment = true, pdfData = {}, emailBody) => {
+const generateEmail = (recipientType, from, subject, url, submissionId, includePdf = true, pdfData = {}, emailBody) => {
   const email = {
     recipientType: recipientType,
     type: 'email',
@@ -11,10 +11,12 @@ const generateEmail = (recipientType, from, subject, url, submissionId, addAttac
       'text/plain': `${url}/${recipientType}/${submissionId}-${recipientType}`
     },
     email_body: emailBody,
+    include_pdf: includePdf,
+    include_attachments: recipientType === 'team',
     attachments: []
   }
 
-  if (addAttachment === true) {
+  if (includePdf === true) {
     email.attachments.push({
       filename: `${submissionId}.pdf`,
       mimetype: 'application/pdf',

--- a/lib/submission/submitter-payload.unit.spec.js
+++ b/lib/submission/submitter-payload.unit.spec.js
@@ -10,9 +10,9 @@ const submissionId = 'abc123'
 const emailBody = 'a email body'
 const pdfData = {some_test_queston: 'some_test_answer'}
 
-test('Generating a user submission email with an attachment', async t => {
-  const addAttachment = true
-  const result = generateEmail('user', from, subject, url, submissionId, addAttachment, pdfData, emailBody)
+test('Generating a user submission email with a PDF', async t => {
+  const includePdf = true
+  const result = generateEmail('user', from, subject, url, submissionId, includePdf, pdfData, emailBody)
 
   const expectedResult = {
     recipientType: 'user',
@@ -23,6 +23,8 @@ test('Generating a user submission email with an attachment', async t => {
       'text/plain': 'some-url/foo/user/abc123-user'
     },
     email_body: emailBody,
+    include_pdf: true,
+    include_attachments: false,
     attachments: [{
       filename: 'abc123.pdf',
       mimetype: 'application/pdf',
@@ -35,22 +37,25 @@ test('Generating a user submission email with an attachment', async t => {
   t.end()
 })
 
-test('Generating a user submission email without an attachment', async t => {
-  const addAttachment = false
-  const result = generateEmail('user', from, subject, url, submissionId, addAttachment, pdfData, emailBody)
+test('Generating a user submission email without a PDF', async t => {
+  const includePdf = false
+  const result = generateEmail('user', from, subject, url, submissionId, includePdf, pdfData, emailBody)
 
   t.deepEquals(result.attachments, [], 'it should have empty attachments')
   t.end()
 })
 
-test('Generating a team submission email', async t => {
-  const addAttachment = true
-  const result = generateEmail('team', from, subject, url, submissionId, addAttachment, pdfData, emailBody)
+test('Attachments are included for a team submission', async t => {
+  const result = generateEmail('team', from, subject, url, submissionId, false, pdfData, emailBody)
 
-  t.deepEquals(result.recipientType, 'team', 'it should populate the recipient type')
-  t.deepEquals(result.body_parts['text/plain'], 'some-url/foo/team/abc123-team', 'it should have a body with a link for the team')
-  t.deepEquals(result.attachments[0].url, undefined, 'it should not have a url as will use pdf_data')
-  t.deepEquals(result.attachments[0].pdf_data, pdfData, 'it should have an pdf_data')
+  t.deepEquals(result.include_attachments, true, 'it add attachments for a team email')
+  t.end()
+})
+
+test('Attachments are not included for a user submission', async t => {
+  const result = generateEmail('user', from, subject, url, submissionId, false, pdfData, emailBody)
+
+  t.deepEquals(result.include_attachments, false, 'it should not include attachments for user emails')
   t.end()
 })
 


### PR DESCRIPTION
This is the first small step towards promoting the submission data to the root
level of the payload.

With these flags we can figure out whether the 'user' recipient should receive
attachments (off by default), and a confirmation PDF (configured in the form)

Once this works the next step is to duplicate the payload to the root level and
use these conditionals to figure out which attachments and pdfs to send.