### PR TITLE
Attach form data to root of payload

### DIFF
--- a/lib/controller/page/type/page.summary/page.summary.controller.js
+++ b/lib/controller/page/type/page.summary/page.summary.controller.js
@@ -144,13 +144,13 @@ SummaryController.attachEmailSubmissions = async (submissionId, userData, submis
   }
 }
 
-SummaryController.generatePDFPayload = (userData, submissionId, recipient) => {
+SummaryController.generatePDFPayload = (userData, submissionId) => {
   const title = submissionId
   const heading = getInstanceProperty('service', 'pdfHeading')
   const subHeading = getInstanceProperty('service', 'pdfSubHeading')
 
   return pdfPayload(
-    submissionDataWithLabels(title, heading, subHeading, recipient, userData)
+    submissionDataWithLabels(title, heading, subHeading, userData)
   )
 }
 
@@ -187,8 +187,17 @@ SummaryController.postValidation = async (pageInstance, userData) => {
     SummaryController.attachEmailSubmissions(submissionId, userData, submissions)
     SummaryController.attachJsonSubmission(submissions, userData)
 
+    const formData = SummaryController.generatePDFPayload(userData, submissionId)
+
+    const submission = {
+      userId: userId,
+      userToken: userToken,
+      formData: formData,
+      submissions
+    }
+
     try {
-      await submitterClient.submit({userId, userToken, submissions}, userData.logger)
+      await submitterClient.submit(submission, userData.logger)
     } catch (error) {
       submissionFailureMetric.inc()
       if (userData.logger) {

--- a/lib/middleware/routes-output/submission-data-with-labels.js
+++ b/lib/middleware/routes-output/submission-data-with-labels.js
@@ -1,7 +1,7 @@
 const {getInstanceController} = require('../../controller/controller')
 const {formatProperties} = require('../../page/page')
 
-const submissionDataWithLabels = (title, heading, subHeading, destination, userData) => {
+const submissionDataWithLabels = (title, heading, subHeading, userData) => {
   const answersComponent = {
     _id: 'page.summary.answers',
     _type: 'answers',
@@ -15,7 +15,6 @@ const submissionDataWithLabels = (title, heading, subHeading, destination, userD
     heading,
     columns: 'full',
     isPdf: true,
-    skipRedact: destination === 'team',
     components: [answersComponent]
   }
 


### PR DESCRIPTION
This is a duplicate of the pdf payload for now.
Once the submitter uses this new form data, we can remove the email / pdf
specific payload.

The PDF doesn't need to be aware of the recipient.  Redacting values
isn't a feature we need on any of our current forms so remove it.

Be more explicit about the PDF payload object, instead of destructuring
it in the argument to the submitter client.