### PR TITLE
Remove email callback endpoint

### DIFF
--- a/lib/controller/page/type/page.summary/page.summary.controller.js
+++ b/lib/controller/page/type/page.summary/page.summary.controller.js
@@ -105,11 +105,10 @@ SummaryController.attachEmailSubmissions = async (submissionId, userData, submis
   toTeamParts = [...new Set(toTeamParts)]
 
   // const timestamp = new Date().getTime()
-  const emailUrlStub = '/api/submitter/email/default'
   const pdfData = SummaryController.generatePDFPayload(userData, submissionId, 'team')
 
   const emailBody = composeEmailBody(userData.getUserData(), userData.contentLang, emailTypes.TEAM)
-  const teamSubmission = generateEmail('team', from, subject, emailUrlStub, submissionId, true, pdfData, emailBody)
+  const teamSubmission = generateEmail('team', from, subject, submissionId, true, pdfData, emailBody)
 
   const uploadedFiles = userData.uploadedFiles()
   uploadedFiles.forEach(upload => {
@@ -133,7 +132,7 @@ SummaryController.attachEmailSubmissions = async (submissionId, userData, submis
       const includePdf = getInstanceProperty('service', 'attachUserSubmission') || false
       const pdfData = SummaryController.generatePDFPayload(userData, submissionId, 'user')
       const emailBody = composeEmailBody(userData.getUserData(), userData.contentLang, emailTypes.USER)
-      const userSubmission = generateEmail('user', from, subject, emailUrlStub, submissionId, includePdf, pdfData, emailBody)
+      const userSubmission = generateEmail('user', from, subject, submissionId, includePdf, pdfData, emailBody)
 
       const toUserParts = userEmail.split(/,\s*/)
       toUserParts.forEach(to => {

--- a/lib/middleware/routes-output/routes-output.js
+++ b/lib/middleware/routes-output/routes-output.js
@@ -1,15 +1,11 @@
 const express = require('express')
 const router = express.Router()
-
 const json2csv = require('json2csv').parse
 const flatten = require('flat')
-
 const useAsync = require('../use-async/use-async')
-const {getInstanceProperty} = require('../../service-data/service-data')
-const {format} = require('../../format/format')
 
 const generateOutput = async (req, res) => {
-  const {outputType, outputId, destination, filename} = req.params
+  const {outputType, outputId, filename} = req.params
 
   if (outputId !== 'default') {
     throw new Error(404)

--- a/lib/middleware/routes-output/routes-output.js
+++ b/lib/middleware/routes-output/routes-output.js
@@ -16,26 +16,7 @@ const generateOutput = async (req, res) => {
   }
 
   const userData = req.user
-  if (outputType === 'email') {
-    let email
-    if (destination === 'team') {
-      email = getInstanceProperty('service', 'emailTemplateTeam') || 'Please find an application attached'
-    } else if (destination === 'user') {
-      email = getInstanceProperty('service', 'emailTemplateUser') || 'A copy of your application is attached'
-    } else {
-      email = 'A copy of the application is attached'
-    }
-    const formatEmail = (str, markdown = false) => {
-      try {
-        str = format(str, req.user.getUserData(), {markdown, lang: req.user.contentLang})
-      } catch (e) {
-        //
-      }
-      return str
-    }
-    email = formatEmail(email)
-    res.send(email)
-  } else if (outputType === 'csv') {
+  if (outputType === 'csv') {
     const jsonData = flatten(userData.getOutputData())
     const outputData = {}
     Object.keys(jsonData).reverse().forEach(key => {

--- a/lib/submission/submitter-payload.js
+++ b/lib/submission/submitter-payload.js
@@ -7,9 +7,6 @@ const generateEmail = (recipientType, from, subject, url, submissionId, includeP
     type: 'email',
     from,
     subject,
-    body_parts: {
-      'text/plain': `${url}/${recipientType}/${submissionId}-${recipientType}`
-    },
     email_body: emailBody,
     include_pdf: includePdf,
     include_attachments: recipientType === 'team',

--- a/lib/submission/submitter-payload.js
+++ b/lib/submission/submitter-payload.js
@@ -1,7 +1,7 @@
 const {getInstanceProperty} = require('../service-data/service-data')
 const {format} = require('../format/format')
 
-const generateEmail = (recipientType, from, subject, url, submissionId, includePdf = true, pdfData = {}, emailBody) => {
+const generateEmail = (recipientType, from, subject, submissionId, includePdf = true, pdfData = {}, emailBody) => {
   const email = {
     recipientType: recipientType,
     type: 'email',

--- a/lib/submission/submitter-payload.unit.spec.js
+++ b/lib/submission/submitter-payload.unit.spec.js
@@ -5,14 +5,13 @@ const {generateEmail} = require('./submitter-payload')
 
 const from = 'bob@example.com'
 const subject = 'some subject'
-const url = 'some-url/foo'
 const submissionId = 'abc123'
 const emailBody = 'a email body'
 const pdfData = {some_test_queston: 'some_test_answer'}
 
 test('Generating a user submission email with a PDF', async t => {
   const includePdf = true
-  const result = generateEmail('user', from, subject, url, submissionId, includePdf, pdfData, emailBody)
+  const result = generateEmail('user', from, subject, submissionId, includePdf, pdfData, emailBody)
 
   const expectedResult = {
     recipientType: 'user',
@@ -36,28 +35,28 @@ test('Generating a user submission email with a PDF', async t => {
 
 test('Generating a user submission email without a PDF', async t => {
   const includePdf = false
-  const result = generateEmail('user', from, subject, url, submissionId, includePdf, pdfData, emailBody)
+  const result = generateEmail('user', from, subject, submissionId, includePdf, pdfData, emailBody)
 
   t.deepEquals(result.attachments, [], 'it should have empty attachments')
   t.end()
 })
 
 test('Attachments are included for a team submission', async t => {
-  const result = generateEmail('team', from, subject, url, submissionId, false, pdfData, emailBody)
+  const result = generateEmail('team', from, subject, submissionId, false, pdfData, emailBody)
 
   t.deepEquals(result.include_attachments, true, 'it add attachments for a team email')
   t.end()
 })
 
 test('Attachments are not included for a user submission', async t => {
-  const result = generateEmail('user', from, subject, url, submissionId, false, pdfData, emailBody)
+  const result = generateEmail('user', from, subject, submissionId, false, pdfData, emailBody)
 
   t.deepEquals(result.include_attachments, false, 'it should not include attachments for user emails')
   t.end()
 })
 
 test('Adding PDF data', async t => {
-  const result = generateEmail('user', from, subject, url, submissionId, true, pdfData, emailBody)
+  const result = generateEmail('user', from, subject, submissionId, true, pdfData, emailBody)
 
   t.deepEquals(result.attachments[0].pdf_data, pdfData, 'it should attach the PDF Data')
   t.end()

--- a/lib/submission/submitter-payload.unit.spec.js
+++ b/lib/submission/submitter-payload.unit.spec.js
@@ -19,9 +19,6 @@ test('Generating a user submission email with a PDF', async t => {
     type: 'email',
     from,
     subject,
-    body_parts: {
-      'text/plain': 'some-url/foo/user/abc123-user'
-    },
     email_body: emailBody,
     include_pdf: true,
     include_attachments: false,


### PR DESCRIPTION
Removes email body callback endpoint as its no longer needed. The mail body is sent in the initial payload.

Also removes the `url` argument from the `generateEmail` function as its no longer required