### PR TITLE
Add input key/field_name to the answers payload

### DIFF
--- a/lib/presenter/pdf-payload.js
+++ b/lib/presenter/pdf-payload.js
@@ -21,7 +21,8 @@ const questions = (section) => {
   return (section.answers || []).map(answer => {
     return {
       label: answer.key.html,
-      answer: answer.value.text
+      answer: answer.value.text,
+      key: answer.component
     }
   })
 }

--- a/lib/presenter/pdf-payload.unit.spec.js
+++ b/lib/presenter/pdf-payload.unit.spec.js
@@ -15,11 +15,13 @@ const expectedPayload = {
       questions: [
         {
           label: 'First name',
-          answer: 'Bob'
+          answer: 'Bob',
+          key: 'first_name'
         },
         {
           label: 'Last name',
-          answer: 'Smith'
+          answer: 'Smith',
+          key: 'last_name'
         }
       ]
     }, {
@@ -28,14 +30,16 @@ const expectedPayload = {
       questions: [
         {
           label: 'Your email address',
-          answer: 'bob.smith@gov.uk'
+          answer: 'bob.smith@gov.uk',
+          key: 'email_address'
         }, {
-
           label: 'Your complaint',
-          answer: 'tester content'
+          answer: 'tester content',
+          key: 'complaint_details'
         }, {
           label: 'Court or tribunal your complaint is about',
-          answer: 'Aberdeen Employment Tribunal'
+          answer: 'Aberdeen Employment Tribunal',
+          key: 'complaint_location'
         }
       ]
     }


### PR DESCRIPTION
Adds the id/`input_name` of the field to the answers payload. Alongside the label text and answer, this gives the full information of the users answer.

Eg:
```
label: "What is your name?",
answer: "Tom Taylor",
key: "full_name:"
```