### PR TITLE
handle machine value when there is an error

### DIFF
--- a/lib/controller/component/type/answers/answers.controller.js
+++ b/lib/controller/component/type/answers/answers.controller.js
@@ -251,7 +251,13 @@ answersComponent.preUpdateContents = async (componentInstance, userData, pageIns
         const value = {}
         value.html = answer
         value.text = striptags(answer)
-        value.machine = userData.getUserDataProperty(nameInstance.name)
+
+        // handles checkboxes and other non-duck-typed objects
+        try {
+          value.machine = userData.getUserDataProperty(nameInstance.name)
+        } catch (_err) {
+          value.machine = value.text
+        }
 
         const lang = userData.contentLang
         let changeText


### PR DESCRIPTION
this falls back to text value
this happens as objects do not duck type
such as check boxes which have different APIs