### PR TITLE
FB-705

### DIFF
--- a/lib/controller/component/type/answers/answers.controller.js
+++ b/lib/controller/component/type/answers/answers.controller.js
@@ -242,21 +242,33 @@ answersComponent.preUpdateContents = async (componentInstance, userData, pageIns
             }
           }
         }
-        const {name} = nameInstance
 
         const question = formatQuestion(nameInstance)
-
         const answer = getDisplayValue(pageInstance, userData, nameInstance)
 
-        const value = {}
-        value.html = answer
-        value.text = striptags(answer)
+        /*
+         *  `String()` is safer than `toString` since some data types
+         *  (such as undefined or null) do not have a `toString` method
+         */
+        const html = String(answer)
+        const text = striptags(html)
+
+        /*
+         *  The fields of `value` are consumed in Nunjucks which
+         *  expects strings
+         */
+        const value = {
+          html,
+          text
+        }
+
+        const {name} = nameInstance
 
         // handles checkboxes and other non-duck-typed objects
         try {
-          value.machine = userData.getUserDataProperty(nameInstance.name)
+          value.machine = userData.getUserDataProperty(name)
         } catch (_err) {
-          value.machine = value.text
+          value.machine = text
         }
 
         const lang = userData.contentLang
@@ -278,7 +290,7 @@ answersComponent.preUpdateContents = async (componentInstance, userData, pageIns
           actions: {
             items: [
               {
-                href: `${getUrl(stepInstance._id, nextPageParams, userData.contentLang)}/change${pageInstance.url}`,
+                href: `${getUrl(stepInstance._id, nextPageParams, lang)}/change${pageInstance.url}`,
                 text: changeText,
                 visuallyHiddenText: `your answer for ${question}`
               }


### PR DESCRIPTION
[FB-705](https://dsdmoj.atlassian.net/browse/FB-705)

- I've ensured that the field values created for and consumed by Nunjucks are strings
- I've moved the `name` variable declaration down to be in closer context to its use (and used it again)
- I've changed some of the other field references to variables which are already declared
