### PR TITLE
FB-680

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,7 @@
 .dependabot
 .circleci
 .npmrc
+.npmignore
 .nvmrc
+.eslintignore
+.eslintrc

--- a/lib/controller/component/type/answers/answers.controller.js
+++ b/lib/controller/component/type/answers/answers.controller.js
@@ -242,21 +242,33 @@ answersComponent.preUpdateContents = async (componentInstance, userData, pageIns
             }
           }
         }
-        const {name} = nameInstance
 
         const question = formatQuestion(nameInstance)
-
         const answer = getDisplayValue(pageInstance, userData, nameInstance)
 
-        const value = {}
-        value.html = answer
-        value.text = striptags(answer)
+        /*
+         *  `String()` is safer than `toString` since some data types
+         *  (such as undefined or null) do not have a `toString` method
+         */
+        const html = String(answer)
+        const text = striptags(html)
+
+        /*
+         *  The fields of `value` are consumed in Nunjucks which
+         *  expects strings
+         */
+        const value = {
+          html,
+          text
+        }
+
+        const {name} = nameInstance
 
         // handles checkboxes and other non-duck-typed objects
         try {
-          value.machine = userData.getUserDataProperty(nameInstance.name)
+          value.machine = userData.getUserDataProperty(name)
         } catch (_err) {
-          value.machine = value.text
+          value.machine = text
         }
 
         const lang = userData.contentLang
@@ -278,7 +290,7 @@ answersComponent.preUpdateContents = async (componentInstance, userData, pageIns
           actions: {
             items: [
               {
-                href: `${getUrl(stepInstance._id, nextPageParams, userData.contentLang)}/change${pageInstance.url}`,
+                href: `${getUrl(stepInstance._id, nextPageParams, lang)}/change${pageInstance.url}`,
                 text: changeText,
                 visuallyHiddenText: `your answer for ${question}`
               }

--- a/lib/page/get-display-value/get-display-value.js
+++ b/lib/page/get-display-value/get-display-value.js
@@ -22,7 +22,7 @@ const getDisplayValue = (pageInstance, userData, nameInstance) => {
 
   let substitution
   let markdown
-  if (nameInstance._type === 'checkboxes') {
+  if (_type === 'checkboxes') {
     if (nameInstance.items) {
       const values = nameInstance.items.filter(item => {
         let itemValue = item.value
@@ -41,32 +41,41 @@ const getDisplayValue = (pageInstance, userData, nameInstance) => {
     }
   } else {
     if (nameInstance.items) {
-      const nameItem = nameInstance.items.filter(item => item.value === answer)[0]
+      const nameItem = nameInstance.items.find(({value}) => value === answer)
       answer = nameItem ? getInstanceTitleSummary(nameItem._id) : answer
       if (nameItem) {
         substitution = true
       }
     }
   }
+
   if (_type === 'fileupload') {
     if (Array.isArray(answer)) {
-      answer = answer.map(a => {
-        return `${a.originalname} (${bytes(a.size)})`
-      }).join('\n\n')
+      answer = answer.map(({originalname, size}) => `${originalname} (${bytes(size)})`).join('\n\n')
       markdown = true
     }
-  }
-
-  const unansweredQuestion = !answer
-
-  if (unansweredQuestion) {
-    answer = 'Not answered'
   }
 
   if (Array.isArray(answer)) {
     answer = answer.join('\n\n')
     markdown = true
+  } else {
+    /**
+     *  Answers may have been coerced to a non-string data type so we can't expect
+     *  truthiness to tell us whether the question has been answered. Instead,
+     *  we have some explicit conditions
+     *
+     *  They are:
+     *    - Guard against undefined or null
+     *    - Coerce to a string and confirm that the string is not empty
+     *
+     *  Any other primitive is acceptable
+     */
+    if (answer === undefined || answer === null || String(answer) === '') {
+      answer = 'Not answered'
+    }
   }
+
   const multiline = nameInstance.multiline || _type === 'fileupload' || _type === 'checkboxes'
   // TODO: check whether the lang property serve any purpose?
   if (substitution || markdown || multiline) {

--- a/lib/page/get-display-value/get-display-value.unit.spec.js
+++ b/lib/page/get-display-value/get-display-value.unit.spec.js
@@ -41,12 +41,13 @@ const resetStubs = () => {
   getUserDataInputPropertyStub.returns()
 }
 
+const nameInstance = {
+  name: 'name'
+}
+
 test('When there is a simple value', t => {
   resetStubs()
 
-  const nameInstance = {
-    name: 'name'
-  }
   const pageInstance = {
     skipRedact: 'skipRedact'
   }
@@ -65,9 +66,6 @@ test('When there is undefined', t => {
 
   getRedactedValueStub.returns(undefined)
 
-  const nameInstance = {
-    name: 'name'
-  }
   const pageInstance = {}
 
   const displayValue = getDisplayValue(pageInstance, userData, nameInstance)
@@ -81,9 +79,6 @@ test('When the value is null', t => {
 
   getRedactedValueStub.returns(null)
 
-  const nameInstance = {
-    name: 'name'
-  }
   const pageInstance = {}
 
   const displayValue = getDisplayValue(pageInstance, userData, nameInstance)
@@ -98,9 +93,6 @@ test('When the value is a string', t => {
   {
     getRedactedValueStub.returns('')
 
-    const nameInstance = {
-      name: 'name'
-    }
     const pageInstance = {}
 
     const displayValue = getDisplayValue(pageInstance, userData, nameInstance)
@@ -110,9 +102,6 @@ test('When the value is a string', t => {
   {
     getRedactedValueStub.returns('string value')
 
-    const nameInstance = {
-      name: 'name'
-    }
     const pageInstance = {}
 
     const displayValue = getDisplayValue(pageInstance, userData, nameInstance)
@@ -128,9 +117,6 @@ test('When the value is a number', t => {
   { // zero
     getRedactedValueStub.returns(0)
 
-    const nameInstance = {
-      name: 'name'
-    }
     const pageInstance = {}
 
     const displayValue = getDisplayValue(pageInstance, userData, nameInstance)
@@ -140,9 +126,6 @@ test('When the value is a number', t => {
   { // greater than zero
     getRedactedValueStub.returns(1)
 
-    const nameInstance = {
-      name: 'name'
-    }
     const pageInstance = {}
 
     const displayValue = getDisplayValue(pageInstance, userData, nameInstance)
@@ -152,9 +135,6 @@ test('When the value is a number', t => {
   { // less than zero
     getRedactedValueStub.returns(-1)
 
-    const nameInstance = {
-      name: 'name'
-    }
     const pageInstance = {}
 
     const displayValue = getDisplayValue(pageInstance, userData, nameInstance)
@@ -170,9 +150,6 @@ test('When the value is a boolean', t => {
   {
     getRedactedValueStub.returns(false)
 
-    const nameInstance = {
-      name: 'name'
-    }
     const pageInstance = {}
 
     const displayValue = getDisplayValue(pageInstance, userData, nameInstance)
@@ -182,9 +159,6 @@ test('When the value is a boolean', t => {
   {
     getRedactedValueStub.returns(true)
 
-    const nameInstance = {
-      name: 'name'
-    }
     const pageInstance = {}
 
     const displayValue = getDisplayValue(pageInstance, userData, nameInstance)
@@ -215,9 +189,6 @@ test('When there is a displayValue method for the component type', t => {
     getDisplayValue: getDisplayValueStub
   })
 
-  const nameInstance = {
-    name: 'name'
-  }
   const pageInstance = {}
 
   const displayValue = getDisplayValue(pageInstance, userData, nameInstance)
@@ -254,6 +225,7 @@ const checkboxesInstance = {
 test('When the instance contains checkboxes that have been selected', t => {
   resetStubs()
   getUserDataInputPropertyStub.returns('yes')
+
   const nameInstance = checkboxesInstance
   const pageInstance = {}
 
@@ -272,6 +244,7 @@ test('When the instance contains checkboxes that have been selected', t => {
 test('When the instance contains checkboxes with non-yes values that have been selected', t => {
   resetStubs()
   getUserDataInputPropertyStub.returns('bazValue')
+
   const nameInstance = checkboxesInstance
   const pageInstance = {}
 
@@ -284,6 +257,7 @@ test('When the instance contains checkboxes with non-yes values that have been s
 test('When the instance contains checkboxes without _ids that have been selected', t => {
   resetStubs()
   getUserDataInputPropertyStub.returns('loofahValue')
+
   const nameInstance = checkboxesInstance
   const pageInstance = {}
 
@@ -326,6 +300,7 @@ const radiosInstance = {
 test('When the instance contains item (radios or selects) that has been selected', t => {
   resetStubs()
   getRedactedValueStub.returns('foo')
+
   const nameInstance = radiosInstance
   const pageInstance = {}
 
@@ -355,6 +330,7 @@ test('When the instance contains file uploads', t => {
     originalname: 'bar',
     size: '48'
   }])
+
   const nameInstance = uploadsInstance
   const pageInstance = {}
 
@@ -376,9 +352,7 @@ test('When the instance contains an answer that has an array as its answer', t =
     'a',
     'b'
   ])
-  const nameInstance = {
-    name: 'name'
-  }
+
   const pageInstance = {}
 
   const displayValue = getDisplayValue(pageInstance, userData, nameInstance)

--- a/lib/page/get-display-value/get-display-value.unit.spec.js
+++ b/lib/page/get-display-value/get-display-value.unit.spec.js
@@ -52,6 +52,7 @@ test('When there is a simple value', t => {
   }
 
   const displayValue = getDisplayValue(pageInstance, userData, nameInstance)
+
   t.equals(displayValue, 'display value', 'it should return that value')
   t.ok(getRedactedValueStub.calledOnce, 'it should call the getRedactedValue method once')
   t.deepEqual(getRedactedValueStub.getCall(0).args, [nameInstance, userData, pageInstance.skipRedact, 'input'], 'it should call the getRedactedValue method with the expected args')
@@ -59,8 +60,9 @@ test('When there is a simple value', t => {
   t.end()
 })
 
-test('When there is no value', t => {
+test('When there is undefined', t => {
   resetStubs()
+
   getRedactedValueStub.returns(undefined)
 
   const nameInstance = {
@@ -69,7 +71,125 @@ test('When there is no value', t => {
   const pageInstance = {}
 
   const displayValue = getDisplayValue(pageInstance, userData, nameInstance)
-  t.equals(displayValue, 'Not answered', 'it should return the expected value for unanswered')
+  t.equals(displayValue, 'Not answered', 'it should return \'Not answered\'')
+
+  t.end()
+})
+
+test('When the value is null', t => {
+  resetStubs()
+
+  getRedactedValueStub.returns(null)
+
+  const nameInstance = {
+    name: 'name'
+  }
+  const pageInstance = {}
+
+  const displayValue = getDisplayValue(pageInstance, userData, nameInstance)
+  t.equals(displayValue, 'Not answered', 'it should return \'Not answered\'')
+
+  t.end()
+})
+
+test('When the value is a string', t => {
+  resetStubs()
+
+  {
+    getRedactedValueStub.returns('')
+
+    const nameInstance = {
+      name: 'name'
+    }
+    const pageInstance = {}
+
+    const displayValue = getDisplayValue(pageInstance, userData, nameInstance)
+    t.equals(displayValue, 'Not answered', 'it should return \'Not answered\'')
+  }
+
+  {
+    getRedactedValueStub.returns('string value')
+
+    const nameInstance = {
+      name: 'name'
+    }
+    const pageInstance = {}
+
+    const displayValue = getDisplayValue(pageInstance, userData, nameInstance)
+    t.equals(displayValue, 'string value', 'it should return \'string value\'')
+  }
+
+  t.end()
+})
+
+test('When the value is a number', t => {
+  resetStubs()
+
+  { // zero
+    getRedactedValueStub.returns(0)
+
+    const nameInstance = {
+      name: 'name'
+    }
+    const pageInstance = {}
+
+    const displayValue = getDisplayValue(pageInstance, userData, nameInstance)
+    t.equals(displayValue, 0, 'it should return 0')
+  }
+
+  { // greater than zero
+    getRedactedValueStub.returns(1)
+
+    const nameInstance = {
+      name: 'name'
+    }
+    const pageInstance = {}
+
+    const displayValue = getDisplayValue(pageInstance, userData, nameInstance)
+    t.equals(displayValue, 1, 'it should return 1')
+  }
+
+  { // less than zero
+    getRedactedValueStub.returns(-1)
+
+    const nameInstance = {
+      name: 'name'
+    }
+    const pageInstance = {}
+
+    const displayValue = getDisplayValue(pageInstance, userData, nameInstance)
+    t.equals(displayValue, -1, 'it should return -1')
+  }
+
+  t.end()
+})
+
+test('When the value is a boolean', t => {
+  resetStubs()
+
+  {
+    getRedactedValueStub.returns(false)
+
+    const nameInstance = {
+      name: 'name'
+    }
+    const pageInstance = {}
+
+    const displayValue = getDisplayValue(pageInstance, userData, nameInstance)
+    t.equals(displayValue, false, 'it should return false')
+  }
+
+  {
+    getRedactedValueStub.returns(true)
+
+    const nameInstance = {
+      name: 'name'
+    }
+    const pageInstance = {}
+
+    const displayValue = getDisplayValue(pageInstance, userData, nameInstance)
+    t.equals(displayValue, true, 'it should return true')
+  }
 
   t.end()
 })
@@ -101,9 +221,9 @@ test('When there is a displayValue method for the component type', t => {
   const pageInstance = {}
 
   const displayValue = getDisplayValue(pageInstance, userData, nameInstance)
-  t.equals(displayValue, 'component display value', 'it should return the expected value for unanswered')
-  t.ok(getDisplayValueStub.calledOnce, 'it should call the component’s getDisplayValue method once')
-  t.deepEqual(getDisplayValueStub.getCall(0).args, [nameInstance, userData], 'it should call the component’s getDisplayValue method with the expected args')
+  t.equals(displayValue, 'component display value', 'it should return \'Not answered\'')
+  t.ok(getDisplayValueStub.calledOnce, 'it should call the component\'s getDisplayValue method once')
+  t.deepEqual(getDisplayValueStub.getCall(0).args, [nameInstance, userData], 'it should call the component\'s getDisplayValue method with the expected args')
 
   t.end()
 })
@@ -139,7 +259,7 @@ test('When the instance contains checkboxes that have been selected', t => {
 
   const displayValue = getDisplayValue(pageInstance, userData, nameInstance)
   t.equals(displayValue, 'foo\n\nbar', 'it should return the labels for the selected values')
-  t.ok(formatStub.calledOnce, 'it should call the component’s getDisplayValue method once')
+  t.ok(formatStub.calledOnce, 'it should call the component\'s getDisplayValue method once')
   t.deepEqual(formatStub.getCall(0).args, ['foo\n\nbar', {}, {
     substitution: true,
     multiline: true,
@@ -211,7 +331,7 @@ test('When the instance contains item (radios or selects) that has been selected
 
   const displayValue = getDisplayValue(pageInstance, userData, nameInstance)
   t.equals(displayValue, 'foo', 'it should return the labels for the selected value')
-  t.ok(formatStub.calledOnce, 'it should call the component’s getDisplayValue method once')
+  t.ok(formatStub.calledOnce, 'it should call the component\'s getDisplayValue method once')
   t.deepEqual(formatStub.getCall(0).args, ['foo', {}, {
     substitution: true,
     multiline: false,
@@ -240,7 +360,7 @@ test('When the instance contains file uploads', t => {
 
   const displayValue = getDisplayValue(pageInstance, userData, nameInstance)
   t.equals(displayValue, 'foo (23 kb)\n\nbar (48 kb)', 'it should return all the file upload names and sizes')
-  t.ok(formatStub.calledOnce, 'it should call the component’s getDisplayValue method once')
+  t.ok(formatStub.calledOnce, 'it should call the component\'s getDisplayValue method once')
   t.deepEqual(formatStub.getCall(0).args, ['foo (23 kb)\n\nbar (48 kb)', {}, {
     substitution: undefined,
     multiline: true,
@@ -263,7 +383,7 @@ test('When the instance contains an answer that has an array as its answer', t =
 
   const displayValue = getDisplayValue(pageInstance, userData, nameInstance)
   t.equals(displayValue, 'a\n\nb', 'it should concatentate all the answer items')
-  t.ok(formatStub.calledOnce, 'it should call the component’s getDisplayValue method once')
+  t.ok(formatStub.calledOnce, 'it should call the component\'s getDisplayValue method once')
   t.deepEqual(formatStub.getCall(0).args, ['a\n\nb', {}, {
     substitution: undefined,
     multiline: false,

--- a/lib/page/update-control-names/update-control-names.js
+++ b/lib/page/update-control-names/update-control-names.js
@@ -97,14 +97,14 @@ const updateControlNames = (pageInstance, userData) => {
           nameInstance.checked = true
         }
       } else {
-      /*
-       *  See also:
-       *
-       *    lib/page/get-display-value/get-display-value.js
-       *
-       *   Any primitive (except undefined or null) is acceptable
-       *   but for Nunjucks it must be transformed to a string
-       */
+        /*
+         *  See also:
+         *
+         *    lib/page/get-display-value/get-display-value.js
+         *
+         *   Any primitive (except undefined or null) is acceptable
+         *   but for Nunjucks it must be transformed to a string
+         */
         const value = getRedactedValue(nameInstance, userData, pageInstance.skipRedact)
 
         if (value !== undefined && value !== null) {

--- a/lib/page/update-control-names/update-control-names.js
+++ b/lib/page/update-control-names/update-control-names.js
@@ -78,26 +78,38 @@ const updateControlNames = (pageInstance, userData) => {
       return
     }
 
-    const composite = getComponentComposite(nameInstance)
-    if (composite) {
-      // do nothing
-    } else if (nameInstance.items) {
-      const propValue = getUserDataProperty(nameInstance.name)
-      nameInstance.items.forEach(item => {
-        const value = item.value || item.text
-        if (value === propValue) {
-          const chosen = item._type === 'option' ? 'selected' : 'checked'
-          item[chosen] = true
+    if (!getComponentComposite(nameInstance)) {
+      /**
+       * Not! component composite
+       */
+      if (nameInstance.items) {
+        const propValue = getUserDataProperty(nameInstance.name)
+
+        nameInstance.items.forEach(item => {
+          const value = item.value || item.text
+          if (value === propValue) {
+            const chosen = item._type === 'option' ? 'selected' : 'checked'
+            item[chosen] = true
+          }
+        })
+      } else if (nameInstance.value) {
+        if (nameInstance.value === getUserDataProperty(nameInstance.name)) {
+          nameInstance.checked = true
         }
-      })
-    } else if (nameInstance.value) {
-      if (nameInstance.value === getUserDataProperty(nameInstance.name)) {
-        nameInstance.checked = true
-      }
-    } else {
-      const value = getRedactedValue(nameInstance, userData, pageInstance.skipRedact)
-      if (typeof value !== 'undefined') {
-        nameInstance.value = value
+      } else {
+      /*
+       *  See also:
+       *
+       *    lib/page/get-display-value/get-display-value.js
+       *
+       *   Any primitive (except undefined or null) is acceptable
+       *   but for Nunjucks it must be transformed to a string
+       */
+        const value = getRedactedValue(nameInstance, userData, pageInstance.skipRedact)
+
+        if (value !== undefined && value !== null) {
+          nameInstance.value = String(value)
+        }
       }
     }
   })


### PR DESCRIPTION
[FB-680](https://dsdmoj.atlassian.net/browse/FB-680)

- A truthiness test of an answer would be incorrect for number primitives if the value was zero
- I've expanded the test to `undefined`, `null`, and zero-length strings before deciding whether the question has been answered (numbers and booleans will always transform to a non-zero-length string)
- Similarly, the value was retrieved on `GET` if the page reloads (or the user navigates back) as a number and Nunjucks made zero disappear. I have transformed to a string for all not `undefined` and not `null` values