### PR TITLE
Remove the deprecated pdf_data field from submission payload

### DIFF
--- a/lib/controller/page/type/page.summary/page.summary.controller.js
+++ b/lib/controller/page/type/page.summary/page.summary.controller.js
@@ -105,8 +105,6 @@ SummaryController.attachEmailSubmissions = async (submissionId, userData, submis
   toTeamParts = [...new Set(toTeamParts)]
 
   // const timestamp = new Date().getTime()
-  const pdfData = SummaryController.generatePDFPayload(userData, submissionId, 'team')
-
   const emailBody = composeEmailBody(userData.getUserData(), userData.contentLang, emailTypes.TEAM)
   const teamSubmission = generateEmail('team', from, subject, submissionId, true, emailBody)
 
@@ -130,7 +128,6 @@ SummaryController.attachEmailSubmissions = async (submissionId, userData, submis
       const userSubject = getInstanceProperty('service', 'emailSubjectUser') || `Your ${serviceName} submission`
       const subject = formatEmail(userSubject)
       const includePdf = getInstanceProperty('service', 'attachUserSubmission') || false
-      const pdfData = SummaryController.generatePDFPayload(userData, submissionId, 'user')
       const emailBody = composeEmailBody(userData.getUserData(), userData.contentLang, emailTypes.USER)
       const userSubmission = generateEmail('user', from, subject, submissionId, includePdf, emailBody)
 

--- a/lib/controller/page/type/page.summary/page.summary.controller.js
+++ b/lib/controller/page/type/page.summary/page.summary.controller.js
@@ -108,7 +108,7 @@ SummaryController.attachEmailSubmissions = async (submissionId, userData, submis
   const pdfData = SummaryController.generatePDFPayload(userData, submissionId, 'team')
 
   const emailBody = composeEmailBody(userData.getUserData(), userData.contentLang, emailTypes.TEAM)
-  const teamSubmission = generateEmail('team', from, subject, submissionId, true, pdfData, emailBody)
+  const teamSubmission = generateEmail('team', from, subject, submissionId, true, emailBody)
 
   const uploadedFiles = userData.uploadedFiles()
   uploadedFiles.forEach(upload => {
@@ -132,7 +132,7 @@ SummaryController.attachEmailSubmissions = async (submissionId, userData, submis
       const includePdf = getInstanceProperty('service', 'attachUserSubmission') || false
       const pdfData = SummaryController.generatePDFPayload(userData, submissionId, 'user')
       const emailBody = composeEmailBody(userData.getUserData(), userData.contentLang, emailTypes.USER)
-      const userSubmission = generateEmail('user', from, subject, submissionId, includePdf, pdfData, emailBody)
+      const userSubmission = generateEmail('user', from, subject, submissionId, includePdf, emailBody)
 
       const toUserParts = userEmail.split(/,\s*/)
       toUserParts.forEach(to => {
@@ -189,12 +189,8 @@ SummaryController.postValidation = async (pageInstance, userData) => {
     const formData = SummaryController.generatePDFPayload(userData, submissionId)
 
     const submission = {
-      formData: formData, // deprecated
       submission: formData,
-
-      submission_details: submissions, // deprecated
       actions: submissions,
-
       attachments: userData.uploadedFiles()
     }
 

--- a/lib/controller/page/type/page.summary/page.summary.controller.unit.spec.js
+++ b/lib/controller/page/type/page.summary/page.summary.controller.unit.spec.js
@@ -334,56 +334,6 @@ test('it does not attach json to submission when env var not present', async t =
   t.end()
 })
 
-test('TEAM PDF: it attaches PDF contents to email submission attachments', async t => {
-  getInstancePropertyStub.withArgs('service', 'emailTemplateTeam').returns('{firstname} submitted!')
-
-  const pageSummaryController = proxyquire('./page.summary.controller', {
-    '../../../../presenter/pdf-payload': {pdfPayload: pdfPayloadStub},
-    '../../../../middleware/routes-output/submission-data-with-labels': {submissionDataWithLabels: submissionDataWithLabelsStub},
-    '../../../../page/check-submits/check-submits': {checkSubmits: checkSubmitsStub},
-    '../../../../constants/constants': {
-      SERVICE_OUTPUT_EMAIL: 'bob@gov.uk'
-    }
-  })
-
-  const userdata = getUserDataMethods({input: {firstname: 'bob'}})
-
-  await pageSummaryController.postValidation({}, userdata)
-
-  const submissions = submitterClientSpy.getCall(0).args[0].actions
-  const emailEntries = submissions.filter(s => s.type === 'email')
-
-  t.equals(emailEntries[0].email_body, 'bob submitted!')
-
-  const pdfData = emailEntries[0].attachments[0].pdf_data
-  t.deepEquals(pdfData, {some: 'PDF contents'})
-
-  submitterClientSpy.resetHistory()
-  t.end()
-})
-
-test('USER PDF: it attaches PDF contents to email submission attachments', async t => {
-  const pageSummaryController = proxyquire('./page.summary.controller', {
-    '../../../../presenter/pdf-payload': {pdfPayload: pdfPayloadStub},
-    '../../../../middleware/routes-output/submission-data-with-labels': {submissionDataWithLabels: submissionDataWithLabelsStub},
-    '../../../../page/check-submits/check-submits': {checkSubmits: checkSubmitsStub},
-    '../../../../constants/constants': {
-      SERVICE_OUTPUT_EMAIL: 'bob@gov.uk'
-    }
-  })
-
-  const userdata = getUserDataMethods({})
-  await pageSummaryController.postValidation({}, userdata)
-
-  const submissions = submitterClientSpy.getCall(0).args[0].actions
-  const emailEntries = submissions.filter(s => s.type === 'email')
-  const pdfData = emailEntries[0].attachments[0].pdf_data
-
-  t.deepEquals(pdfData, {some: 'PDF contents'})
-  submitterClientSpy.resetHistory()
-  t.end()
-})
-
 test('Dynamic content is rendered in the Team email body', async t => {
   submitterClientSpy.resetHistory()
 

--- a/lib/submission/submitter-payload.js
+++ b/lib/submission/submitter-payload.js
@@ -1,7 +1,7 @@
 const {getInstanceProperty} = require('../service-data/service-data')
 const {format} = require('../format/format')
 
-const generateEmail = (recipientType, from, subject, submissionId, includePdf = true, pdfData = {}, emailBody) => {
+const generateEmail = (recipientType, from, subject, submissionId, includePdf = true, emailBody) => {
   const email = {
     recipientType: recipientType,
     type: 'email',
@@ -17,8 +17,7 @@ const generateEmail = (recipientType, from, subject, submissionId, includePdf = 
     email.attachments.push({
       filename: `${submissionId}.pdf`,
       mimetype: 'application/pdf',
-      type: 'output',
-      pdf_data: pdfData
+      type: 'output'
     })
   }
 

--- a/lib/submission/submitter-payload.unit.spec.js
+++ b/lib/submission/submitter-payload.unit.spec.js
@@ -7,7 +7,6 @@ const from = 'bob@example.com'
 const subject = 'some subject'
 const submissionId = 'abc123'
 const emailBody = 'a email body'
-const pdfData = {some_test_queston: 'some_test_answer'}
 
 test('Generating a user submission email with a PDF', async t => {
   const includePdf = true

--- a/lib/submission/submitter-payload.unit.spec.js
+++ b/lib/submission/submitter-payload.unit.spec.js
@@ -11,7 +11,7 @@ const pdfData = {some_test_queston: 'some_test_answer'}
 
 test('Generating a user submission email with a PDF', async t => {
   const includePdf = true
-  const result = generateEmail('user', from, subject, submissionId, includePdf, pdfData, emailBody)
+  const result = generateEmail('user', from, subject, submissionId, includePdf, emailBody)
 
   const expectedResult = {
     recipientType: 'user',
@@ -24,8 +24,7 @@ test('Generating a user submission email with a PDF', async t => {
     attachments: [{
       filename: 'abc123.pdf',
       mimetype: 'application/pdf',
-      type: 'output',
-      pdf_data: pdfData
+      type: 'output'
     }]
   }
 
@@ -35,29 +34,22 @@ test('Generating a user submission email with a PDF', async t => {
 
 test('Generating a user submission email without a PDF', async t => {
   const includePdf = false
-  const result = generateEmail('user', from, subject, submissionId, includePdf, pdfData, emailBody)
+  const result = generateEmail('user', from, subject, submissionId, includePdf, emailBody)
 
   t.deepEquals(result.attachments, [], 'it should have empty attachments')
   t.end()
 })
 
 test('Attachments are included for a team submission', async t => {
-  const result = generateEmail('team', from, subject, submissionId, false, pdfData, emailBody)
+  const result = generateEmail('team', from, subject, submissionId, false, emailBody)
 
   t.deepEquals(result.include_attachments, true, 'it add attachments for a team email')
   t.end()
 })
 
 test('Attachments are not included for a user submission', async t => {
-  const result = generateEmail('user', from, subject, submissionId, false, pdfData, emailBody)
+  const result = generateEmail('user', from, subject, submissionId, false, emailBody)
 
   t.deepEquals(result.include_attachments, false, 'it should not include attachments for user emails')
-  t.end()
-})
-
-test('Adding PDF data', async t => {
-  const result = generateEmail('user', from, subject, submissionId, true, pdfData, emailBody)
-
-  t.deepEquals(result.attachments[0].pdf_data, pdfData, 'it should attach the PDF Data')
   t.end()
 })


### PR DESCRIPTION
We no longer use the `pdf_data` field in the Submission payload. It was included in the `actions` array.

Instead now we rely on the `sections` field under `submission`.

This PR removes these deprecated fields. 