### PR TITLE
Remove user token backdoor

### DIFF
--- a/lib/middleware/user-session/user-session.js
+++ b/lib/middleware/user-session/user-session.js
@@ -4,7 +4,6 @@ const cookieParser = require('cookie-parser')
 
 const aes256 = require('aes256')
 
-const submitterClient = require('../../client/submitter/submitter')
 const user = require('../../user/user')
 const {getInstanceProperty} = require('../../service-data/service-data')
 const {getUrl} = require('../../route/route')
@@ -91,24 +90,6 @@ const init = (options = {}) => {
   router.use(cookieParser())
 
   router.use((req, res, next) => {
-    const userIdAndToken = req.get('x-encrypted-user-id-and-token')
-    if (userIdAndToken) {
-      if (req.method !== 'GET') {
-        throw new Error(403)
-      }
-
-      const userDetails = submitterClient.decryptUserIdAndToken(userIdAndToken)
-      if (!userDetails.userId) {
-        throw new Error(403)
-      }
-      const {userId, userToken} = userDetails
-      req.session = {}
-      addUserIdTokenMethods(req, userId, userToken)
-
-      next()
-      return
-    }
-
     let encryptedSessionId = req.cookies[sessionName]
     if (!encryptedSessionId) {
       //  Brand new session


### PR DESCRIPTION
Remove special header that can be given to assume a users session.
This had to be a valid header so isn't dangerous but is unnecessary

This is outside of the actual session auth mechanism so is safe to remove.

E2E passes on this branch. (save and return and user uploads will need to be manually tested)

