### PR TITLE
FB-786

### DIFF
--- a/lib/constants/constants.js
+++ b/lib/constants/constants.js
@@ -1,13 +1,16 @@
-const {FBError} = require('@ministryofjustice/fb-utils-node')
+require('@ministryofjustice/module-alias/register-module')(module)
+
 const fs = require('fs')
 
-class FBConstantsError extends FBError {}
+const CommonError = require('~/fb-runner-node/error')
 
 const getEnv = require('./get-env')
 const processEnv = getEnv()
 
 const path = require('path')
 const runnerDir = path.resolve(__dirname, '..', '..')
+
+class ConstantsError extends CommonError {}
 
 const {
   APP_SHA,
@@ -29,25 +32,25 @@ const {
 // Ensure that both service token and datastore url are both set or unset
 if (SERVICE_TOKEN || USER_DATASTORE_URL) {
   if (!SERVICE_TOKEN) {
-    throw new FBConstantsError({
+    throw new ConstantsError({
       code: 'ENOSERVICETOKEN',
       message: 'No service token provided though user datastore url was set'
     })
   }
   if (!USER_DATASTORE_URL) {
-    throw new FBConstantsError({
+    throw new ConstantsError({
       code: 'ENOUSERDATASTOREURL',
       message: 'No user datastore url provided though service token was set'
     })
   }
   if (!SERVICE_SLUG) {
-    throw new FBConstantsError({
+    throw new ConstantsError({
       code: 'ENOSERVICESLUG',
       message: 'No service slug provided though service token and user datastore url were set'
     })
   }
   if (!SERVICE_SECRET) {
-    throw new FBConstantsError({
+    throw new ConstantsError({
       code: 'ENOSERVICESECRET',
       message: 'No service secret provided though service token and user datastore url were set'
     })
@@ -56,19 +59,19 @@ if (SERVICE_TOKEN || USER_DATASTORE_URL) {
 
 if (SUBMITTER_URL) {
   if (!SERVICE_TOKEN) {
-    throw new FBConstantsError({
+    throw new ConstantsError({
       code: 'ENOSERVICETOKEN',
       message: 'No service token provided though submitter url was set'
     })
   }
   if (!SUBMITTER_URL) {
-    throw new FBConstantsError({
+    throw new ConstantsError({
       code: 'ENOSUBMITTERURL',
       message: 'No submitter url provided though service token was set'
     })
   }
   if (!SERVICE_SLUG) {
-    throw new FBConstantsError({
+    throw new ConstantsError({
       code: 'ENOSERVICESLUG',
       message: 'No service slug provided though service token and submitter url were set'
     })

--- a/lib/error/index.js
+++ b/lib/error/index.js
@@ -1,0 +1,62 @@
+/**
+ * @module CommonError
+ **/
+
+module.exports = class CommonError extends Error {
+  /**
+   * CommonError constructor
+   *
+   * @param {string} message
+   * Error message
+   *
+   * If not passed, will use any value found in options.error.message
+   *
+   * @param {{error: object, data: any}} options
+   * Error options
+   *
+   * @param {object} options.error
+   * Error object or plain object representing an error
+   *
+   * @param {any} options.data
+   * Additional data to attach to the returned error
+   *
+   * @return {CommonError}
+   **/
+  constructor (message, options = {}) {
+    if (typeof message === 'object') {
+      options = message
+      message = undefined
+    }
+
+    const {
+      error,
+      data
+    } = options
+
+    super(error)
+
+    const {
+      constructor,
+      constructor: {
+        name = 'CommonError'
+      }
+    } = this
+
+    if (Error.captureStackTrace) Error.captureStackTrace(this, constructor.bind(this))
+
+    this.name = name
+    this.message = message || options.message
+
+    if (error) {
+      Object
+        .entries(error)
+        .forEach(([key, value]) => {
+          this[key] = value
+        })
+    }
+
+    if (data) {
+      this.data = data
+    }
+  }
+}

--- a/lib/middleware/csrf/csrf.js
+++ b/lib/middleware/csrf/csrf.js
@@ -1,5 +1,8 @@
-const {FBError} = require('@ministryofjustice/fb-utils-node')
+require('@ministryofjustice/module-alias/register-module')(module)
+
 const csrfToken = require('csrf-token')
+
+const CommonError = require('~/fb-runner-node/error')
 
 const getTokenSecret = (userId, token) => {
   // hash this?
@@ -30,7 +33,7 @@ const init = (baseToken) => {
      *
      * @return {undefined}
      *
-     * @throws {FBError}
+     * @throws {CommonError}
      * If validation fails, thows a 403 with an explanatory code
      */
     validateCsrf = async (csrfToken, userId) => {
@@ -48,7 +51,7 @@ const init = (baseToken) => {
         }
       }
       if (disallowed) {
-        throw new FBError({
+        throw new CommonError({
           error: {
             code: disallowed,
             message: 403

--- a/lib/middleware/csrf/csrf.unit.spec.js
+++ b/lib/middleware/csrf/csrf.unit.spec.js
@@ -104,7 +104,7 @@ test('When a post request originates from an external domain and an invalid csrf
   try {
     t.throws(await callMiddleware(req))
   } catch (e) {
-    t.equal(e.name, 'FBError', 'it should return the right type of error')
+    t.equal(e.name, 'CommonError', 'it should return the right type of error')
     t.equal(e.message, 403, 'it should return the right error message')
     t.equal(e.code, 'ECSRFTOKENINVALID', 'it should return the right error code')
   }
@@ -122,7 +122,7 @@ test('When a post request originates from an external domain and no csrf token i
   try {
     t.throws(await callMiddleware(req))
   } catch (e) {
-    t.equal(e.name, 'FBError', 'it should return the right type of error')
+    t.equal(e.name, 'CommonError', 'it should return the right type of error')
     t.equal(e.message, 403, 'it should return the right error message')
     t.equal(e.code, 'ECSRFTOKENMISSING', 'it should return the right error code')
   }

--- a/lib/middleware/referrer/referrer.js
+++ b/lib/middleware/referrer/referrer.js
@@ -1,7 +1,9 @@
+require('@ministryofjustice/module-alias/register-module')(module)
+
+const CommonError = require('~/fb-runner-node/error')
 
 // Short-circuit posts with incorrect referrer
 // but let internal traffic through
-const {FBError} = require('@ministryofjustice/fb-utils-node')
 const init = (fqd) => {
   return (req, res, next) => {
     if (!req.get('x-forwarded-host') || !fqd) {
@@ -19,7 +21,7 @@ const init = (fqd) => {
         }
       }
       if (disallowed) {
-        throw new FBError({
+        throw new CommonError({
           error: {
             code: disallowed,
             message: 403

--- a/lib/middleware/referrer/referrer.unit.spec.js
+++ b/lib/middleware/referrer/referrer.unit.spec.js
@@ -53,7 +53,7 @@ test('When the fully qualified domain is set and a post is made without a referr
       t.notOk(true, 'it should throw an error')
     })
     .catch(e => {
-      t.equal(e.name, 'FBError', 'it should return the right type of error')
+      t.equal(e.name, 'CommonError', 'it should return the right type of error')
       t.equal(e.message, 403, 'it should return the right error message')
       t.equal(e.code, 'ENOREFERRER', 'it should return the right error code')
     })
@@ -76,7 +76,7 @@ test('When the fully qualified domain is set and a post is made from an external
       t.notOk(true, 'it should throw an error')
     })
     .catch(e => {
-      t.equal(e.name, 'FBError', 'it should return the right type of error')
+      t.equal(e.name, 'CommonError', 'it should return the right type of error')
       t.equal(e.message, 403, 'it should return the right error message')
       t.equal(e.code, 'EINVALIDREFERRER', 'it should return the right error code')
     })

--- a/lib/module/savereturn/controller/client/fb-save-return-client.js
+++ b/lib/module/savereturn/controller/client/fb-save-return-client.js
@@ -1,5 +1,5 @@
 const FBJWTClient = require('@ministryofjustice/fb-client/lib/user/jwt/client')
-class FBSaveReturnClientError extends FBJWTClient.prototype.ErrorClass {}
+class SaveReturnClientError extends FBJWTClient.prototype.ErrorClass {}
 
 /**
  * Creates save return client
@@ -25,7 +25,7 @@ class FBSaveReturnClient extends FBJWTClient {
    *
    **/
   constructor (serviceSecret, serviceToken, serviceSlug, saveReturnUrl) {
-    super(serviceSecret, serviceToken, serviceSlug, saveReturnUrl, FBSaveReturnClientError)
+    super(serviceSecret, serviceToken, serviceSlug, saveReturnUrl, SaveReturnClientError)
   }
 
   /**

--- a/lib/module/savereturn/controller/client/fb-save-return-client.unit.spec.js
+++ b/lib/module/savereturn/controller/client/fb-save-return-client.unit.spec.js
@@ -43,7 +43,7 @@ const testInstantiation = (t, params, expectedCode, expectedMessage) => {
   try {
     t.throws(failedClient = new FBUserDataStoreClient(...params))
   } catch (e) {
-    t.equal(e.name, 'FBSaveReturnClientError', 'it should return an error of the correct type')
+    t.equal(e.name, 'SaveReturnClientError', 'it should return an error of the correct type')
     t.equal(e.code, expectedCode, 'it should return the correct error code')
     t.equal(e.message, expectedMessage, 'it should return the correct error message')
   }
@@ -91,7 +91,7 @@ const resetStubs = () => {
 
 // Error class
 test('When throwing errors', t => {
-  t.equal(saveReturnClient.ErrorClass.name, 'FBSaveReturnClientError', 'it should use the client\'s error class')
+  t.equal(saveReturnClient.ErrorClass.name, 'SaveReturnClientError', 'it should use the client\'s error class')
 
   t.end()
 })

--- a/lib/page/process-input/process-control-standard.js
+++ b/lib/page/process-input/process-control-standard.js
@@ -3,8 +3,9 @@ require('@ministryofjustice/module-alias/register-module')(module)
 const {PLATFORM_ENV} = require('~/fb-runner-node/constants/constants')
 const {getServiceSchema} = require('~/fb-runner-node/service-data/service-data')
 
-const {FBError} = require('@ministryofjustice/fb-utils-node')
-class FBProcessInputError extends FBError {}
+const CommonError = require('~/fb-runner-node/error')
+
+class InputError extends CommonError {}
 
 module.exports = function processControlStandard (pageInstance, userData, nameInstance, options) {
   const {controlName} = options
@@ -24,7 +25,7 @@ module.exports = function processControlStandard (pageInstance, userData, nameIn
         lede: 'The form will not work correctly unless you fix this problem'
       }
     }
-    throw new FBProcessInputError(`Input name ${controlName} is not unique`, {
+    throw new InputError(`Input name ${controlName} is not unique`, {
       error: {
         code: 'EDUPLICATEINPUTNAME',
         renderError

--- a/lib/page/process-input/process-control-standard.unit.spec.js
+++ b/lib/page/process-input/process-control-standard.unit.spec.js
@@ -136,9 +136,9 @@ test('When processing a control for which the value provided is an array', t => 
   } catch (e) {
     t.ok(errorLoggerStub.calledOnce, 'it should log the error')
     t.deepEqual(errorLoggerStub.args[0], [{name: 'foo'}, 'Input name is not unique for the request'], 'it should call the logger emthod with the expected args')
-    t.equal(e.name, 'FBProcessInputError', 'it should throw a FBProcessInputError')
+    t.equal(e.name, 'InputError', 'it should throw an InputError')
     t.equal(e.code, 'EDUPLICATEINPUTNAME', 'it should add the expected code')
-    t.equal(e.message, 'Input name foo is not unique', 'it should throw a FBProcessInputError')
+    t.equal(e.message, 'Input name foo is not unique', 'it should throw an InputError')
     t.deepEqual(e.renderError, {
       heading: 'Input name foo is not unique',
       lede: 'The form will not work correctly unless you fix this problem'

--- a/lib/page/process-uploads/multer/lib/make-middleware.js
+++ b/lib/page/process-uploads/multer/lib/make-middleware.js
@@ -29,7 +29,7 @@ function makeMiddleware (setup) {
     var preservePath = options.preservePath
 
     req.body = Object.create(null)
-    // FB addition - add bodyErrors prop to req and addFilesError method
+    //  addition - add bodyErrors prop to req and addFilesError method
     req.bodyErrors = Object.create(null)
     const addFilesError = (fieldname, err, file) => {
       req.bodyErrors.files = req.bodyErrors.files || Object.create(null)

--- a/lib/server/sources/configure/sources-configure-dependencies.js
+++ b/lib/server/sources/configure/sources-configure-dependencies.js
@@ -1,8 +1,13 @@
+require('@ministryofjustice/module-alias/register-module')(module)
+
 const path = require('path')
 const loadJson = require('load-json-file').sync
 
-const {FBLogger, FBError} = require('@ministryofjustice/fb-utils-node')
-class FBDependencyError extends FBError {}
+const {FBLogger} = require('@ministryofjustice/fb-utils-node')
+
+const CommonError = require('~/fb-runner-node/error')
+
+class DependencyError extends CommonError {}
 
 const configureDependencies = (servicePackagePath, serviceNodeModulesPath) => {
   const servicePackage = loadJson(servicePackagePath)
@@ -16,7 +21,7 @@ const configureDependencies = (servicePackagePath, serviceNodeModulesPath) => {
     deps.forEach(dep => {
       const depVersion = dependencies[dep]
       if (versionCheck[dep] && versionCheck[dep] !== depVersion) {
-        throw new FBDependencyError(`Different versions of ${dep} found: ${depVersion} / ${versionCheck[dep]}`)
+        throw new DependencyError(`Different versions of ${dep} found: ${depVersion} / ${versionCheck[dep]}`)
       }
       versionCheck[dep] = depVersion
       const depPackagePath = path.join(serviceNodeModulesPath, dep, 'package.json')

--- a/lib/server/sources/configure/sources-configure-dependencies.unit.spec.js
+++ b/lib/server/sources/configure/sources-configure-dependencies.unit.spec.js
@@ -169,7 +169,7 @@ test('When determining the sources for a form containing a dependency specified 
   try {
     t.throws(configureDependencies('service_package_path', 'service_node_modules_path'))
   } catch (e) {
-    t.equal(e.name, 'FBDependencyError', 'it should throw an error of the correct type')
+    t.equal(e.name, 'DependencyError', 'it should throw an error of the correct type')
     t.equal(e.message, 'Different versions of nested_components_a found: other_version / version', 'it should report the correct error message')
   }
 

--- a/lib/server/sources/sources-configure.js
+++ b/lib/server/sources/sources-configure.js
@@ -1,8 +1,11 @@
+require('@ministryofjustice/module-alias/register-module')(module)
+
 const path = require('path')
 const configureModules = require('./configure/sources-configure-modules')
-const {FBError} = require('@ministryofjustice/fb-utils-node')
 
-class FBServerError extends FBError {}
+const CommonError = require('~/fb-runner-node/error')
+
+class ServerError extends CommonError {}
 
 const configureSources = async (options = {}) => {
   const {
@@ -12,7 +15,7 @@ const configureSources = async (options = {}) => {
   } = options
 
   if (!SERVICE_PATH) {
-    throw new FBServerError({
+    throw new ServerError({
       code: 'ENOSERVICEPATH',
       message: 'No SERVICE_PATH was provided'
     })

--- a/lib/server/sources/sources-configure.unit.spec.js
+++ b/lib/server/sources/sources-configure.unit.spec.js
@@ -42,7 +42,7 @@ test('When configuring sources and no SERVICE_PATH is provided', async t => {
   try {
     t.throws(await configureSources())
   } catch (e) {
-    t.equal(e.name, 'FBServerError', 'it should throw an error of the correct type')
+    t.equal(e.name, 'ServerError', 'it should throw an error of the correct type')
     t.equal(e.message, 'No SERVICE_PATH was provided', 'it should report the correct error message')
   }
 

--- a/lib/service-data/runtime/inject-repeatable-pages.js
+++ b/lib/service-data/runtime/inject-repeatable-pages.js
@@ -2,11 +2,11 @@
  * @module injectRepeatablePages
  **/
 
-const jp = require('jsonpath')
+const jsonPath = require('jsonpath')
 const {deepClone} = require('@ministryofjustice/fb-utils-node')
 
 const addRepeatablePages = (instances) => {
-  const repeatablePages = jp.query(instances, '$..[?(@.repeatable && @._type.startsWith("page."))]')
+  const repeatablePages = jsonPath.query(instances, '$..[?(@.repeatable && @._type.startsWith("page."))]')
   repeatablePages.forEach(repeatablePage => {
     const stepId = repeatablePage._id
 
@@ -15,7 +15,7 @@ const addRepeatablePages = (instances) => {
       stepInstance.heading += ` {param@${stepInstance.namespace}}`
     }
 
-    jp.apply(instances, `$..[?(@.steps && @.steps.includes("${stepId}"))]`, (value) => {
+    jsonPath.apply(instances, `$..[?(@.steps && @.steps.includes("${stepId}"))]`, (value) => {
       const repeatableSummaryId = `${repeatablePage._id}.summary`
       let repeatableSummaryUrl = repeatablePage.url || `/${repeatablePage._id}`
       repeatableSummaryUrl = repeatableSummaryUrl.replace(/\/:[^/]+/, '')

--- a/lib/service-data/runtime/load-json.js
+++ b/lib/service-data/runtime/load-json.js
@@ -1,16 +1,15 @@
 /**
  * @module loadJSON
  **/
+require('@ministryofjustice/module-alias/register-module')(module)
 
 const fs = require('fs')
 const glob = require('glob-promise')
 const loadJsonFile = require('load-json-file')
 
-const {
-  FBError
-} = require('@ministryofjustice/fb-utils-node')
+const CommonError = require('~/fb-runner-node/error')
 
-class JSONLoadError extends FBError {}
+class LoadJSONError extends CommonError {}
 
 /**
  * Convenience promise rejector for wrong type
@@ -20,11 +19,11 @@ class JSONLoadError extends FBError {}
  * @param {string} type
  * Incorrect type passed
  *
- * @return {Promise.<JSONLoadError>}
- * Promised JSONLoadError
+ * @return {Promise.<LoadJSONError>}
+ * Promised LoadJSONError
  **/
 const rejectWrongType = type => {
-  return Promise.reject(new JSONLoadError(`${type} passed instead of an object`, {
+  return Promise.reject(new LoadJSONError(`${type} passed instead of an object`, {
     error: {
       code: 'EWRONGTYPE'
     }
@@ -53,14 +52,14 @@ const getJsonSrc = sourceObj => {
     return rejectWrongType(typeof sourceObj)
   }
   if (!sourceObj.source) {
-    return Promise.reject(new JSONLoadError('No source specified', {
+    return Promise.reject(new LoadJSONError('No source specified', {
       error: {
         code: 'ENOSOURCE'
       }
     }))
   }
   if (!sourceObj.path) {
-    return Promise.reject(new JSONLoadError('No path specified', {
+    return Promise.reject(new LoadJSONError('No path specified', {
       error: {
         code: 'ENOPATH'
       }
@@ -69,7 +68,7 @@ const getJsonSrc = sourceObj => {
   let jsonPaths = []
   const pathExists = fs.existsSync(sourceObj.path)
   if (!pathExists) {
-    return Promise.reject(new JSONLoadError(`${sourceObj.path} does not exist`, {
+    return Promise.reject(new LoadJSONError(`${sourceObj.path} does not exist`, {
       error: {
         code: 'EPATHDOESNOTEXIST'
       }
@@ -109,7 +108,7 @@ const load = sourceObjs => {
   const sources = sourceObjs.map(sourceObj => sourceObj ? sourceObj.source : sourceObj)
   const uniqueSources = sources.filter((elem, pos, arr) => arr.indexOf(elem) === pos)
   if (sources.length !== uniqueSources.length) {
-    return Promise.reject(new JSONLoadError('Sources should be unique', {
+    return Promise.reject(new LoadJSONError('Sources should be unique', {
       error: {
         code: 'EDUPLICATESOURCES'
       },
@@ -119,8 +118,7 @@ const load = sourceObjs => {
     }))
   }
 
-  const srcPromises = sourceObjs.map(sourceObj => getJsonSrc(sourceObj))
-  return Promise.all(srcPromises)
+  return Promise.all(sourceObjs.map(sourceObj => getJsonSrc(sourceObj)))
 }
 module.exports = {
   load

--- a/lib/service-data/runtime/load-json.unit.spec.js
+++ b/lib/service-data/runtime/load-json.unit.spec.js
@@ -74,7 +74,7 @@ test('When no source property is passed', function (t) {
       path: path1
     }])
     .catch(e => {
-      t.equals(e.name, 'JSONLoadError', 'it should throw an JSONLoadError object')
+      t.equals(e.name, 'LoadJSONError', 'it should throw an LoadJSONError object')
       t.equals(e.code, 'ENOSOURCE', 'it should return the ENOSOURCE code')
       t.equals(e.message, 'No source specified', 'it should return the correct message')
     })
@@ -88,7 +88,7 @@ test('When no path property is passed', function (t) {
       source: 'source1'
     }])
     .catch(e => {
-      t.equals(e.name, 'JSONLoadError', 'it should throw an JSONLoadError object')
+      t.equals(e.name, 'LoadJSONError', 'it should throw an LoadJSONError object')
       t.equals(e.code, 'ENOPATH', 'it should return the ENOPATH code')
       t.equals(e.message, 'No path specified', 'it should return the correct message')
     })
@@ -100,7 +100,7 @@ test('When null is passed instead of a source object', function (t) {
   jsonLoader
     .load([null])
     .catch(e => {
-      t.equals(e.name, 'JSONLoadError', 'it should throw an JSONLoadError object')
+      t.equals(e.name, 'LoadJSONError', 'it should throw an LoadJSONError object')
       t.equals(e.code, 'EWRONGTYPE', 'it should return the EWRONGTYPE code')
       t.equals(e.message, 'null passed instead of an object', 'it should return the correct message')
     })
@@ -112,7 +112,7 @@ test('When undefined is passed instead of a source object', function (t) {
   jsonLoader
     .load([undefined])
     .catch(e => {
-      t.equals(e.name, 'JSONLoadError', 'it should throw an JSONLoadError object')
+      t.equals(e.name, 'LoadJSONError', 'it should throw an LoadJSONError object')
       t.equals(e.code, 'EWRONGTYPE', 'it should return the EWRONGTYPE code')
       t.equals(e.message, 'undefined passed instead of an object', 'it should return the correct message')
     })
@@ -124,7 +124,7 @@ test('When a string is passed instead of a source object', function (t) {
   jsonLoader
     .load(['/path'])
     .catch(e => {
-      t.equals(e.name, 'JSONLoadError', 'it should throw an JSONLoadError object')
+      t.equals(e.name, 'LoadJSONError', 'it should throw an LoadJSONError object')
       t.equals(e.code, 'EWRONGTYPE', 'it should return the EWRONGTYPE code')
       t.equals(e.message, 'string passed instead of an object', 'it should return the correct message')
     })
@@ -136,7 +136,7 @@ test('When a number is passed instead of a source object', function (t) {
   jsonLoader
     .load([2])
     .catch(e => {
-      t.equals(e.name, 'JSONLoadError', 'it should throw an JSONLoadError object')
+      t.equals(e.name, 'LoadJSONError', 'it should throw an LoadJSONError object')
       t.equals(e.code, 'EWRONGTYPE', 'it should return the EWRONGTYPE code')
       t.equals(e.message, 'number passed instead of an object', 'it should return the correct message')
     })
@@ -148,7 +148,7 @@ test('When an array is passed instead of a source object', function (t) {
   jsonLoader
     .load([['/path']])
     .catch(e => {
-      t.equals(e.name, 'JSONLoadError', 'it should throw an JSONLoadError object')
+      t.equals(e.name, 'LoadJSONError', 'it should throw an LoadJSONError object')
       t.equals(e.code, 'EWRONGTYPE', 'it should return the EWRONGTYPE code')
       t.equals(e.message, 'array passed instead of an object', 'it should return the correct message')
     })
@@ -160,7 +160,7 @@ test('When loading the json from a source that does not exist', function (t) {
   jsonLoader
     .load([nonexistentLocation])
     .catch(e => {
-      t.equals(e.name, 'JSONLoadError', 'it should throw a JSONLoadError object')
+      t.equals(e.name, 'LoadJSONError', 'it should throw a LoadJSONError object')
       t.equals(e.code, 'EPATHDOESNOTEXIST', 'it should return the EPATHDOESNOTEXIST code')
       t.equals(e.message, 'no/such/location does not exist', 'it should return the correct message')
     })
@@ -201,7 +201,7 @@ test('When loading duplicate sources', function (t) {
   jsonLoader
     .load([source1, source1])
     .catch(e => {
-      t.equals(e.name, 'JSONLoadError', 'it should throw an JSONLoadError object')
+      t.equals(e.name, 'LoadJSONError', 'it should throw an LoadJSONError object')
       t.equals(e.code, 'EDUPLICATESOURCES', 'it should return the correct code')
       t.deepEquals(e.data, {
         sources: [

--- a/lib/service-data/runtime/merge-instances.js
+++ b/lib/service-data/runtime/merge-instances.js
@@ -1,12 +1,15 @@
 /**
  * @module mergeInstances
  **/
+require('@ministryofjustice/module-alias/register-module')(module)
 
 const jsonPath = require('jsonpath')
 
-const {FBLogger, FBError, clone, deepClone} = require('@ministryofjustice/fb-utils-node')
+const {FBLogger, clone, deepClone} = require('@ministryofjustice/fb-utils-node')
 
-class FBMergeError extends FBError {}
+const CommonError = require('~/fb-runner-node/error')
+
+class MergeError extends CommonError {}
 
 /**
  * Add a $source property to instances indicating their source
@@ -64,7 +67,7 @@ function flattenSources (sourceObjs) {
   // TODO: make this a pure function rather than rely on the closure
   function expandIsa (instance) {
     function throwFlattenError (message, code) {
-      throw new FBMergeError(message, {
+      throw new MergeError(message, {
         error: {
           code
         },

--- a/lib/service-data/runtime/merge-instances.unit.spec.js
+++ b/lib/service-data/runtime/merge-instances.unit.spec.js
@@ -27,7 +27,7 @@ test('When merging sources and a referenced source is missing', function (t) {
     const merged = merge(input)
     /* eslint-enable no-unused-vars */
   } catch (e) {
-    t.equal(e.name, 'FBMergeError', 'it should throw an FBMergeError')
+    t.equal(e.name, 'MergeError', 'it should throw an MergeError')
     t.equal(e.message, 'No instance "z" found, referenced by "g"', 'it should report the expected source')
     t.equal(e.code, 'ENOISA', 'it should return the correct error code')
   }
@@ -42,7 +42,7 @@ test('When merging sources and a referenced source is missing', function (t) {
     const merged = merge(input)
     /* eslint-enable no-unused-vars */
   } catch (e) {
-    t.equal(e.name, 'FBMergeError', 'it should throw an FBMergeError')
+    t.equal(e.name, 'MergeError', 'it should throw an MergeError')
     t.equal(e.message, 'No source "source2" for instance "e", referenced by "g"', 'it should report the expected source')
     t.equal(e.code, 'ENOISASOURCE', 'it should return the correct error code')
   }
@@ -57,7 +57,7 @@ test('When merging sources and a referenced instance that specifies its source i
     const merged = merge(input)
     /* eslint-enable no-unused-vars */
   } catch (e) {
-    t.equal(e.name, 'FBMergeError', 'it should throw an FBMergeError')
+    t.equal(e.name, 'MergeError', 'it should throw an MergeError')
     t.equal(e.message, 'No instance "e" found in source "source2", referenced by "g"', 'it should report the expected instance id and source')
     t.equal(e.code, 'ENOISAINSOURCE', 'it should return the correct error code')
   }

--- a/lib/service-data/runtime/propagate-categories.js
+++ b/lib/service-data/runtime/propagate-categories.js
@@ -5,7 +5,7 @@
 //  NB. this propagation method could be deprecated
 // this info could arguably be better obtained by providing a helper method to query an instance’s schema
 
-const jp = require('jsonpath')
+const jsonPath = require('jsonpath')
 const {deepClone} = require('@ministryofjustice/fb-utils-node')
 
 /**
@@ -26,7 +26,7 @@ const propagate = (instances, schemas) => {
   Object.keys(schemas).forEach(type => {
     const categoryTypes = schemas[type].category
     if (categoryTypes) {
-      const categoryInstances = jp.query(instances, `$..[?(@._type === "${type}")]`)
+      const categoryInstances = jsonPath.query(instances, `$..[?(@._type === "${type}")]`)
       categoryInstances.forEach(categoryInstance => {
         categoryTypes.forEach(categoryType => {
           // TODO: Is ${categoryType} the best idea?

--- a/lib/service-data/runtime/propagate-categories.unit.spec.js
+++ b/lib/service-data/runtime/propagate-categories.unit.spec.js
@@ -1,7 +1,7 @@
 const test = require('tape')
 const path = require('path')
 
-const jp = require('jsonpath')
+const jsonPath = require('jsonpath')
 
 const {propagate} = require('./propagate-categories')
 
@@ -12,7 +12,7 @@ const getTestData = name => {
 const schemas = getTestData('schemas')
 
 const getNestedInstance = (instances, id) => {
-  return jp.query(instances, `$..[?(@._id === "${id}")]`)[0]
+  return jsonPath.query(instances, `$..[?(@._id === "${id}")]`)[0]
 }
 
 test('When propagating categories from an instance’s schema', function (t) {

--- a/lib/service-data/runtime/propagate-show.js
+++ b/lib/service-data/runtime/propagate-show.js
@@ -37,7 +37,6 @@ function createAllConditions (...condtions) {
   return {
     _type: 'condition',
     all
-    // : definedConditions
   }
 }
 

--- a/lib/service-data/runtime/propagate-steps.js
+++ b/lib/service-data/runtime/propagate-steps.js
@@ -1,13 +1,17 @@
 /**
  * @module propagateSteps
  **/
+require('@ministryofjustice/module-alias/register-module')(module)
 
-const jp = require('jsonpath')
-const {deepClone, FBError} = require('@ministryofjustice/fb-utils-node')
+const jsonPath = require('jsonpath')
 
-class FBPageMissingError extends FBError { }
-class FBPageParentError extends FBError { }
-class FBPageRepeatableNamespaceError extends FBError { }
+const {deepClone} = require('@ministryofjustice/fb-utils-node')
+
+const CommonError = require('~/fb-runner-node/error')
+
+class PageNotFoundError extends CommonError {}
+class PageHasParentError extends CommonError {}
+class PageRepeatableNamespaceError extends CommonError {}
 
 /**
  * Add parent ref to all page instances
@@ -21,10 +25,10 @@ class FBPageRepeatableNamespaceError extends FBError { }
 const addPageParents = instances => {
   instances = deepClone(instances)
 
-  jp.query(instances, '$..[?(@.steps)]').forEach(instance => {
+  jsonPath.query(instances, '$..[?(@.steps)]').forEach(instance => {
     instance.steps.forEach(step => {
       if (!instances[step]) {
-        throw new FBPageMissingError(`${step} does not exist`, {
+        throw new PageNotFoundError(`${step} does not exist`, {
           data: {
             step,
             instances
@@ -32,7 +36,7 @@ const addPageParents = instances => {
         })
       }
       if (instances[step]._parent) {
-        throw new FBPageParentError(`${step} already has _parent property`, {
+        throw new PageHasParentError(`${step} already has _parent property`, {
           data: {
             step,
             instances
@@ -180,7 +184,7 @@ const propagateUrls = (instances, instance) => {
   }
   if (instance.repeatable) {
     if (!instance.namespace) {
-      throw new FBPageRepeatableNamespaceError(`${instance._id} is repeatable but has no namespace`, {
+      throw new PageRepeatableNamespaceError(`${instance._id} is repeatable but has no namespace`, {
         data: {
           _id: instance._id,
           instances
@@ -217,15 +221,15 @@ const propagate = (instances) => {
   instances = deepClone(instances)
   const instancesWithParents = addPageParents(instances)
 
-  jp.query(instancesWithParents, '$..[?(@.stepsHeading)]').forEach(instance => {
+  jsonPath.query(instancesWithParents, '$..[?(@.stepsHeading)]').forEach(instance => {
     propagateStepsHeading(instancesWithParents, instance)
   })
 
-  jp.query(instancesWithParents, '$..[?(@.sectionHeading)]').forEach(instance => {
+  jsonPath.query(instancesWithParents, '$..[?(@.sectionHeading)]').forEach(instance => {
     propagateSectionHeading(instancesWithParents, instance)
   })
 
-  jp.query(instancesWithParents, '$..[?(@._type && @._type.startsWith("page."))]').forEach(instance => {
+  jsonPath.query(instancesWithParents, '$..[?(@._type && @._type.startsWith("page."))]').forEach(instance => {
     propagateNamespaces(instancesWithParents, instance)
     propagateUrls(instancesWithParents, instance)
   })

--- a/lib/service-data/runtime/propagate-steps.unit.spec.js
+++ b/lib/service-data/runtime/propagate-steps.unit.spec.js
@@ -1,7 +1,7 @@
 const test = require('tap').test
 
 const path = require('path')
-const jp = require('jsonpath')
+const jsonPath = require('jsonpath')
 
 const {deepClone} = require('@ministryofjustice/fb-utils-node')
 
@@ -13,7 +13,7 @@ const getTestData = name => {
 }
 
 const getNestedInstance = (instances, id) => {
-  return jp.query(instances, `$..[?(@._id === "${id}")]`)[0]
+  return jsonPath.query(instances, `$..[?(@._id === "${id}")]`)[0]
 }
 
 test('When adding _parent properties to step instances', async t => {
@@ -69,7 +69,7 @@ test('When a step is referenced by multiple parent pages', async t => {
   const badData = getTestData('input-duplicate-step-ref')
   const error = t.throws(() => propagate(badData), 'should throw an error')
 
-  t.equal(error.name, 'FBPageParentError', 'it should return a FBPageParentError')
+  t.equal(error.name, 'PageHasParentError', 'it should return a PageHasParentError')
   t.equal(error.data.step, 'stepA', 'it should return the duplicated step')
   const eInstances = error.data.instances
   t.notDeepEqual(eInstances.stepA, badData.stepA, 'it should have altered the duplicated step')
@@ -114,7 +114,7 @@ test('When propagating a repeatable instance without a namespace', async t => {
   }
 
   const error = t.throws(() => propagate(input), 'should throw an error')
-  t.equal(error.name, 'FBPageRepeatableNamespaceError', 'it should throw an error')
+  t.equal(error.name, 'PageRepeatableNamespaceError', 'it should throw an error')
   t.equal(error.message, 'repeatableA is repeatable but has no namespace', 'it should report the id of the page without the namespace as the error message')
   t.deepEqual(error.data, expectedErrorData, 'it should return the instances processed so far as the data property of the error object')
 })
@@ -124,7 +124,7 @@ test('When a single step is missing', async t => {
 
   const error = t.throws(() => propagate(badData), 'should throw an error')
 
-  t.equal(error.name, 'FBPageMissingError', 'it should return a FBPageMissingError')
+  t.equal(error.name, 'PageNotFoundError', 'it should return a PageNotFoundError')
   t.equal(error.data.step, 'stepA', 'it should return the missing step')
 })
 
@@ -133,6 +133,6 @@ test('When there are both present and missing steps', async t => {
 
   const error = t.throws(() => propagate(badData), 'should throw an error')
 
-  t.equal(error.name, 'FBPageMissingError', 'it should return a FBPageMissingError')
+  t.equal(error.name, 'PageNotFoundError', 'it should return a PageNotFoundError')
   t.equal(error.data.step, 'stepX', 'it should return the missing step')
 })

--- a/lib/service-data/service-data.js
+++ b/lib/service-data/service-data.js
@@ -8,11 +8,13 @@ const set = require('lodash.set')
 const sortKeys = require('sort-keys')
 const replace = require('replace-in-file')
 
-const {FBError, deepClone} = require('@ministryofjustice/fb-utils-node')
+const {deepClone} = require('@ministryofjustice/fb-utils-node')
 
 const {getRuntimeData} = require('./runtime/get-runtime-data')
 
-class FBServiceDataError extends FBError {
+const CommonError = require('~/fb-runner-node/error')
+
+class ServiceDataError extends CommonError {
   constructor (error = {}) {
     super({
       error
@@ -76,7 +78,7 @@ external.setServiceSchemas = (schemas) => {
     serviceSchemas = schemas
     Object.freeze(serviceSchemas)
   } else {
-    throw new FBServiceDataError({
+    throw new ServiceDataError({
       code: 'ESERVICESCHEMASFROZEN',
       message: 'Attempt to set frozen service schemas'
     })
@@ -185,7 +187,7 @@ external.setServiceSources = (sourceObjs) => {
     serviceSources = sourceObjs
     Object.freeze(serviceSources)
   } else {
-    throw new FBServiceDataError({
+    throw new ServiceDataError({
       code: 'ESERVICESOURCESFROZEN',
       message: 'Attempt to set frozen service sources'
     })
@@ -217,7 +219,7 @@ external.setServiceInstances = (instances, freeze) => {
     external.setSourceInstances(instances.sourceInstances.data)
     timestamp = Date.now().toString()
   } else {
-    throw new FBServiceDataError({
+    throw new ServiceDataError({
       code: 'ESERVICEDATAFROZEN',
       message: 'Attempt to set frozen service data'
     })
@@ -510,7 +512,7 @@ external.deleteDiscreteInstance = async (_id) => {
 }
 
 const throwRejectedPromise = (error) => {
-  return Promise.reject(new FBServiceDataError({error}))
+  return Promise.reject(new ServiceDataError({error}))
 }
 
 external.setInstance = (instance) => {

--- a/lib/service-data/service-data.unit.spec.js
+++ b/lib/service-data/service-data.unit.spec.js
@@ -214,7 +214,7 @@ test('When the service schemas have been set', t => {
     error = e
   }
 
-  t.equals(error.name, 'FBServiceDataError', 'setServiceSchemas should throw an error if an attempt is made to set the schemas again')
+  t.equals(error.name, 'ServiceDataError', 'setServiceSchemas should throw an error if an attempt is made to set the schemas again')
   t.equals(error.message, 'Attempt to set frozen service schemas', 'setServiceSchemas should return the correct error message')
   t.equals(error.code, 'ESERVICESCHEMASFROZEN', 'setServiceSchemas should return the correct error code')
 
@@ -261,7 +261,7 @@ test('When the service sources have been set', t => {
     error = e
   }
 
-  t.equals(error.name, 'FBServiceDataError', 'setServiceSources should throw an error if an attempt is made to set the sources again')
+  t.equals(error.name, 'ServiceDataError', 'setServiceSources should throw an error if an attempt is made to set the sources again')
   t.equals(error.message, 'Attempt to set frozen service sources', 'setServiceSources should return the correct error message')
   t.equals(error.code, 'ESERVICESOURCESFROZEN', 'setServiceSources should return the correct error code')
 
@@ -361,7 +361,7 @@ test('When the service instances have been set', t => {
 
   const timestampC = getTimestamp()
   t.equal(timestampB, timestampC, 'getTimestamp should return an unchanged timestamp value')
-  t.equals(error.name, 'FBServiceDataError', 'setServiceInstances should throw an error if an attempt is made to set the schemas again')
+  t.equals(error.name, 'ServiceDataError', 'setServiceInstances should throw an error if an attempt is made to set the schemas again')
   t.equals(error.message, 'Attempt to set frozen service data', 'setServiceInstances should return the correct error message')
   t.equals(error.code, 'ESERVICEDATAFROZEN', 'setServiceInstances should return the correct error code')
 
@@ -651,7 +651,7 @@ test('When setInstance is invoked incorrectly', t => {
     _type: 'foo'
   })
     .catch(err => {
-      t.equal(err.name, 'FBServiceDataError', 'it should reject instance missing _id property with the correct error')
+      t.equal(err.name, 'ServiceDataError', 'it should reject instance missing _id property with the correct error')
       t.equal(err.error.code, 'ESETINSTANCEMISSINGID', 'it should reject instance missing _id property with the correct error code')
       t.equal(err.error.message, 'No id passed for instance', 'it should reject instance missing _id property with the correct error message')
     })
@@ -660,7 +660,7 @@ test('When setInstance is invoked incorrectly', t => {
     _id: 'b'
   })
     .catch(err => {
-      t.equal(err.name, 'FBServiceDataError', 'it should reject instance missing _type property with the correct error')
+      t.equal(err.name, 'ServiceDataError', 'it should reject instance missing _type property with the correct error')
       t.equal(err.error.code, 'ESETINSTANCEMISSINGTYPE', 'it should reject instance missing _type property with the correct error code')
       t.equal(err.error.message, 'Instance ‘b’ has no type', 'it should reject instance missing _type property with the correct error message')
     })
@@ -670,7 +670,7 @@ test('When setInstance is invoked incorrectly', t => {
     _type: 'foo'
   })
     .catch(err => {
-      t.equal(err.name, 'FBServiceDataError', 'it should reject instance which cannot be found with the correct error')
+      t.equal(err.name, 'ServiceDataError', 'it should reject instance which cannot be found with the correct error')
       t.equal(err.error.code, 'ESETINSTANCEINSTANCENOTFOUND', 'it should reject instance which cannot be found with the correct error code')
       t.equal(err.error.message, 'Instance ‘z’ not found', 'it should reject instance which cannot be found with the correct error message')
     })
@@ -685,7 +685,7 @@ test('When setInstance is invoked incorrectly', t => {
     _type: 'foo'
   })
     .catch(err => {
-      t.equal(err.name, 'FBServiceDataError', 'it should reject instance which has no source reference with the correct error')
+      t.equal(err.name, 'ServiceDataError', 'it should reject instance which has no source reference with the correct error')
       t.equal(err.error.code, 'ESETINSTANCENOSOURCE', 'it should reject instance which has no source reference with the correct error code')
       t.equal(err.error.message, 'Instance ‘b’ has no source', 'it should reject instance which has no source reference with the correct error message')
     })
@@ -699,7 +699,7 @@ test('When setInstance is invoked incorrectly', t => {
     _type: 'foo'
   })
     .catch(err => {
-      t.equal(err.name, 'FBServiceDataError', 'it should reject instance whose source is missing with the correct error')
+      t.equal(err.name, 'ServiceDataError', 'it should reject instance whose source is missing with the correct error')
       t.equal(err.error.code, 'ESETINSTANCESOURCENOTFOUND', 'it should reject instance whose source is missing with the correct error code')
       t.equal(err.error.message, 'Source specified for instance ‘b’ does not exist', 'it should reject instance whose source is missing with the correct error message')
     })
@@ -735,28 +735,28 @@ test('When setting a property on an instance', t => {
 
   setInstanceProperty(undefined, 'newProp', 'newValue')
     .catch(err => {
-      t.equal(err.name, 'FBServiceDataError', 'it should reject call with missing id property with the correct error')
+      t.equal(err.name, 'ServiceDataError', 'it should reject call with missing id property with the correct error')
       t.equal(err.error.code, 'ESETINSTANCEPROPERTYMISSINGID', 'it should reject call with missing id property with the correct error code')
       t.equal(err.error.message, 'No id passed to setInstanceProperty', 'it should reject call with missing id property with the correct error message')
     })
 
   setInstanceProperty('b', undefined, 'newValue')
     .catch(err => {
-      t.equal(err.name, 'FBServiceDataError', 'it should reject call with missing ‘property’ property with the correct error')
+      t.equal(err.name, 'ServiceDataError', 'it should reject call with missing ‘property’ property with the correct error')
       t.equal(err.error.code, 'ESETINSTANCEPROPERTYMISSINGPROPERTY', 'it should reject call with missing ‘property’ property with the correct error code')
       t.equal(err.error.message, 'No property for instance ‘b’ passed to setInstanceProperty', 'it should reject call with missing ‘property’ property with the correct error message')
     })
 
   setInstanceProperty('b', '_id', 'newValue')
     .catch(err => {
-      t.equal(err.name, 'FBServiceDataError', 'it should reject call with ‘_id’ property with the correct error')
+      t.equal(err.name, 'ServiceDataError', 'it should reject call with ‘_id’ property with the correct error')
       t.equal(err.error.code, 'ESETINSTANCEPROPERTYPROTECTED', 'it should reject call with ‘_id’ property with the correct error code')
       t.equal(err.error.message, 'Property ‘_id’ for instance ‘b’ is protected', 'it should reject call with ‘_id’ property with the correct error message')
     })
 
   setInstanceProperty('b', '_type', 'newValue')
     .catch(err => {
-      t.equal(err.name, 'FBServiceDataError', 'it should reject call with ‘_type’ property with the correct error')
+      t.equal(err.name, 'ServiceDataError', 'it should reject call with ‘_type’ property with the correct error')
       t.equal(err.error.code, 'ESETINSTANCEPROPERTYPROTECTED', 'it should reject call with ‘_type’ property with the correct error code')
       t.equal(err.error.message, 'Property ‘_type’ for instance ‘b’ is protected', 'it should reject call with ‘_type’ property with the correct error message')
     })
@@ -964,7 +964,7 @@ test('When createInstance attempts to create instance that already exists', t =>
     _type: 'foo'
   })
     .catch(err => {
-      t.equal(err.name, 'FBServiceDataError', 'it should reject instance that already exists with the correct error')
+      t.equal(err.name, 'ServiceDataError', 'it should reject instance that already exists with the correct error')
       t.equal(err.error.code, 'ECREATEINSTANCEINSTANCEEXISTS', 'it should reject instance that already exists with the correct error code')
       t.equal(err.error.message, 'Instance ‘a’ already exists', 'it should reject instance that already exists with the correct error message')
     })
@@ -974,7 +974,7 @@ test('When createInstance attempts to create instance that already exists', t =>
     _type: 'foo'
   })
     .catch(err => {
-      t.equal(err.name, 'FBServiceDataError', 'it should reject nested instance that already exists with the correct error')
+      t.equal(err.name, 'ServiceDataError', 'it should reject nested instance that already exists with the correct error')
       t.equal(err.error.code, 'ECREATEINSTANCEINSTANCEEXISTS', 'it should reject nested instance that already exists with the correct error code')
       t.equal(err.error.message, 'Instance ‘b’ already exists', 'it should reject nested instance that already exists with the correct error message')
     })
@@ -1011,7 +1011,7 @@ test('When createInstance is invoked incorrectly', t => {
     _type: 'foo'
   })
     .catch(err => {
-      t.equal(err.name, 'FBServiceDataError', 'it should reject instance missing _id property with the correct error')
+      t.equal(err.name, 'ServiceDataError', 'it should reject instance missing _id property with the correct error')
       t.equal(err.error.code, 'ECREATEINSTANCEMISSINGID', 'it should reject instance missing _id property with the correct error code')
       t.equal(err.error.message, 'No id passed for instance', 'it should reject instance missing _id property with the correct error message')
     })
@@ -1020,7 +1020,7 @@ test('When createInstance is invoked incorrectly', t => {
     _id: 'z'
   })
     .catch(err => {
-      t.equal(err.name, 'FBServiceDataError', 'it should reject instance missing _type property with the correct error')
+      t.equal(err.name, 'ServiceDataError', 'it should reject instance missing _type property with the correct error')
       t.equal(err.error.code, 'ECREATEINSTANCEMISSINGTYPE', 'it should reject instance missing _type property with the correct error code')
       t.equal(err.error.message, 'Instance ‘z’ has no type', 'it should reject instance missing _type property with the correct error message')
     })
@@ -1032,7 +1032,7 @@ test('When createInstance is invoked incorrectly', t => {
     _id: 'a'
   })
     .catch(err => {
-      t.equal(err.name, 'FBServiceDataError', 'it should reject instance when instance to add to is missing with the correct error')
+      t.equal(err.name, 'ServiceDataError', 'it should reject instance when instance to add to is missing with the correct error')
       t.equal(err.error.code, 'ECREATEINSTANCEADDNOPROPERTY', 'it should reject instance when instance to add to is missing with the correct error code')
       t.equal(err.error.message, 'Instance ‘a’ specified to add new instance ‘z’ to without any property', 'it should reject instance when instance to add to is missing with the correct error message')
     })
@@ -1045,7 +1045,7 @@ test('When createInstance is invoked incorrectly', t => {
     property: 'components'
   })
     .catch(err => {
-      t.equal(err.name, 'FBServiceDataError', 'it should reject instance when instance to add to is missing with the correct error')
+      t.equal(err.name, 'ServiceDataError', 'it should reject instance when instance to add to is missing with the correct error')
       t.equal(err.error.code, 'ECREATEINSTANCEADDNOTFOUND', 'it should reject instance when instance to add to is missing with the correct error code')
       t.equal(err.error.message, 'Instance ‘y’ to add new instance ‘z’ to not found', 'it should reject instance when instance to add to is missing with the correct error message')
     })
@@ -1064,7 +1064,7 @@ test('When createInstance is invoked incorrectly', t => {
     property: 'components'
   })
     .catch(err => {
-      t.equal(err.name, 'FBServiceDataError', 'it should reject instance when instance to add to is missing with the correct error')
+      t.equal(err.name, 'ServiceDataError', 'it should reject instance when instance to add to is missing with the correct error')
       t.equal(err.error.code, 'ECREATEINSTANCEADDNOSOURCE', 'it should reject instance when instance to add to is missing with the correct error code')
       t.equal(err.error.message, 'Instance ‘a’ to add new instance ‘z’ to has no source', 'it should reject instance when instance to add to is missing with the correct error message')
     })
@@ -1078,7 +1078,7 @@ test('When createInstance is invoked incorrectly', t => {
     _type: 'foo'
   })
     .catch(err => {
-      t.equal(err.name, 'FBServiceDataError', 'it should reject instance whose source is missing with the correct error')
+      t.equal(err.name, 'ServiceDataError', 'it should reject instance whose source is missing with the correct error')
       t.equal(err.error.code, 'ECREATEINSTANCESOURCENOTFOUND', 'it should reject instance whose source is missing with the correct error code')
       t.equal(err.error.message, 'Source specified for instance ‘z’ does not exist', 'it should reject instance whose source is missing with the correct error message')
     })

--- a/package-lock.json
+++ b/package-lock.json
@@ -4323,9 +4323,9 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "inquirer": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.2.tgz",
-      "integrity": "sha512-cZGvHaHwcR9E3xK9EGO5pHKELU+yaeJO7l2qGKIbqk4bCuDuAn15LCoUTS2nSkfv9JybFlnAGrOcVpCDZZOLhw==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.3.tgz",
+      "integrity": "sha512-+OiOVeVydu4hnCGLCSX+wedovR/Yzskv9BFqUNNKq9uU2qg7LCcCo3R86S2E7WLo0y/x2pnEZfZe1CoYnORUAw==",
       "dev": true,
       "requires": {
         "ansi-escapes": "^4.2.1",
@@ -6225,9 +6225,9 @@
       }
     },
     "ono": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/ono/-/ono-6.0.0.tgz",
-      "integrity": "sha512-vhx50giT0dDBLYYXwKU/tuNsT6CwPzGZmd6yypPsXrkq+ujT0lX0q4tvMQ/5jxM6HKntk7p3N51Ts0fD8qL5dA=="
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ono/-/ono-6.0.1.tgz",
+      "integrity": "sha512-5rdYW/106kHqLeG22GE2MHKq+FlsxMERZev9DCzQX1zwkxnFwBivSn5i17a5O/rDmOJOdf4Wyt80UZljzx9+DA=="
     },
     "opener": {
       "version": "1.5.1",
@@ -7058,9 +7058,9 @@
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
     },
     "resolve": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.14.1.tgz",
-      "integrity": "sha512-fn5Wobh4cxbLzuHaE+nphztHy43/b++4M6SsGFC2gB8uYwf0C8LcarfCz1un7UTW8OFQg9iNjZ4xpcFVGebDPg==",
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.14.2.tgz",
+      "integrity": "sha512-EjlOBLBO1kxsUxsKjLt7TAECyKW6fOh1VRkykQkKGzcBbjjPIxBqGh0jf7GJ3k/f5mxMqW3htMD3WdTUVtW8HQ==",
       "requires": {
         "path-parse": "^1.0.6"
       }
@@ -7352,9 +7352,9 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "sinon": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-8.0.2.tgz",
-      "integrity": "sha512-8W1S7BnCyvk7SK+Xi15B1QAVLuS81G/NGmWefPb31+ly6xI3fXaug/g5oUdfc8+7ruC4Ay51AxuLlYm8diq6kA==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-8.0.4.tgz",
+      "integrity": "sha512-cFsmgmvsgFb87e7SV7IcekogITlHX2KmlplyI9Pda0FH1Z8Ms/kWbpLs25Idp0m6ZJ3HEEjhaYYXbcTtWWUn4w==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.7.0",
@@ -9444,9 +9444,9 @@
       "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
     },
     "uglify-js": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.3.tgz",
-      "integrity": "sha512-7tINm46/3puUA4hCkKYo4Xdts+JDaVC9ZPRcG8Xw9R4nhO/gZgUM3TENq8IF4Vatk8qCig4MzP/c8G4u2BkVQg==",
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.4.tgz",
+      "integrity": "sha512-tinYWE8X1QfCHxS1lBS8yiDekyhSXOO6R66yNOCdUJeojxxw+PX2BHAz/BWyW7PQ7pkiWVxJfIEbiDxyLWvUGg==",
       "dev": true,
       "optional": true,
       "requires": {


### PR DESCRIPTION
[FB-786](https://dsdmoj.atlassian.net/browse/FB-786) **Create Error classes in the packages which use them**

- Another step toward deprecating `fb-utils-node`

Little/no refactoring. Introduces `CommonError` class into *Runner* (formerly `FBError` in `fb-utils-node` with some code-style changes). Additional name changes

_Depends on [FB-772](https://dsdmoj.atlassian.net/browse/FB-772) and [FB-734](https://dsdmoj.atlassian.net/browse/FB-734)_