### PR TITLE
use private key to sign calls to datastore

### DIFF
--- a/lib/client/user/datastore/datastore.js
+++ b/lib/client/user/datastore/datastore.js
@@ -7,7 +7,8 @@ const {
   SERVICE_SECRET,
   SERVICE_TOKEN,
   SERVICE_SLUG,
-  USER_DATASTORE_URL
+  USER_DATASTORE_URL,
+  ENCODED_PRIVATE_KEY
 } = require('~/fb-runner-node/constants/constants')
 
 const {
@@ -16,7 +17,7 @@ const {
 } = metrics.getMetricsClient()
 
 const userDataStoreClient = USER_DATASTORE_URL
-  ? new FBUserDataStoreClient(SERVICE_SECRET, SERVICE_TOKEN, SERVICE_SLUG, USER_DATASTORE_URL) // initialise user datastore client
+  ? new FBUserDataStoreClient(SERVICE_SECRET, SERVICE_TOKEN, SERVICE_SLUG, USER_DATASTORE_URL, ENCODED_PRIVATE_KEY)
   : {offline: true, setMetricsInstrumentation: () => {}}
 
 userDataStoreClient.setMetricsInstrumentation(apiMetrics, requestMetrics)

--- a/package-lock.json
+++ b/package-lock.json
@@ -198,9 +198,9 @@
       }
     },
     "@ministryofjustice/fb-client": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@ministryofjustice/fb-client/-/fb-client-1.0.6.tgz",
-      "integrity": "sha512-f/zuRa8+xP1khSAV20Grp5pzVjMshxkmPCy38Abqt4hHeHxjVcaQaUNJWo6zcH6H9cEf5+CedXKzjvGDr0muOg==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/fb-client/-/fb-client-1.0.7.tgz",
+      "integrity": "sha512-0KDBinCULe+mgCaNJrF2GaoBZUdaQ2Qh+OgEXmsb3uEGvAOKjX54LCEAnF7vqMuPJSP21NaU01vBYanlRHxuJg==",
       "requires": {
         "aes256": "^1.0.4",
         "got": "10.2.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@ministryofjustice/fb-client": "1.0.6",
+    "@ministryofjustice/fb-client": "1.0.7",
     "@ministryofjustice/fb-components": "1.0.6",
     "@ministryofjustice/module-alias": "^1.0.8",
     "@promster/express": "^4.0.0",


### PR DESCRIPTION
- communication with datastore now uses private key to sign
- datastore will verify with public key
- this is done by sending the `x-access-token-v2` header