### PR TITLE
BUG: Uploads not progressing to the next page

### DIFF
--- a/lib/controller/component/type/answers/answers.page-summary-list.unit.spec.js
+++ b/lib/controller/component/type/answers/answers.page-summary-list.unit.spec.js
@@ -42,6 +42,7 @@ const formatStub = {
 const answersRepeatableStub = sinon.stub()
 
 const userDataStub = {
+  getUserData: sinon.stub().returns({}),
   getUserDataProperty: sinon.stub()
 }
 

--- a/lib/controller/component/type/answers/answers.page-summary.unit.spec.js
+++ b/lib/controller/component/type/answers/answers.page-summary.unit.spec.js
@@ -42,6 +42,7 @@ const formatStub = {
 const answersRepeatableStub = sinon.stub()
 
 const userDataStub = {
+  getUserData: sinon.stub().returns({}),
   getUserDataProperty: sinon.stub(),
   getUserDataInputProperty: sinon.stub()
 }

--- a/lib/controller/component/type/upload/index.js
+++ b/lib/controller/component/type/upload/index.js
@@ -17,13 +17,16 @@ function getUploadPage ({getBodyInput}) {
 }
 
 const {
-  countComponentAcceptedFiles,
+  clearComponentFiles,
+  hasComponentAcceptedAnyFiles,
   getComponentAcceptedFiles
 } = require('~/fb-runner-node/page/utils/utils-uploads')
 
 module.exports = class UploadController extends CommonController {
-  async preFlight (componentInstance, userData, {_id}) {
+  async preFlight (componentInstance, userData, {_id}, POST) {
     const bodyInput = userData.getBodyInput()
+
+    if (!POST) clearComponentFiles(componentInstance, userData)
 
     if (Reflect.has(bodyInput, 'fieldName')) userData.setUserDataProperty('fieldName', Reflect.get(bodyInput, 'fieldName'))
 
@@ -46,7 +49,7 @@ module.exports = class UploadController extends CommonController {
   }
 
   isAnswered (...args) {
-    return countComponentAcceptedFiles(...args) > 0
+    return hasComponentAcceptedAnyFiles(...args)
   }
 
   getAnsweredDisplayValue (component, userData, scope) {

--- a/lib/controller/component/type/upload/index.js
+++ b/lib/controller/component/type/upload/index.js
@@ -16,6 +16,11 @@ function getUploadPage ({getBodyInput}) {
   return uploadPage
 }
 
+const {
+  countComponentAcceptedFiles,
+  getComponentAcceptedFiles
+} = require('~/fb-runner-node/page/utils/utils-uploads')
+
 module.exports = class UploadController extends CommonController {
   async preFlight (componentInstance, userData, {_id}) {
     const bodyInput = userData.getBodyInput()
@@ -40,18 +45,14 @@ module.exports = class UploadController extends CommonController {
     return componentInstance
   }
 
-  isAnswered ({name}, userData, scope) {
-    const uploadValue = userData.getUserDataInputProperty(name) || []
-
-    return !!uploadValue.length
+  isAnswered (...args) {
+    return countComponentAcceptedFiles(...args) > 0
   }
 
-  getAnsweredDisplayValue ({name, ...instance}, userData, scope) {
-    const uploadValue = userData.getUserDataInputProperty(name) || []
+  getAnsweredDisplayValue (component, userData, scope) {
+    const value = getComponentAcceptedFiles(component, userData).map(({originalname, size}) => `${originalname} (${bytes(size)})`).join('\n\n')
 
-    const value = uploadValue.map(({originalname, size}) => `${originalname} (${bytes(size)})`).join('\n\n')
-
-    return format(value, {}, {multiline: this.isMultiLine({...instance, name}, value), substitution: true, markdown: true, lang: userData.contentLang})
+    return format(value, {}, {multiline: this.isMultiLine(component, value), substitution: true, markdown: true, lang: userData.contentLang})
       .replace(/<p>/g, '<p class="govuk-body">')
   }
 }

--- a/lib/controller/component/type/upload/index.unit.spec.js
+++ b/lib/controller/component/type/upload/index.unit.spec.js
@@ -11,23 +11,25 @@ const sinon = require('sinon')
 const bytesStub = sinon.stub()
 const formatStub = sinon.stub()
 
+const countComponentAcceptedFilesStub = sinon.stub()
+const getComponentAcceptedFilesStub = sinon.stub()
+
 const UploadController = proxyquire('.', {
   bytes: bytesStub,
   '~/fb-runner-node/format/format': {
     format: formatStub
+  },
+  '~/fb-runner-node/page/utils/utils-uploads': {
+    countComponentAcceptedFiles: countComponentAcceptedFilesStub,
+    getComponentAcceptedFiles: getComponentAcceptedFilesStub
   }
 })
 
 test('is answered', (t) => {
-  const getUserDataInputPropertyStub = sinon.stub().returns([{}])
+  countComponentAcceptedFilesStub.returns(1)
 
-  const componentInstance = {
-    name: 'mock component'
-  }
-
-  const userData = {
-    getUserDataInputProperty: getUserDataInputPropertyStub
-  }
+  const componentInstance = {}
+  const userData = {}
 
   const uploadController = new UploadController()
 
@@ -37,15 +39,10 @@ test('is answered', (t) => {
 })
 
 test('is not answered', (t) => {
-  const getUserDataInputPropertyStub = sinon.stub().returns(undefined)
+  countComponentAcceptedFilesStub.returns(0)
 
-  const componentInstance = {
-    name: 'mock component'
-  }
-
-  const userData = {
-    getUserDataInputProperty: getUserDataInputPropertyStub
-  }
+  const componentInstance = {}
+  const userData = {}
 
   const uploadController = new UploadController()
 
@@ -55,10 +52,12 @@ test('is not answered', (t) => {
 })
 
 test('get answered display value', (t) => {
+  getComponentAcceptedFilesStub.reset()
+
   bytesStub.reset()
   formatStub.reset()
 
-  const getUserDataInputPropertyStub = sinon.stub().returns([{originalname: 'mock original name', size: 'mock size'}])
+  getComponentAcceptedFilesStub.returns([{originalname: 'mock original name', size: 'mock size'}])
 
   formatStub.returns('mock formatted value')
 
@@ -67,7 +66,6 @@ test('get answered display value', (t) => {
   }
 
   const userData = {
-    getUserDataInputProperty: getUserDataInputPropertyStub,
     contentLang: 'mock content lang'
   }
 

--- a/lib/controller/component/type/upload/index.unit.spec.js
+++ b/lib/controller/component/type/upload/index.unit.spec.js
@@ -11,7 +11,7 @@ const sinon = require('sinon')
 const bytesStub = sinon.stub()
 const formatStub = sinon.stub()
 
-const countComponentAcceptedFilesStub = sinon.stub()
+const hasComponentAcceptedAnyFilesStub = sinon.stub()
 const getComponentAcceptedFilesStub = sinon.stub()
 
 const UploadController = proxyquire('.', {
@@ -20,13 +20,13 @@ const UploadController = proxyquire('.', {
     format: formatStub
   },
   '~/fb-runner-node/page/utils/utils-uploads': {
-    countComponentAcceptedFiles: countComponentAcceptedFilesStub,
+    hasComponentAcceptedAnyFiles: hasComponentAcceptedAnyFilesStub,
     getComponentAcceptedFiles: getComponentAcceptedFilesStub
   }
 })
 
 test('is answered', (t) => {
-  countComponentAcceptedFilesStub.returns(1)
+  hasComponentAcceptedAnyFilesStub.returns(true)
 
   const componentInstance = {}
   const userData = {}
@@ -39,7 +39,7 @@ test('is answered', (t) => {
 })
 
 test('is not answered', (t) => {
-  countComponentAcceptedFilesStub.returns(0)
+  hasComponentAcceptedAnyFilesStub.returns(false)
 
   const componentInstance = {}
   const userData = {}

--- a/lib/controller/page/type/page.summary/index.js
+++ b/lib/controller/page/type/page.summary/index.js
@@ -45,6 +45,7 @@ const submitterClient = require('~/fb-runner-node/client/submitter/submitter')
 module.exports = class SummaryController extends CommonController {
   async preFlight (pageInstance, userData) {
     const performsSubmit = checkSubmits(pageInstance, userData)
+
     if (performsSubmit) {
       const {
         _id,

--- a/lib/controller/page/type/page.uploadCheck/index.js
+++ b/lib/controller/page/type/page.uploadCheck/index.js
@@ -82,7 +82,7 @@ function createRadios ({contentLang: lang}, count = 0) {
   }
 }
 
-const getUploadedFilesForUploadControls = (pageInstance, userData) => getComponents(pageInstance)
+const getComponentFilesFor = (pageInstance, userData) => getComponents(pageInstance)
   .reduce((accumulator, component) => accumulator.concat(getComponentFiles(component, userData)), [])
   .sort(({timestamp: alpha}, {timestamp: omega}) => new Date(alpha).valueOf() - new Date(omega).valueOf())
 
@@ -197,7 +197,7 @@ module.exports = class UploadCheckController extends CommonController {
 
     if (uploadPage) {
       if (!POST) {
-        const uploaded = getUploadedFilesForUploadControls(getInstance(uploadPage), userData)
+        const uploaded = getComponentFilesFor(getInstance(uploadPage), userData)
 
         const {
           fieldName

--- a/lib/controller/page/type/page.uploadCheck/index.js
+++ b/lib/controller/page/type/page.uploadCheck/index.js
@@ -16,17 +16,17 @@ const {
 } = require('~/fb-runner-node/page/page')
 
 const {
-  getUploadControls,
-  getUploadedMaxFiles,
-  getUploadedMinFiles,
-  hasUploadedMaxFiles,
-  hasUploadedMinFiles,
-  getUploadedFiles,
-  setUploadedFiles,
-  clearUploadedFiles,
-  addToAcceptedFiles,
-  removeFromAcceptedFiles,
-  hasAcceptedFile
+  getComponents,
+  getComponentMaxFiles,
+  getComponentMinFiles,
+  hasComponentMaxFiles,
+  hasComponentMinFiles,
+  getComponentFiles,
+  setComponentFiles,
+  clearComponentFiles,
+  addToComponentAcceptedFiles,
+  removeFromComponentAcceptedFiles,
+  hasComponentAcceptedFile
 } = require('~/fb-runner-node/page/utils/utils-uploads')
 
 const {
@@ -82,8 +82,8 @@ function createRadios ({contentLang: lang}, count = 0) {
   }
 }
 
-const getUploadedFilesForUploadControls = (pageInstance, userData) => getUploadControls(pageInstance)
-  .reduce((accumulator, component) => accumulator.concat(getUploadedFiles(component, userData)), [])
+const getUploadedFilesForUploadControls = (pageInstance, userData) => getComponents(pageInstance)
+  .reduce((accumulator, component) => accumulator.concat(getComponentFiles(component, userData)), [])
   .sort(({timestamp: alpha}, {timestamp: omega}) => new Date(alpha).valueOf() - new Date(omega).valueOf())
 
 const hasUploadedFile = (uploaded, alpha) => uploaded.some(({fieldname, fieldName: omega = fieldname}) => alpha === omega)
@@ -99,7 +99,7 @@ function isFieldNameAccepted (userData, fieldName) {
     return fieldName.some(mapFieldNameAccepted(userData))
   }
 
-  return hasAcceptedFile(userData, fieldName)
+  return hasComponentAcceptedFile(userData, fieldName)
 }
 
 function isFieldNameUploaded (uploaded, fieldName) {
@@ -126,10 +126,10 @@ function prepareUploadCheckPage (pageInstance, userData, uploadList) {
     name: 'uploadCheck'
   }
 
-  const maxFiles = components.reduce((max, component) => Math.max(max, getUploadedMaxFiles(component)), 0)
-  const minFiles = components.reduce((min, component) => Math.max(min, getUploadedMinFiles(component)), 0) // Math.max!
-  const hasMaxFiles = components.every((component, userData) => hasUploadedMaxFiles(component, userData))
-  const hasMinFiles = components.every((component, userData) => hasUploadedMinFiles(component, userData))
+  const maxFiles = components.reduce((max, component) => Math.max(max, getComponentMaxFiles(component)), 0)
+  const minFiles = components.reduce((min, component) => Math.max(min, getComponentMinFiles(component)), 0) // Math.max!
+  const hasMaxFiles = components.every((component, userData) => hasComponentMaxFiles(component, userData))
+  const hasMinFiles = components.every((component, userData) => hasComponentMinFiles(component, userData))
 
   uploadCheck.uploadPage = uploadPage
   uploadCheck.uploadList = uploadList
@@ -205,35 +205,35 @@ module.exports = class UploadCheckController extends CommonController {
 
         if (isFieldNameAccepted(userData, fieldName)) {
           if (isFieldNameUploaded(uploaded, fieldName)) {
-          /*
-           *  Is in accepted list
-           *  Is in uploaded list
-           *    - Uploaded (Back, uploaded)
-           */
+            /*
+             *  Is in accepted list
+             *  Is in uploaded list
+             *    - Uploaded (Back, uploaded)
+             */
             pageInstance = prepareUploadCheckPage(pageInstance, userData, uploaded)
           } else {
-          /*
-           *  Is in accepted list
-           *  Not in uploaded list
-           *    - Redirect (Back, deleted)
-           */
+            /*
+             *  Is in accepted list
+             *  Not in uploaded list
+             *    - Redirect (Back, deleted)
+             */
             pageInstance.$validated = true
             pageInstance = await getRedirectFromPageToPage(pageInstance, getInstance(uploadPage), userData)
           }
         } else {
           if (isFieldNameUploaded(uploaded, fieldName)) {
-          /*
-           *  Not in accepted list
-           *  Is in uploaded list
-           *    - Uploaded
-           */
+            /*
+             *  Not in accepted list
+             *  Is in uploaded list
+             *    - Uploaded
+             */
             pageInstance = prepareUploadCheckPage(pageInstance, userData, uploaded)
           } else {
-          /*
-           *  Not in accepted list
-           *  Not in uploaded list
-           *    - Redirect (Back, deleted)
-           */
+            /*
+             *  Not in accepted list
+             *  Not in uploaded list
+             *    - Redirect (Back, deleted)
+             */
             pageInstance.$validated = true
             pageInstance = await getRedirectFromPageToPage(pageInstance, getInstance(uploadPage), userData)
           }
@@ -257,41 +257,49 @@ module.exports = class UploadCheckController extends CommonController {
     userData.setUserDataProperty('upload', upload)
 
     if (this.isUploadAccepted(userData)) {
-    /*
-     *  Accepted
-     */
-      getUploadControls(getInstance(uploadPage))
+      /*
+       *  Accepted
+       */
+      getComponents(getInstance(uploadPage))
         .forEach((component) => {
-          const was = getUploadedFiles(component, userData)
+          const was = getComponentFiles(component, userData)
+
           const uploadItem = was.find(({uuid}) => Array.isArray(upload) ? upload.includes(uuid) : uuid === upload)
+
           if (uploadItem) {
             const {
               fieldname: fieldName,
               ...file
             } = uploadItem
 
-            addToAcceptedFiles(userData, {...file, fieldName})
+            /*
+             *  The upload has been accepted by the user so we want to add it to the list of accepted files ...
+             */
+            addToComponentAcceptedFiles(userData, {...file, fieldName})
 
-            const now = was.filter((item) => item !== uploadItem)
+            const now = was.filter((item) => item !== uploadItem) // .concat(uploadItem)
 
+            /*
+             *  ... and remove it from the list of uploaded files (which is "uploaded but not accepted yet")
+             */
             if (now.length) {
-              setUploadedFiles(component, now, userData)
+              setComponentFiles(component, now, userData)
             } else {
-              clearUploadedFiles(component, userData)
+              clearComponentFiles(component, userData)
             }
           }
         })
     } else {
-    /*
-     *  Rejected or otherwise
-     */
-      if (this.isUploadRejected(userData)) {
       /*
-       *  Rejected
+       *  Rejected or otherwise
        */
-        getUploadControls(getInstance(uploadPage))
+      if (this.isUploadRejected(userData)) {
+        /*
+         *  Rejected
+         */
+        getComponents(getInstance(uploadPage))
           .forEach((component) => {
-            const was = getUploadedFiles(component, userData)
+            const was = getComponentFiles(component, userData)
             const uploadItem = was.find(({uuid}) => Array.isArray(upload) ? upload.includes(uuid) : uuid === upload)
             if (uploadItem) {
               const {
@@ -299,14 +307,14 @@ module.exports = class UploadCheckController extends CommonController {
                 ...file
               } = uploadItem
 
-              removeFromAcceptedFiles(userData, {...file, fieldName})
+              removeFromComponentAcceptedFiles(userData, {...file, fieldName})
 
               const now = was.filter((item) => item !== uploadItem)
 
               if (now.length) {
-                setUploadedFiles(component, now, userData)
+                setComponentFiles(component, now, userData)
               } else {
-                clearUploadedFiles(component, userData)
+                clearComponentFiles(component, userData)
               }
 
               userData.setFlashMessage({

--- a/lib/controller/page/type/page.uploadSummary/index.js
+++ b/lib/controller/page/type/page.uploadSummary/index.js
@@ -15,20 +15,25 @@ const {
 } = require('~/fb-runner-node/page/page')
 
 const {
-  getUploadControls,
-  getUploadedMaxFiles,
-  getUploadedMinFiles,
-  hasAcceptedMaxFiles,
-  hasAcceptedMinFiles,
-  hasAcceptedMaxFilesForUploadControls,
-  hasAcceptedMinFilesForUploadControls,
-  removeFromAcceptedFiles,
-  hasAcceptedFileByUUID,
-  getAcceptedFileByUUID
+  getUrl
+} = require('~/fb-runner-node/route/route')
+
+const {
+  getComponents,
+  getComponentMaxFiles,
+  getComponentMinFiles,
+  clearComponentFiles,
+  hasComponentAcceptedMaxFiles,
+  hasComponentAcceptedMinFiles,
+  hasComponentsAcceptedMaxFiles,
+  hasComponentsAcceptedMinFiles,
+  removeFromComponentAcceptedFiles,
+  hasComponentAcceptedFileByUUID,
+  getComponentAcceptedFileByUUID
 } = require('~/fb-runner-node/page/utils/utils-uploads')
 
 const {
-  getUploadControlName
+  getComponentName
 } = require('~/fb-runner-node/page/utils/utils-controls')
 
 const {
@@ -98,8 +103,8 @@ module.exports = class UploadSummaryController extends CommonController {
   }
 
   /*
- *  POST
- */
+   *  POST
+   */
   async resolveRouteForRemoveUpload (summaryPageInstance, userData) {
     try {
       const {
@@ -108,7 +113,7 @@ module.exports = class UploadSummaryController extends CommonController {
 
       const controlPageInstance = getInstance(uploadPage)
 
-      return hasAcceptedMinFilesForUploadControls(controlPageInstance, userData)
+      return hasComponentsAcceptedMinFiles(controlPageInstance, userData)
         ? summaryPageInstance
         : controlPageInstance
     } catch (e) {
@@ -117,8 +122,8 @@ module.exports = class UploadSummaryController extends CommonController {
   }
 
   /*
- *  POST
- */
+   *  POST
+   */
   async resolveRoute (pageInstance, userData) {
     try {
       const {
@@ -131,20 +136,27 @@ module.exports = class UploadSummaryController extends CommonController {
 
       if (uploadPage) {
         if (decision === 'confirm') {
+          getComponents(getInstance(uploadPage))
+            .forEach((component) => {
+              clearComponentFiles(component, userData)
+            })
+
           return getRedirectFromPageToPage(pageInstance, getInstance(uploadPage), userData)
         } else {
           const {
             accepted
           } = userData.getUserData()
 
-          getUploadControls(getInstance(uploadPage))
-            .forEach(({name}) => {
-              userData.setUserDataProperty(name, accepted
-                .filter(({fieldName}) => getUploadControlName(fieldName) === name)
-                .map(({fieldName, fieldname = fieldName, ...file}) => ({...file, fieldname})))
-            })
+          getComponents(getInstance(uploadPage))
+            .forEach((component) => {
+              const {name} = component
 
-          userData.unsetUserDataProperty('accepted')
+              userData.setUserDataProperty(name, accepted
+                .filter(({fieldName}) => getComponentName(fieldName) === name)
+                .map(({fieldName, fieldname = fieldName, ...file}) => ({...file, fieldname})))
+
+              clearComponentFiles(component, userData)
+            })
 
           await userData.saveData()
         }
@@ -157,19 +169,25 @@ module.exports = class UploadSummaryController extends CommonController {
   }
 
   /*
- *  GET and POST
- */
+   *  GET and POST
+   */
   async preFlight (pageInstance, userData) {
-    userData.unsetUserDataProperty('decision')
+    if (Reflect.has(userData.getUserData(), 'accepted')) {
+      userData.unsetUserDataProperty('decision')
 
-    await userData.saveData()
+      await userData.saveData()
+    } else {
+      const uploadPage = userData.getUserDataProperty('uploadPage')
+
+      pageInstance.redirect = getUrl(uploadPage, {}, userData.contentLang)
+    }
 
     return pageInstance
   }
 
   /*
- *  GET and POST
- */
+   *  GET and POST
+   */
   async setContents (pageInstance, userData) {
     const {
       uploadPage,
@@ -186,29 +204,29 @@ module.exports = class UploadSummaryController extends CommonController {
       } = userData
 
       const uploadPageInstance = getInstance(uploadPage)
-      const uploadPageControls = getUploadControls(uploadPageInstance)
+      const uploadPageControls = getComponents(uploadPageInstance)
 
-      if (hasAcceptedMinFilesForUploadControls(uploadPageInstance, userData)) {
-      /*
-       *  One upload list
-       */
-        const uploadList = uploadPageControls
+      if (hasComponentsAcceptedMinFiles(uploadPageInstance, userData)) {
         /*
-         *  But there may be more than one upload component per page
+         *  One upload list
          */
+        const uploadList = uploadPageControls
+          /*
+           *  But there may be more than one upload component per page
+           */
           .reduce((accumulator, {name, label: componentName = name}, componentIndex, components) => accumulator.concat(
             acceptList
-            /*
-             *  And each upload component may have several uploads
-             */
-              .filter(({fieldName}) => getUploadControlName(fieldName) === name)
-            /*
-             *  Ensure the uploads are sorted in order of upload
-             */
+              /*
+               *  And each upload component may have several uploads
+               */
+              .filter(({fieldName}) => getComponentName(fieldName) === name)
+              /*
+               *  Ensure the uploads are sorted in order of upload
+               */
               .sort(({timestamp: alpha}, {timestamp: omega}) => new Date(alpha).valueOf() - new Date(omega).valueOf())
-            /*
-             *  Create the content for the summary list row
-             */
+              /*
+               *  Create the content for the summary list row
+               */
               .map(({originalname, size, uuid}, componentUploadIndex, componentUploads) => {
                 const count = componentUploadIndex + 1
                 const rowIndiciaText = getString('uploadSummary.summaryList.row.indicia', lang)
@@ -248,15 +266,15 @@ module.exports = class UploadSummaryController extends CommonController {
 
         const count = Array.isArray(fieldName) ? fieldName.length : 1
 
-        const maxFiles = uploadPageControls.reduce((max, component) => Math.max(max, getUploadedMaxFiles(component)), 0)
-        const minFiles = uploadPageControls.reduce((min, component) => Math.max(min, getUploadedMinFiles(component)), 0) // Math.max!
+        const maxFiles = uploadPageControls.reduce((max, component) => Math.max(max, getComponentMaxFiles(component)), 0)
+        const minFiles = uploadPageControls.reduce((min, component) => Math.max(min, getComponentMinFiles(component)), 0) // Math.max!
 
-        const hasMaxFiles = uploadPageControls.every((component) => hasAcceptedMaxFiles(component, userData))
-        const hasMinFiles = uploadPageControls.every((component) => hasAcceptedMinFiles(component, userData))
+        const hasMaxFiles = uploadPageControls.every((component) => hasComponentAcceptedMaxFiles(component, userData))
+        const hasMinFiles = uploadPageControls.every((component) => hasComponentAcceptedMinFiles(component, userData))
 
         /*
-     *  The sum of all components' uploads
-     */
+         *  The sum of all components' uploads
+         */
         const uploadCount = uploadList.length
 
         uploadSummary.uploadPage = uploadPage
@@ -272,7 +290,7 @@ module.exports = class UploadSummaryController extends CommonController {
           {count}, {lang}
         )
 
-        if (hasAcceptedMaxFilesForUploadControls(uploadPageInstance, userData)) {
+        if (hasComponentsAcceptedMaxFiles(uploadPageInstance, userData)) {
           pageInstance.components = components.concat(uploadSummary)
         } else {
           pageInstance.components = components.concat(uploadSummary, createRadios(userData, count))
@@ -284,8 +302,8 @@ module.exports = class UploadSummaryController extends CommonController {
   }
 
   /*
- *  POST
- */
+   *  POST
+   */
   async postValidation (pageInstance, userData) {
     const {
       uploadPage
@@ -296,10 +314,10 @@ module.exports = class UploadSummaryController extends CommonController {
     if (this.hasRemoveUpload(userData)) {
       const upload = this.getRemoveUpload(userData)
 
-      if (hasAcceptedFileByUUID(userData, upload)) {
-        const uploadItem = getAcceptedFileByUUID(userData, upload)
+      if (hasComponentAcceptedFileByUUID(userData, upload)) {
+        const uploadItem = getComponentAcceptedFileByUUID(userData, upload)
 
-        removeFromAcceptedFiles(userData, uploadItem)
+        removeFromComponentAcceptedFiles(userData, uploadItem)
 
         userData.setFlashMessage({
           type: 'file.removed',

--- a/lib/middleware/routes-metadata/routes-metadata.js
+++ b/lib/middleware/routes-metadata/routes-metadata.js
@@ -90,7 +90,9 @@ function metadataRouter () {
 }
 
 const handleRedirectUrl = async (res, {url, changePage, params = {}} = {}, {contentLang}) => res.redirect(getUrl(getRedirectUrl(url, changePage), params, contentLang))
+
 const handleRedirect = async (res, {redirect, params = {}} = {}, {contentLang}) => res.redirect(getUrl(redirect, params, contentLang))
+
 const hasRedirectUrl = ({url, changePage, params = {}} = {}, {contentLang}) => hasUrl(getRedirectUrl(url, changePage), params, contentLang)
 
 const hasRedirect = (pageInstance = {}) => Reflect.has(pageInstance, 'redirect')
@@ -153,7 +155,7 @@ async function executePreFlight (pageInstance, userData, ...args) {
   const componentInstances = jsonPath.query(pageInstance, '$..[?(@._type)]')
   for await (const componentInstance of componentInstances) {
     await getComponentController(componentInstance)
-      .preFlight(componentInstance, userData, pageInstance)
+      .preFlight(componentInstance, userData, pageInstance, ...args)
   }
 
   return pageInstance
@@ -169,7 +171,7 @@ async function executeSetContents (pageInstance, userData, ...args) {
   const componentInstances = jsonPath.query(pageInstance, '$..[?(@._type)]')
   for await (const componentInstance of componentInstances) {
     await getComponentController(componentInstance)
-      .setContents(componentInstance, userData, pageInstance)
+      .setContents(componentInstance, userData, pageInstance, ...args)
   }
 
   return pageInstance
@@ -185,7 +187,7 @@ async function executePostValidation (pageInstance, userData, ...args) {
   const componentInstances = jsonPath.query(pageInstance, '$..[?(@._type)]')
   for await (const componentInstance of componentInstances) {
     await getComponentController(componentInstance)
-      .postValidation(componentInstance, userData, pageInstance)
+      .postValidation(componentInstance, userData, pageInstance, ...args)
   }
 
   return pageInstance
@@ -201,7 +203,7 @@ async function executePreUpdateContents (pageInstance, userData, ...args) {
   const componentInstances = jsonPath.query(pageInstance, '$..[?(@._type)]')
   for await (const componentInstance of componentInstances) {
     await getComponentController(componentInstance)
-      .preUpdateContents(componentInstance, userData, pageInstance)
+      .preUpdateContents(componentInstance, userData, pageInstance, ...args)
   }
 
   return pageInstance
@@ -217,7 +219,7 @@ async function executePreRender (pageInstance, userData, ...args) {
   const componentInstances = jsonPath.query(pageInstance, '$..[?(@._type)]')
   for await (const componentInstance of componentInstances) {
     await getComponentController(componentInstance)
-      .preRender(componentInstance, userData, pageInstance)
+      .preRender(componentInstance, userData, pageInstance, ...args)
   }
 
   return pageInstance

--- a/lib/middleware/routes-metadata/routes-metadata.js
+++ b/lib/middleware/routes-metadata/routes-metadata.js
@@ -103,7 +103,7 @@ const isConfirmationPage = ({_type}) => _type === 'page.confirmation'
 const isUploadCheckPage = ({_type}) => _type === 'page.uploadCheck'
 const isUploadSummaryPage = ({_type}) => _type === 'page.uploadSummary'
 const hasFileUploadComponents = ({components = []}) => components.some(({_type}) => _type === 'fileupload')
-const hasComponents = ({components = []}) => components.some(({_type}) => _type === 'upload')
+const hasUploadComponents = ({components = []}) => components.some(({_type}) => _type === 'upload')
 
 async function handleUploadCheckPage (res, pageInstance, userData) {
   const pageController = getPageController(pageInstance)
@@ -373,7 +373,7 @@ async function pageHandler (req, res) {
 
     {
       const hasFileUploads = hasFileUploadComponents(pageInstance) // components.some(({_type}) => 'fileupload')
-      const hasUploads = hasComponents(pageInstance) // components.some(({_type}) => 'upload')
+      const hasUploads = hasUploadComponents(pageInstance) // components.some(({_type}) => 'upload')
 
       if (hasFileUploads || hasUploads) {
         /*

--- a/lib/middleware/routes-metadata/routes-metadata.js
+++ b/lib/middleware/routes-metadata/routes-metadata.js
@@ -91,7 +91,6 @@ function metadataRouter () {
 
 const handleRedirectUrl = async (res, {url, changePage, params = {}} = {}, {contentLang}) => res.redirect(getUrl(getRedirectUrl(url, changePage), params, contentLang))
 const handleRedirect = async (res, {redirect, params = {}} = {}, {contentLang}) => res.redirect(getUrl(redirect, params, contentLang))
-
 const hasRedirectUrl = ({url, changePage, params = {}} = {}, {contentLang}) => hasUrl(getRedirectUrl(url, changePage), params, contentLang)
 
 const hasRedirect = (pageInstance = {}) => Reflect.has(pageInstance, 'redirect')
@@ -102,7 +101,7 @@ const isConfirmationPage = ({_type}) => _type === 'page.confirmation'
 const isUploadCheckPage = ({_type}) => _type === 'page.uploadCheck'
 const isUploadSummaryPage = ({_type}) => _type === 'page.uploadSummary'
 const hasFileUploadComponents = ({components = []}) => components.some(({_type}) => _type === 'fileupload')
-const hasUploadComponents = ({components = []}) => components.some(({_type}) => _type === 'upload')
+const hasComponents = ({components = []}) => components.some(({_type}) => _type === 'upload')
 
 async function handleUploadCheckPage (res, pageInstance, userData) {
   const pageController = getPageController(pageInstance)
@@ -248,6 +247,7 @@ async function pageHandler (req, res) {
   } = req
 
   let handlerData = getData(url)
+
   if (!handlerData && url.match(/\/change/)) {
     url = url.replace(/\/change(\/.+){0,1}$/, (m, m1) => {
       CHANGEPAGE = m1 || true
@@ -371,7 +371,7 @@ async function pageHandler (req, res) {
 
     {
       const hasFileUploads = hasFileUploadComponents(pageInstance) // components.some(({_type}) => 'fileupload')
-      const hasUploads = hasUploadComponents(pageInstance) // components.some(({_type}) => 'upload')
+      const hasUploads = hasComponents(pageInstance) // components.some(({_type}) => 'upload')
 
       if (hasFileUploads || hasUploads) {
         /*

--- a/lib/page/process-uploads/get-allowed-upload-controls.js
+++ b/lib/page/process-uploads/get-allowed-upload-controls.js
@@ -1,11 +1,11 @@
 require('@ministryofjustice/module-alias/register-module')(module)
 
 const {
-  getUploadedMaxFiles
+  getComponentMaxFiles
 } = require('~/fb-runner-node/page/utils/utils-uploads')
 
 const {
-  getUploadFieldName
+  getFieldName
 } = require('~/fb-runner-node/page/utils/utils-controls')
 
 module.exports = function getAllowedUploadControls (uploadControls) {
@@ -14,13 +14,13 @@ module.exports = function getAllowedUploadControls (uploadControls) {
       name
     } = control
 
-    const maxFiles = getUploadedMaxFiles(control)
+    const maxFiles = getComponentMaxFiles(control)
     let count = 1
     const limit = maxFiles + 1
 
     while (count < limit) {
       accumulator.push({
-        name: getUploadFieldName(name, count),
+        name: getFieldName(name, count),
         maxCount: 1
       })
 

--- a/lib/page/process-uploads/get-allowed-upload-controls.js
+++ b/lib/page/process-uploads/get-allowed-upload-controls.js
@@ -8,8 +8,8 @@ const {
   getFieldName
 } = require('~/fb-runner-node/page/utils/utils-controls')
 
-module.exports = function getAllowedUploadControls (uploadControls) {
-  return uploadControls.reduce((accumulator, control) => {
+module.exports = function getAllowedComponents (components) {
+  return components.reduce((accumulator, control) => {
     const {
       name
     } = control

--- a/lib/page/process-uploads/get-allowed-upload-controls.unit.spec.js
+++ b/lib/page/process-uploads/get-allowed-upload-controls.unit.spec.js
@@ -1,17 +1,17 @@
 const test = require('tape')
 
-const getAllowedUploadControls = require('./get-allowed-upload-controls')
+const getAllowedComponents = require('./get-allowed-upload-controls')
 
-const uploadControlsMaxFiles = [{
+const componentsMaxFiles = [{
   name: 'test',
   maxFiles: 2
 }]
 
-const uploadControlsNoMaxFiles = [{
+const componentsNoMaxFiles = [{
   name: 'test'
 }]
 
-const uploadControlsMultiple = [{
+const componentsMultiple = [{
   name: 'test',
   maxFiles: 2
 }, {
@@ -19,9 +19,9 @@ const uploadControlsMultiple = [{
 }]
 
 test('Without `maxFiles`', t => {
-  const allowedUploadControls = getAllowedUploadControls(uploadControlsNoMaxFiles)
+  const allowedComponents = getAllowedComponents(componentsNoMaxFiles)
 
-  t.deepEqual(allowedUploadControls, [{
+  t.deepEqual(allowedComponents, [{
     name: 'test[1]',
     maxCount: 1
   }], 'returns one of one')
@@ -30,9 +30,9 @@ test('Without `maxFiles`', t => {
 })
 
 test('With `maxFiles`', t => {
-  const allowedUploadControls = getAllowedUploadControls(uploadControlsMaxFiles)
+  const allowedComponents = getAllowedComponents(componentsMaxFiles)
 
-  t.deepEqual(allowedUploadControls, [{
+  t.deepEqual(allowedComponents, [{
     name: 'test[1]',
     maxCount: 1
   }, {
@@ -44,9 +44,9 @@ test('With `maxFiles`', t => {
 })
 
 test('With and without `maxFiles` for multiple controls', t => {
-  const allowedUploadControls = getAllowedUploadControls(uploadControlsMultiple)
+  const allowedComponents = getAllowedComponents(componentsMultiple)
 
-  t.deepEqual(allowedUploadControls, [{
+  t.deepEqual(allowedComponents, [{
     name: 'test[1]',
     maxCount: 1
   }, {

--- a/lib/page/process-uploads/process-upload-controls.js
+++ b/lib/page/process-uploads/process-upload-controls.js
@@ -1,5 +1,10 @@
 require('@ministryofjustice/module-alias/register-module')(module)
 
+const debug = require('debug')
+const error = debug('runner:process-components')
+
+debug.enable('runner:*')
+
 const proxyquire = require('proxyquire')
 
 const makeMiddleware = require('./multer/lib/make-middleware')
@@ -12,10 +17,10 @@ const {UPLOADS_DIR} = require('~/fb-runner-node/constants/constants')
 const {getString} = require('~/fb-runner-node/service-data/service-data')
 const {format} = require('~/fb-runner-node/format/format')
 
-async function processUploadControls (userData, uploadControls, expectedUploadControls) {
+async function processComponents (userData, components, expectedComponents) {
   return new Promise((resolve, reject) => {
     const {req} = userData
-    const maxFileSize = Math.max(...uploadControls.map(control => control.maxSize), 0)
+    const maxFileSize = Math.max(...components.map(control => control.maxSize), 0)
 
     const upload = multer({
       limits: {
@@ -24,16 +29,12 @@ async function processUploadControls (userData, uploadControls, expectedUploadCo
       dest: UPLOADS_DIR
     })
 
-    const uploadFieldsParser = upload.fields(expectedUploadControls)
+    const componentFieldsParser = upload.fields(expectedComponents)
 
     // NB. passing null for res here
 
-    uploadFieldsParser(req, null, (err) => {
-      if (err instanceof multer.MulterError) {
-        // A Multer error occurred when uploading.
-      } else if (err) {
-        // An unknown error occurred when uploading.
-      }
+    componentFieldsParser(req, null, (err) => {
+      if (err) error(err)
 
       userData.setBodyInput(req.body)
 
@@ -67,4 +68,4 @@ async function processUploadControls (userData, uploadControls, expectedUploadCo
   })
 }
 
-module.exports = processUploadControls
+module.exports = processComponents

--- a/lib/page/process-uploads/process-upload-controls.unit.spec.js
+++ b/lib/page/process-uploads/process-upload-controls.unit.spec.js
@@ -27,11 +27,11 @@ getStringStub.returns('Successfully removed {filename}')
 
 const {getUserDataMethods} = require('~/fb-runner-node/middleware/user-data/user-data')
 
-const processUploadControls = proxyquire('./process-upload-controls', {
+const processComponents = proxyquire('./process-upload-controls', {
   multer: multerStub
 })
 
-test('`processUploadControls` is called (fileupload)', async t => {
+test('`processComponents` is called (fileupload)', async t => {
   const userData = {
     req: {
       body: {}
@@ -43,12 +43,12 @@ test('`processUploadControls` is called (fileupload)', async t => {
   const setBodyInputStub = sinon.stub(userData, 'setBodyInput')
   setBodyInputStub.returns({})
 
-  const uploadControls = [{
+  const components = [{
     _type: 'fileupload',
     maxSize: 5 * 1024 * 1024
   }]
-  const allowedUploadControls = [{fieldname: 'test[1]', maxCount: 1}]
-  const {files, fileErrors} = await processUploadControls(userData, uploadControls, allowedUploadControls)
+  const allowedComponents = [{fieldname: 'test[1]', maxCount: 1}]
+  const {files, fileErrors} = await processComponents(userData, components, allowedComponents)
 
   t.plan(4)
   t.deepEqual(files, ['a', 'b'], 'it should return the files parsed by multer')
@@ -60,7 +60,7 @@ test('`processUploadControls` is called (fileupload)', async t => {
   t.end()
 })
 
-test('`processUploadControls` is called (upload)', async t => {
+test('`processComponents` is called (upload)', async t => {
   const userData = {
     req: {
       body: {}
@@ -72,12 +72,12 @@ test('`processUploadControls` is called (upload)', async t => {
   const setBodyInputStub = sinon.stub(userData, 'setBodyInput')
   setBodyInputStub.returns({})
 
-  const uploadControls = [{
+  const components = [{
     _type: 'upload',
     maxSize: 5 * 1024 * 1024
   }]
-  const allowedUploadControls = [{fieldname: 'test[1]', maxCount: 1}]
-  const {files, fileErrors} = await processUploadControls(userData, uploadControls, allowedUploadControls)
+  const allowedComponents = [{fieldname: 'test[1]', maxCount: 1}]
+  const {files, fileErrors} = await processComponents(userData, components, allowedComponents)
 
   t.plan(4)
   t.deepEqual(files, ['a', 'b'], 'it should return the files parsed by multer')
@@ -106,12 +106,12 @@ test('Removing an upload (fileupload) ', async t => {
   const setUserDataPropertyStub = sinon.stub(userData, 'setUserDataProperty')
   const setFlashMessageStub = sinon.stub(userData, 'setFlashMessage')
 
-  const uploadControls = [{
+  const components = [{
     _type: 'fileupload',
     maxSize: 5 * 1024 * 1024
   }]
-  const allowedUploadControls = [{fieldname: 'test[1]', maxCount: 1}]
-  await processUploadControls(userData, uploadControls, allowedUploadControls)
+  const allowedComponents = [{fieldname: 'test[1]', maxCount: 1}]
+  await processComponents(userData, components, allowedComponents)
 
   t.plan(4)
   t.deepEqual(getUserDataPropertyStub.getCall(0).args, ['foo'], 'it should retrieve the correct user data property')
@@ -144,12 +144,12 @@ test('Removing an upload (upload) ', async t => {
   const setUserDataPropertyStub = sinon.stub(userData, 'setUserDataProperty')
   const setFlashMessageStub = sinon.stub(userData, 'setFlashMessage')
 
-  const uploadControls = [{
+  const components = [{
     _type: 'upload',
     maxSize: 5 * 1024 * 1024
   }]
-  const allowedUploadControls = [{fieldname: 'test[1]', maxCount: 1}]
-  await processUploadControls(userData, uploadControls, allowedUploadControls)
+  const allowedComponents = [{fieldname: 'test[1]', maxCount: 1}]
+  await processComponents(userData, components, allowedComponents)
 
   t.plan(4)
   t.deepEqual(getUserDataPropertyStub.getCall(0).args, ['foo'], 'it should retrieve the correct user data property')
@@ -182,12 +182,12 @@ test('Removing an upload when a property has multiple uploads (fileupload)', asy
   const unsetUserDataPropertyStub = sinon.stub(userData, 'unsetUserDataProperty')
   const setUserDataPropertyStub = sinon.stub(userData, 'setUserDataProperty')
 
-  const uploadControls = [{
+  const components = [{
     _type: 'fileupload',
     maxSize: 5 * 1024 * 1024
   }]
-  const allowedUploadControls = [{fieldname: 'test[1]', maxCount: 1}]
-  await processUploadControls(userData, uploadControls, allowedUploadControls)
+  const allowedComponents = [{fieldname: 'test[1]', maxCount: 1}]
+  await processComponents(userData, components, allowedComponents)
 
   t.plan(3)
   t.deepEqual(getUserDataPropertyStub.getCall(0).args, ['foo'], 'it should retrieve the correct user data property')
@@ -214,12 +214,12 @@ test('Removing an upload when a property has multiple uploads (upload)', async t
   const unsetUserDataPropertyStub = sinon.stub(userData, 'unsetUserDataProperty')
   const setUserDataPropertyStub = sinon.stub(userData, 'setUserDataProperty')
 
-  const uploadControls = [{
+  const components = [{
     _type: 'upload',
     maxSize: 5 * 1024 * 1024
   }]
-  const allowedUploadControls = [{fieldname: 'test[1]', maxCount: 1}]
-  await processUploadControls(userData, uploadControls, allowedUploadControls)
+  const allowedComponents = [{fieldname: 'test[1]', maxCount: 1}]
+  await processComponents(userData, components, allowedComponents)
 
   t.plan(3)
   t.deepEqual(getUserDataPropertyStub.getCall(0).args, ['foo'], 'it should retrieve the correct user data property')
@@ -241,12 +241,12 @@ test('Trying to remove an upload which does not exist (fileupload)', async t => 
   const unsetUserDataPropertyStub = sinon.stub(userData, 'unsetUserDataProperty')
   const setUserDataPropertyStub = sinon.stub(userData, 'setUserDataProperty')
 
-  const uploadControls = [{
+  const components = [{
     _type: 'fileupload',
     maxSize: 5 * 1024 * 1024
   }]
-  const allowedUploadControls = [{fieldname: 'test[1]', maxCount: 1}]
-  await processUploadControls(userData, uploadControls, allowedUploadControls)
+  const allowedComponents = [{fieldname: 'test[1]', maxCount: 1}]
+  await processComponents(userData, components, allowedComponents)
 
   t.plan(3)
   t.deepEqual(getUserDataPropertyStub.getCall(0).args, ['foo'], 'it should retrieve the correct user data property')
@@ -268,12 +268,12 @@ test('Trying to remove an upload which does not exist (upload)', async t => {
   const unsetUserDataPropertyStub = sinon.stub(userData, 'unsetUserDataProperty')
   const setUserDataPropertyStub = sinon.stub(userData, 'setUserDataProperty')
 
-  const uploadControls = [{
+  const components = [{
     _type: 'upload',
     maxSize: 5 * 1024 * 1024
   }]
-  const allowedUploadControls = [{fieldname: 'test[1]', maxCount: 1}]
-  await processUploadControls(userData, uploadControls, allowedUploadControls)
+  const allowedComponents = [{fieldname: 'test[1]', maxCount: 1}]
+  await processComponents(userData, components, allowedComponents)
 
   t.plan(3)
   t.deepEqual(getUserDataPropertyStub.getCall(0).args, ['foo'], 'it should retrieve the correct user data property')

--- a/lib/page/process-uploads/process-uploaded-files.js
+++ b/lib/page/process-uploads/process-uploaded-files.js
@@ -16,33 +16,33 @@ const {
 const hasFieldName = ({getBodyInput}) => Reflect.has(getBodyInput(), 'fieldName')
 const getFieldName = ({getBodyInput}) => Reflect.get(getBodyInput(), 'fieldName')
 
-function processUploadedFilesForFieldName (userData, files, fieldName, uploadControls) {
+function processComponentFilesByFieldName (userData, files, fieldName, components) {
   if (!Reflect.has(files, fieldName)) {
-    const controlName = getComponentName(fieldName)
-    const control = uploadControls.find(({name}) => controlName === name)
+    const componentName = getComponentName(fieldName)
+    const component = components.find(({name}) => componentName === name)
 
-    const was = getComponentFiles(control, userData)
+    const was = getComponentFiles(component, userData)
 
     const now = was.filter(({fieldname}) => fieldname === fieldName)
 
     if (now.length) {
-      setComponentFiles(control, now, userData)
+      setComponentFiles(component, now, userData)
     } else {
-      clearComponentFiles(control, userData)
+      clearComponentFiles(component, userData)
     }
   }
 }
 
-const mapUploadedFilesToFieldName = (userData, files, uploadControls) => (fieldName) => processUploadedFilesForFieldName(userData, files, fieldName, uploadControls)
+const mapComponentFilesToFieldName = (userData, files, components) => (fieldName) => processComponentFilesByFieldName(userData, files, fieldName, components)
 
-module.exports = async function processUploadedFiles (pageInstance, userData, {files, fileErrors = {}}, uploadControls, expectedControls = {}) {
+module.exports = async function processComponentFiles (pageInstance, userData, {files, fileErrors = {}}, components, expectedControls = {}) {
   if (hasFieldName(userData)) {
     const fieldName = getFieldName(userData)
 
     if (Array.isArray(fieldName)) {
-      fieldName.forEach(mapUploadedFilesToFieldName(userData, files, uploadControls))
+      fieldName.forEach(mapComponentFilesToFieldName(userData, files, components))
     } else {
-      processUploadedFilesForFieldName(userData, files, fieldName, uploadControls)
+      processComponentFilesByFieldName(userData, files, fieldName, components)
     }
   }
 
@@ -52,19 +52,19 @@ module.exports = async function processUploadedFiles (pageInstance, userData, {f
      *  The field value is an array, and `file` is its first item
      */
     .forEach(([fieldName, [file]], index) => {
-      const controlName = getComponentName(fieldName)
-      const control = uploadControls.find(({name}) => controlName === name)
+      const componentName = getComponentName(fieldName)
+      const component = components.find(({name}) => componentName === name)
 
-      const maxFiles = getComponentMaxFiles(control)
-      const minFiles = getComponentMinFiles(control)
-      const maxSize = getComponentMaxSize(control)
+      const maxFiles = getComponentMaxFiles(component)
+      const minFiles = getComponentMinFiles(component)
+      const maxSize = getComponentMaxSize(component)
 
       const {
         validation: {
           accept
         } = {},
         expires
-      } = control
+      } = component
 
       file.maxFiles = maxFiles
       file.minFiles = minFiles

--- a/lib/page/process-uploads/process-uploaded-files.js
+++ b/lib/page/process-uploads/process-uploaded-files.js
@@ -1,16 +1,16 @@
 require('@ministryofjustice/module-alias/register-module')(module)
 
 const {
-  getUploadControlName
+  getComponentName
 } = require('~/fb-runner-node/page/utils/utils-controls')
 
 const {
-  getUploadedFiles,
-  setUploadedFiles,
-  getUploadedMaxFiles,
-  getUploadedMinFiles,
-  getUploadedMaxSize,
-  clearUploadedFiles
+  getComponentFiles,
+  setComponentFiles,
+  getComponentMaxFiles,
+  getComponentMinFiles,
+  getComponentMaxSize,
+  clearComponentFiles
 } = require('~/fb-runner-node/page/utils/utils-uploads')
 
 const hasFieldName = ({getBodyInput}) => Reflect.has(getBodyInput(), 'fieldName')
@@ -18,17 +18,17 @@ const getFieldName = ({getBodyInput}) => Reflect.get(getBodyInput(), 'fieldName'
 
 function processUploadedFilesForFieldName (userData, files, fieldName, uploadControls) {
   if (!Reflect.has(files, fieldName)) {
-    const controlName = getUploadControlName(fieldName)
+    const controlName = getComponentName(fieldName)
     const control = uploadControls.find(({name}) => controlName === name)
 
-    const was = getUploadedFiles(control, userData)
+    const was = getComponentFiles(control, userData)
 
     const now = was.filter(({fieldname}) => fieldname === fieldName)
 
     if (now.length) {
-      setUploadedFiles(control, now, userData)
+      setComponentFiles(control, now, userData)
     } else {
-      clearUploadedFiles(control, userData)
+      clearComponentFiles(control, userData)
     }
   }
 }
@@ -52,12 +52,12 @@ module.exports = async function processUploadedFiles (pageInstance, userData, {f
      *  The field value is an array, and `file` is its first item
      */
     .forEach(([fieldName, [file]], index) => {
-      const controlName = getUploadControlName(fieldName)
+      const controlName = getComponentName(fieldName)
       const control = uploadControls.find(({name}) => controlName === name)
 
-      const maxFiles = getUploadedMaxFiles(control)
-      const minFiles = getUploadedMinFiles(control)
-      const maxSize = getUploadedMaxSize(control)
+      const maxFiles = getComponentMaxFiles(control)
+      const minFiles = getComponentMinFiles(control)
+      const maxSize = getComponentMaxSize(control)
 
       const {
         validation: {

--- a/lib/page/process-uploads/process-uploaded-files.unit.spec.js
+++ b/lib/page/process-uploads/process-uploaded-files.unit.spec.js
@@ -1,6 +1,6 @@
 const test = require('tape')
 const sinon = require('sinon')
-const processUploadedFiles = require('./process-uploaded-files')
+const processComponentFiles = require('./process-uploaded-files')
 
 const fileUploadControl = [{
   _type: 'fileupload',
@@ -38,7 +38,7 @@ const userData = {getUserDataProperty: () => sinon.stub().returns([]), getBodyIn
 test('The `accept` property is not present (fileupload)', async t => {
   const {
     files
-  } = await processUploadedFiles(pageInstance, userData, uploadedFiles, fileUploadControl)
+  } = await processComponentFiles(pageInstance, userData, uploadedFiles, fileUploadControl)
 
   t.deepEqual(files.allowed_types, undefined, '`allowed_types` is undefined')
 
@@ -48,7 +48,7 @@ test('The `accept` property is not present (fileupload)', async t => {
 test('The `accept` property is not present (upload)', async t => {
   const {
     files
-  } = await processUploadedFiles(pageInstance, userData, uploadedFiles, uploadControl)
+  } = await processComponentFiles(pageInstance, userData, uploadedFiles, uploadControl)
 
   t.deepEqual(files.allowed_types, undefined, '`allowed_types` is undefined')
 
@@ -69,7 +69,7 @@ test('The `accept` property is an array (fileupload)', async t => {
 
   const {
     files
-  } = await processUploadedFiles(pageInstance, userData, uploadedFiles, fileUploadControlWithoutAccept)
+  } = await processComponentFiles(pageInstance, userData, uploadedFiles, fileUploadControlWithoutAccept)
 
   t.deepEqual(files.allowed_types, undefined, '`allowed_types` is undefined')
 
@@ -90,7 +90,7 @@ test('The `accept` property is an array (upload)', async t => {
 
   const {
     files
-  } = await processUploadedFiles(pageInstance, userData, uploadedFiles, uploadControlWithoutAccept)
+  } = await processComponentFiles(pageInstance, userData, uploadedFiles, uploadControlWithoutAccept)
 
   t.deepEqual(files.allowed_types, undefined, '`allowed_types` is undefined')
 
@@ -115,7 +115,7 @@ test('The `accept` property is an array of mimetypes (fileupload)', async t => {
         file
       ]
     }
-  } = await processUploadedFiles(pageInstance, userData, uploadedFiles, fileUploadControlWithAccept)
+  } = await processComponentFiles(pageInstance, userData, uploadedFiles, fileUploadControlWithAccept)
 
   t.deepEqual(file.allowed_types, ['application/pdf', 'image/png'], '`allowed_types` is an array of mimetypes')
 
@@ -140,7 +140,7 @@ test('The `accept` property is an array of mimetypes (upload)', async t => {
         file
       ]
     }
-  } = await processUploadedFiles(pageInstance, userData, uploadedFiles, uploadControlWithAccept)
+  } = await processComponentFiles(pageInstance, userData, uploadedFiles, uploadControlWithAccept)
 
   t.deepEqual(file.allowed_types, ['application/pdf', 'image/png'], '`allowed_types` is an array of mimetypes')
 
@@ -194,7 +194,7 @@ test('When an uploaded file is valid', async t => {
     const {
       files,
       fileErrors
-    } = await processUploadedFiles(pageInstance, userData, uploadedFilesWithoutFileErrors, fileUploadControl)
+    } = await processComponentFiles(pageInstance, userData, uploadedFilesWithoutFileErrors, fileUploadControl)
 
     t.deepEqual(files, uploadedFilesWithoutFileErrors.files, 'returns the `files` property of the uploaded files object')
     t.deepEqual(fileErrors, {}, 'returns an object when the `fileErrors` property of the uploaded files object does not exist')
@@ -204,7 +204,7 @@ test('When an uploaded file is valid', async t => {
     const {
       files,
       fileErrors
-    } = await processUploadedFiles(pageInstance, userData, uploadedFilesWithoutFileErrors, uploadControl)
+    } = await processComponentFiles(pageInstance, userData, uploadedFilesWithoutFileErrors, uploadControl)
 
     t.deepEqual(files, uploadedFilesWithoutFileErrors.files, 'returns the `files` property of the uploaded files object')
     t.deepEqual(fileErrors, {}, 'returns an object when the `fileErrors` property of the uploaded files object does not exist')
@@ -214,7 +214,7 @@ test('When an uploaded file is valid', async t => {
     const {
       files,
       fileErrors
-    } = await processUploadedFiles(pageInstance, userData, uploadedFilesWithErrors, fileUploadControl)
+    } = await processComponentFiles(pageInstance, userData, uploadedFilesWithErrors, fileUploadControl)
 
     t.deepEqual(files, uploadedFilesWithErrors.files, 'returns the `files` property of the uploaded files object')
     t.deepEqual(fileErrors, uploadedFilesWithErrors.fileErrors, 'returns the `fileErrors` property of the uploaded files object')
@@ -224,7 +224,7 @@ test('When an uploaded file is valid', async t => {
     const {
       files,
       fileErrors
-    } = await processUploadedFiles(pageInstance, userData, uploadedFilesWithErrors, uploadControl)
+    } = await processComponentFiles(pageInstance, userData, uploadedFilesWithErrors, uploadControl)
 
     t.deepEqual(files, uploadedFilesWithErrors.files, 'returns the `files` property of the uploaded files object')
     t.deepEqual(fileErrors, uploadedFilesWithErrors.fileErrors, 'returns the `fileErrors` property of the uploaded files object')
@@ -250,7 +250,7 @@ test('When an uploaded file is not valid', async t => {
     const {
       files,
       fileErrors
-    } = await processUploadedFiles(pageInstance, userData, uploadedFiles, fileUploadControl)
+    } = await processComponentFiles(pageInstance, userData, uploadedFiles, fileUploadControl)
 
     t.deepEqual(files, {}, 'removes the invalid file from the `files` object')
     t.deepEqual(fileErrors, {
@@ -285,7 +285,7 @@ test('When an uploaded file is not valid', async t => {
     const {
       files,
       fileErrors
-    } = await processUploadedFiles(pageInstance, userData, uploadedFiles, uploadControl)
+    } = await processComponentFiles(pageInstance, userData, uploadedFiles, uploadControl)
 
     t.deepEqual(files, {}, 'removes the invalid file from the `files` object')
     t.deepEqual(fileErrors, {

--- a/lib/page/process-uploads/process-uploads.js
+++ b/lib/page/process-uploads/process-uploads.js
@@ -4,10 +4,10 @@ const metrics = require('~/fb-runner-node/middleware/metrics/metrics')
 const prometheusClient = metrics.getClient()
 const csrf = require('~/fb-runner-node/middleware/csrf/csrf')
 
-const {getUploadControls} = require('~/fb-runner-node/page/utils/utils-uploads')
+const {getComponents} = require('~/fb-runner-node/page/utils/utils-uploads')
 
-const getAllowedUploadControls = require('./get-allowed-upload-controls')
-const processUploadControls = require('./process-upload-controls')
+const getAllowedComponents = require('./get-allowed-upload-controls')
+const processComponents = require('./process-upload-controls')
 const processUploadedFiles = require('./process-uploaded-files')
 const registerUploadErrors = require('./register-upload-errors')
 const storeUploadedFiles = require('./store-uploaded-files')
@@ -23,21 +23,21 @@ const processUploadsMetrics = new prometheusClient.Histogram({
   buckets
 })
 
-const uploadControlsMetrics = new prometheusClient.Histogram({
+const componentsMetrics = new prometheusClient.Histogram({
   name: 'process_uploads_get_upload_controls',
   help: 'Process file uploads for a request - determine upload controls for instance',
   labelNames,
   buckets
 })
 
-const allowedUploadControlsMetrics = new prometheusClient.Histogram({
+const allowedComponentsMetrics = new prometheusClient.Histogram({
   name: 'process_uploads_get_allowed_controls',
   help: 'Process file uploads for a request - determine allowed upload controls',
   labelNames,
   buckets
 })
 
-const processUploadControlsMetrics = new prometheusClient.Histogram({
+const processComponentsMetrics = new prometheusClient.Histogram({
   name: 'process_uploads_process_controls',
   help: 'Process file uploads for a request - process upload controls',
   labelNames,
@@ -72,17 +72,17 @@ module.exports = async function processUploads (pageInstance, userData) {
     // record complete process
     const endProcessUploadsMetrics = processUploadsMetrics.startTimer()
 
-    const endUploadControlsMetrics = uploadControlsMetrics.startTimer()
-    const uploadControls = getUploadControls(pageInstance)
-    endUploadControlsMetrics()
+    const endComponentsMetrics = componentsMetrics.startTimer()
+    const components = getComponents(pageInstance)
+    endComponentsMetrics()
 
-    const endAllowedUploadControlsMetrics = allowedUploadControlsMetrics.startTimer()
-    const allowedUploadControls = getAllowedUploadControls(uploadControls)
-    endAllowedUploadControlsMetrics()
+    const endAllowedComponentsMetrics = allowedComponentsMetrics.startTimer()
+    const allowedComponents = getAllowedComponents(components)
+    endAllowedComponentsMetrics()
 
-    const endProcessUploadControlsMetrics = processUploadControlsMetrics.startTimer()
-    const processedResults = await processUploadControls(userData, uploadControls, allowedUploadControls)
-    endProcessUploadControlsMetrics()
+    const endProcessComponentsMetrics = processComponentsMetrics.startTimer()
+    const processedResults = await processComponents(userData, components, allowedComponents)
+    endProcessComponentsMetrics()
 
     // only now has the multipart body been processed - check the csrf token
     try {
@@ -96,7 +96,7 @@ module.exports = async function processUploads (pageInstance, userData) {
     }
 
     const endProcessUploadedFilesMetrics = processUploadedFilesMetrics.startTimer()
-    const uploadResults = await processUploadedFiles(pageInstance, userData, processedResults, uploadControls, allowedUploadControls)
+    const uploadResults = await processUploadedFiles(pageInstance, userData, processedResults, components, allowedComponents)
     endProcessUploadedFilesMetrics()
 
     const endStoreUploadedFilesMetrics = storeUploadedFilesMetrics.startTimer()

--- a/lib/page/process-uploads/process-uploads.unit.spec.js
+++ b/lib/page/process-uploads/process-uploads.unit.spec.js
@@ -14,22 +14,22 @@ const validateCsrfStub = sinon.stub().callsFake(token => {
 })
 
 const utils = {
-  getUploadControls: () => {}
+  getComponents: () => {}
 }
 
 const saveDataStub = sinon.stub()
-const getUploadControlStub = sinon.stub(utils, 'getUploadControls')
+const getComponentsStub = sinon.stub(utils, 'getComponents')
 
-const getAllowedUploadControlsStub = sinon.stub()
-const processUploadControlsStub = sinon.stub()
+const getAllowedComponentsStub = sinon.stub()
+const processComponentsStub = sinon.stub()
 const processUploadedFilesStub = sinon.stub()
 const registerUploadErrorsStub = sinon.stub()
 const storeUploadedFilesStub = sinon.stub()
 
 const processUploads = proxyquire('./process-uploads', {
   '~/fb-runner-node/page/utils/utils-uploads': utils,
-  './get-allowed-upload-controls': getAllowedUploadControlsStub,
-  './process-upload-controls': processUploadControlsStub,
+  './get-allowed-upload-controls': getAllowedComponentsStub,
+  './process-upload-controls': processComponentsStub,
   './process-uploaded-files': processUploadedFilesStub,
   './register-upload-errors': registerUploadErrorsStub,
   './store-uploaded-files': storeUploadedFilesStub,
@@ -46,9 +46,9 @@ test('When processUploads is called when method is not POST', async t => {
   }
   await processUploads(pageInstance, userData)
 
-  t.equal(getUploadControlStub.notCalled, true, 'it should not call getUploadControls')
-  t.equal(getAllowedUploadControlsStub.notCalled, true, 'it should not call getAllowedUploadControls')
-  t.equal(processUploadControlsStub.notCalled, true, 'it should not call processUploadControls')
+  t.equal(getComponentsStub.notCalled, true, 'it should not call getComponents')
+  t.equal(getAllowedComponentsStub.notCalled, true, 'it should not call getAllowedComponents')
+  t.equal(processComponentsStub.notCalled, true, 'it should not call processComponents')
   t.equal(processUploadedFilesStub.notCalled, true, 'it should not call processUploadedFiles')
   t.equal(registerUploadErrorsStub.notCalled, true, 'it should not call registerUploadErrors')
   t.equal(storeUploadedFilesStub.notCalled, true, 'it should not call storeUploadedFiles')
@@ -66,9 +66,9 @@ test('When processUploads is called when encType is not true', async t => {
   }
   await processUploads(pageInstance, userData)
 
-  t.equal(getUploadControlStub.notCalled, true, 'it should not call getUploadControls')
-  t.equal(getAllowedUploadControlsStub.notCalled, true, 'it should not call getAllowedUploadControls')
-  t.equal(processUploadControlsStub.notCalled, true, 'it should not call processUploadControls')
+  t.equal(getComponentsStub.notCalled, true, 'it should not call getComponents')
+  t.equal(getAllowedComponentsStub.notCalled, true, 'it should not call getAllowedComponents')
+  t.equal(processComponentsStub.notCalled, true, 'it should not call processComponents')
   t.equal(processUploadedFilesStub.notCalled, true, 'it should not call processUploadedFiles')
   t.equal(registerUploadErrorsStub.notCalled, true, 'it should not call registerUploadErrors')
   t.equal(storeUploadedFilesStub.notCalled, true, 'it should not call storeUploadedFiles')
@@ -90,9 +90,9 @@ test('When processUploads is called when encType is true and method is POST', as
   }
   await processUploads(pageInstance, userData)
 
-  t.equal(getUploadControlStub.called, true, 'it should call getUploadControls')
-  t.equal(getAllowedUploadControlsStub.called, true, 'it should call getAllowedUploadControls')
-  t.equal(processUploadControlsStub.called, true, 'it should call processUploadControls')
+  t.equal(getComponentsStub.called, true, 'it should call getComponents')
+  t.equal(getAllowedComponentsStub.called, true, 'it should call getAllowedComponents')
+  t.equal(processComponentsStub.called, true, 'it should call processComponents')
   t.equal(processUploadedFilesStub.called, true, 'it should call processUploadedFiles')
   t.equal(registerUploadErrorsStub.called, true, 'it should call registerUploadErrors')
   t.equal(storeUploadedFilesStub.called, true, 'it should call storeUploadedFiles')

--- a/lib/page/process-uploads/register-upload-errors.js
+++ b/lib/page/process-uploads/register-upload-errors.js
@@ -26,16 +26,16 @@ module.exports = function registerUploadErrors (pageInstance, userData, fileErro
         errorList.forEach(({fieldname, errorMessage, originalname: filename}) => {
           const componentName = getComponentName(fieldname)
           const [
-            control = {}
+            component = {}
           ] = jsonPath.query(pageInstance, `$..[?(@.name === "${componentName}")]`)
 
-          const maxFiles = getComponentMaxFiles(control)
-          const minFiles = getComponentMinFiles(control)
+          const maxFiles = getComponentMaxFiles(component)
+          const minFiles = getComponentMinFiles(component)
           const isMultiple = maxFiles > 1 || minFiles > 1
 
           const {
             validation = {}
-          } = control
+          } = component
 
           const type = errorMessage || (isMultiple ? `${errorType}.multiple` : errorType)
 

--- a/lib/page/process-uploads/register-upload-errors.js
+++ b/lib/page/process-uploads/register-upload-errors.js
@@ -6,12 +6,12 @@ const {
 } = require('~/fb-runner-node/page/set-errors/set-errors')
 
 const {
-  getUploadControlName
+  getComponentName
 } = require('~/fb-runner-node/page/utils/utils-controls')
 
 const {
-  getUploadedMaxFiles,
-  getUploadedMinFiles
+  getComponentMaxFiles,
+  getComponentMinFiles
 } = require('~/fb-runner-node/page/utils/utils-uploads')
 
 const jsonPath = require('jsonpath')
@@ -24,13 +24,13 @@ module.exports = function registerUploadErrors (pageInstance, userData, fileErro
     Object.entries(fileErrors)
       .forEach(([errorType, errorList]) => {
         errorList.forEach(({fieldname, errorMessage, originalname: filename}) => {
-          const controlName = getUploadControlName(fieldname)
+          const componentName = getComponentName(fieldname)
           const [
             control = {}
-          ] = jsonPath.query(pageInstance, `$..[?(@.name === "${controlName}")]`)
+          ] = jsonPath.query(pageInstance, `$..[?(@.name === "${componentName}")]`)
 
-          const maxFiles = getUploadedMaxFiles(control)
-          const minFiles = getUploadedMinFiles(control)
+          const maxFiles = getComponentMaxFiles(control)
+          const minFiles = getComponentMinFiles(control)
           const isMultiple = maxFiles > 1 || minFiles > 1
 
           const {
@@ -39,7 +39,7 @@ module.exports = function registerUploadErrors (pageInstance, userData, fileErro
 
           const type = errorMessage || (isMultiple ? `${errorType}.multiple` : errorType)
 
-          addError(type, controlName, {
+          addError(type, componentName, {
             values: {
               filename,
               maxFiles,
@@ -47,7 +47,7 @@ module.exports = function registerUploadErrors (pageInstance, userData, fileErro
               maxSize: validation.maxSize,
               accept: validation.accept
             },
-            target: `${controlName}[1]`
+            target: `${componentName}[1]`
           })
         })
       })

--- a/lib/page/process-uploads/store-uploaded-files.js
+++ b/lib/page/process-uploads/store-uploaded-files.js
@@ -4,8 +4,8 @@ const fs = require('fs')
 const uuid = require('uuid')
 
 const {
-  getUploadControlName,
-  getUploadControlType
+  getComponentName,
+  getComponentType
 } = require('~/fb-runner-node/page/utils/utils-controls')
 
 const {
@@ -61,8 +61,8 @@ const storeUploadedFiles = async (pageInstance, userData, {files, fileErrors} = 
         originalname
       } = omega
 
-      const controlName = getUploadControlName(fieldname)
-      const controlType = getUploadControlType(pageInstance, fieldname)
+      const controlName = getComponentName(fieldname)
+      const controlType = getComponentType(pageInstance, fieldname)
 
       /*
        *  To keep `fileupload` as-is

--- a/lib/page/process-uploads/store-uploaded-files.unit.spec.js
+++ b/lib/page/process-uploads/store-uploaded-files.unit.spec.js
@@ -34,8 +34,8 @@ const userData = {
 const setUserDataPropertyStub = stub(userData, 'setUserDataProperty')
 const setFlashMessageStub = stub(userData, 'setFlashMessage')
 const setSuccessfulUploadStub = stub(userData, 'setSuccessfulUpload')
-const getUploadControlNameStub = stub()
-const getUploadControlTypeStub = stub()
+const getComponentNameStub = stub()
+const getComponentTypeStub = stub()
 const uuid = require('uuid')
 const uuidStub = stub(uuid, 'v4')
 uuidStub.callsFake(() => 'uuid')
@@ -43,8 +43,8 @@ uuidStub.callsFake(() => 'uuid')
 const storeUploadedFiles = proxyquire('./store-uploaded-files', {
   fs: fs,
   '~/fb-runner-node/page/utils/utils-controls': {
-    getUploadControlName: getUploadControlNameStub,
-    getUploadControlType: getUploadControlTypeStub
+    getComponentName: getComponentNameStub,
+    getComponentType: getComponentTypeStub
   },
   '~/fb-runner-node/client/user/filestore/filestore': userFileStoreClient,
   '~/fb-runner-node/service-data/service-data': serviceData
@@ -65,8 +65,8 @@ test('When storeUploadedFiles is passed a list of uploaded files to store', asyn
     }
   }
 
-  getUploadControlNameStub.returns('mock control name')
-  getUploadControlTypeStub.returns('fileupload')
+  getComponentNameStub.returns('mock component name')
+  getComponentTypeStub.returns('fileupload')
 
   const fileErrors = await storeUploadedFiles(pageInstance, userData, uploadedResults)
 
@@ -86,7 +86,7 @@ test('When storeUploadedFiles is passed a list of uploaded files to store', asyn
 
   const setUserDataPropertyStubArgs = setUserDataPropertyStub.getCall(0).args
 
-  t.deepEqual(setUserDataPropertyStubArgs[0], 'mock control name', 'it should update the correct user data property')
+  t.deepEqual(setUserDataPropertyStubArgs[0], 'mock component name', 'it should update the correct user data property')
 
   t.deepEqual(setUserDataPropertyStubArgs[1], [
     {
@@ -110,7 +110,7 @@ test('When storeUploadedFiles is passed a list of uploaded files to store', asyn
 
   const setSuccessfulUploadStubArgs = setSuccessfulUploadStub.getCall(0).args
 
-  t.deepEqual(setSuccessfulUploadStubArgs[0], 'mock control name', 'it should increment the field’s successful file upload count')
+  t.deepEqual(setSuccessfulUploadStubArgs[0], 'mock component name', 'it should increment the field’s successful file upload count')
 
   t.deepEqual(fsUnlinkStub.getCall(0).args[0], '/tmp/uploadedfilehash', 'it should delete the file after it has been uploaded')
 
@@ -120,8 +120,8 @@ test('When storeUploadedFiles is passed a list of uploaded files to store', asyn
   fsUnlinkStub.resetHistory()
   FBUserFileStoreClientStub.resetHistory()
 
-  getUploadControlNameStub.reset()
-  getUploadControlTypeStub.reset()
+  getComponentNameStub.reset()
+  getComponentTypeStub.reset()
 })
 
 test('When storeUploadedFiles is passed a files with policy properties', async t => {

--- a/lib/page/redirect-next-page/redirect-next-page.js
+++ b/lib/page/redirect-next-page/redirect-next-page.js
@@ -33,19 +33,20 @@ function checkNextPage (changePage, currentPage, userData) {
 
   const {_id} = nextPage
 
-  let nextPageInstance = getInstance(_id)
-  nextPageInstance = skipPage(nextPageInstance, userData)
+  if (_id !== userData.getUserDataProperty('uploadPage')) {
+    let nextPageInstance = getInstance(_id)
+    nextPageInstance = skipPage(nextPageInstance, userData)
 
-  if (!nextPageInstance.redirect) {
-    nextPageInstance = setControlNames(nextPageInstance, userData)
-    nextPageInstance = setRepeatable(nextPageInstance, userData)
-    nextPageInstance = setComposite(nextPageInstance, userData)
-    nextPageInstance = skipComponents(nextPageInstance, userData)
+    if (!nextPageInstance.redirect) {
+      nextPageInstance = setControlNames(nextPageInstance, userData)
+      nextPageInstance = setRepeatable(nextPageInstance, userData)
+      nextPageInstance = setComposite(nextPageInstance, userData)
+      nextPageInstance = skipComponents(nextPageInstance, userData)
+      nextPageInstance = validateInput(nextPageInstance, userData)
 
-    nextPageInstance = validateInput(nextPageInstance, userData)
-
-    if (!nextPageInstance.$validated) {
-      return nextPage
+      if (!nextPageInstance.$validated) {
+        return nextPage
+      }
     }
   }
 

--- a/lib/page/redirect-next-page/redirect-next-page.js
+++ b/lib/page/redirect-next-page/redirect-next-page.js
@@ -20,7 +20,8 @@ const setRepeatable = require('~/fb-runner-node/page/set-repeatable/set-repeatab
 const skipComponents = require('~/fb-runner-node/page/skip-components/skip-components')
 const validateInput = require('~/fb-runner-node/page/validate-input/validate-input')
 
-const transformChangePageData = ({route: _id, params}) => ({_id, params})
+const transformChangePageData = ({route: _id, params} = {}) => ({_id, params})
+const hasUploadComponents = ({components = []} = {}) => components.some(({_type}) => _type === 'upload')
 
 function checkNextPage (changePage, currentPage, userData) {
   if (checkPageIdParams(changePage, currentPage)) {
@@ -33,18 +34,37 @@ function checkNextPage (changePage, currentPage, userData) {
 
   const {_id} = nextPage
 
-  if (_id !== userData.getUserDataProperty('uploadPage')) {
-    let nextPageInstance = getInstance(_id)
-    nextPageInstance = skipPage(nextPageInstance, userData)
+  let pageInstance = getInstance(_id)
 
-    if (!nextPageInstance.redirect) {
-      nextPageInstance = setControlNames(nextPageInstance, userData)
-      nextPageInstance = setRepeatable(nextPageInstance, userData)
-      nextPageInstance = setComposite(nextPageInstance, userData)
-      nextPageInstance = skipComponents(nextPageInstance, userData)
-      nextPageInstance = validateInput(nextPageInstance, userData)
-
-      if (!nextPageInstance.$validated) {
+  /*
+   *  See also `getRedirectForPreviousPage`
+   *
+   *  This is problematic but (for now) acceptable
+   *
+   *  In order to compute the next page, we transform and validate
+   *  each of the pages in the journey chain. If a page does not validate
+   *  we stop there
+   *
+   *  `upload` components may appear on a page and have either one or two steps
+   *  enabling the user to check then see a summary of their uploads. But
+   *  beyond the component page (in other words, once the user has progressed
+   *  to either of the steps) the form data for the uploads does not exist,
+   *  so it can't be revalidated
+   *
+   *  Consequently, pages containing `upload` components are "skipped over" for
+   *  re-validation here -- they are presumed to be valid
+   *
+   *  At some point it may be necessary to create a better mechanism!
+   */
+  if (!hasUploadComponents(pageInstance)) {
+    pageInstance = skipPage(pageInstance, userData)
+    if (!pageInstance.redirect) {
+      pageInstance = setControlNames(pageInstance, userData)
+      pageInstance = setRepeatable(pageInstance, userData)
+      pageInstance = setComposite(pageInstance, userData)
+      pageInstance = skipComponents(pageInstance, userData)
+      pageInstance = validateInput(pageInstance, userData)
+      if (!pageInstance.$validated) {
         return nextPage
       }
     }
@@ -66,7 +86,7 @@ function getNextUrlForChangePage (changePage, currentPage, userData) {
   }
 }
 
-const getRedirectForNextPage = async (pageInstance, userData) => {
+module.exports = async function getRedirectForNextPage (pageInstance, userData) {
   const {
     $validated = false
   } = pageInstance
@@ -103,5 +123,3 @@ const getRedirectForNextPage = async (pageInstance, userData) => {
 
   return pageInstance
 }
-
-module.exports = getRedirectForNextPage

--- a/lib/page/redirect-next-page/redirect-next-page.js
+++ b/lib/page/redirect-next-page/redirect-next-page.js
@@ -32,14 +32,18 @@ function checkNextPage (changePage, currentPage, userData) {
   if (typeof nextPage === 'string') nextPage = {_id: nextPage}
 
   const {_id} = nextPage
+
   let nextPageInstance = getInstance(_id)
   nextPageInstance = skipPage(nextPageInstance, userData)
+
   if (!nextPageInstance.redirect) {
     nextPageInstance = setControlNames(nextPageInstance, userData)
     nextPageInstance = setRepeatable(nextPageInstance, userData)
     nextPageInstance = setComposite(nextPageInstance, userData)
     nextPageInstance = skipComponents(nextPageInstance, userData)
+
     nextPageInstance = validateInput(nextPageInstance, userData)
+
     if (!nextPageInstance.$validated) {
       return nextPage
     }

--- a/lib/page/redirect-previous-page/redirect-previous-page.js
+++ b/lib/page/redirect-previous-page/redirect-previous-page.js
@@ -20,7 +20,8 @@ const setRepeatable = require('~/fb-runner-node/page/set-repeatable/set-repeatab
 const skipComponents = require('~/fb-runner-node/page/skip-components/skip-components')
 const validateInput = require('~/fb-runner-node/page/validate-input/validate-input')
 
-const transformChangePageData = ({route: _id, params}) => ({_id, params})
+const transformChangePageData = ({route: _id, params} = {}) => ({_id, params})
+const hasUploadComponents = ({components = []} = {}) => components.some(({_type}) => _type === 'upload')
 
 function checkPreviousPage (changePage, currentPage, userData) {
   if (checkPageIdParams(changePage, currentPage)) {
@@ -33,8 +34,29 @@ function checkPreviousPage (changePage, currentPage, userData) {
 
   const {_id} = previousPage
 
-  if (_id !== userData.getUserDataProperty('uploadPage')) {
-    let pageInstance = getInstance(_id)
+  let pageInstance = getInstance(_id)
+
+  /*
+   *  See also `getRedirectForNextPage`
+   *
+   *  This is problematic but (for now) acceptable
+   *
+   *  In order to compute the next page, we transform and validate
+   *  each of the pages in the journey chain. If a page does not validate
+   *  we stop there
+   *
+   *  `upload` components may appear on a page and have either one or two steps
+   *  enabling the user to check then see a summary of their uploads. But
+   *  beyond the component page (in other words, once the user has progressed
+   *  to either of the steps) the form data for the uploads does not exist,
+   *  so it can't be revalidated
+   *
+   *  Consequently, pages containing `upload` components are "skipped over" for
+   *  re-validation here -- they are presumed to be valid
+   *
+   *  At some point it may be necessary to create a better mechanism!
+   */
+  if (!hasUploadComponents(pageInstance)) {
     pageInstance = skipPage(pageInstance, userData)
     if (!pageInstance.redirect) {
       pageInstance = setControlNames(pageInstance, userData)

--- a/lib/page/redirect-previous-page/redirect-previous-page.js
+++ b/lib/page/redirect-previous-page/redirect-previous-page.js
@@ -32,16 +32,19 @@ function checkPreviousPage (changePage, currentPage, userData) {
   if (typeof previousPage === 'string') previousPage = {_id: previousPage}
 
   const {_id} = previousPage
-  let pageInstance = getInstance(_id)
-  pageInstance = skipPage(pageInstance, userData)
-  if (!pageInstance.redirect) {
-    pageInstance = setControlNames(pageInstance, userData)
-    pageInstance = setRepeatable(pageInstance, userData)
-    pageInstance = setComposite(pageInstance, userData)
-    pageInstance = skipComponents(pageInstance, userData)
-    pageInstance = validateInput(pageInstance, userData)
-    if (!pageInstance.$validated) {
-      return previousPage
+
+  if (_id !== userData.getUserDataProperty('uploadPage')) {
+    let pageInstance = getInstance(_id)
+    pageInstance = skipPage(pageInstance, userData)
+    if (!pageInstance.redirect) {
+      pageInstance = setControlNames(pageInstance, userData)
+      pageInstance = setRepeatable(pageInstance, userData)
+      pageInstance = setComposite(pageInstance, userData)
+      pageInstance = skipComponents(pageInstance, userData)
+      pageInstance = validateInput(pageInstance, userData)
+      if (!pageInstance.$validated) {
+        return previousPage
+      }
     }
   }
 

--- a/lib/page/set-fileuploads/set-fileupload-controls-max-size.js
+++ b/lib/page/set-fileuploads/set-fileupload-controls-max-size.js
@@ -3,7 +3,7 @@ require('@ministryofjustice/module-alias/register-module')(module)
 const jsonPath = require('jsonpath')
 const bytes = require('bytes')
 
-const {getUploadControls} = require('~/fb-runner-node/page/utils/utils-uploads')
+const {getComponents} = require('~/fb-runner-node/page/utils/utils-uploads')
 const {getInstanceProperty} = require('~/fb-runner-node/service-data/service-data')
 
 module.exports = function setFileUploadControlsMaxSize (pageInstance) {
@@ -14,7 +14,7 @@ module.exports = function setFileUploadControlsMaxSize (pageInstance) {
   /**
    * Filter upload controls
    */
-  const uploadControls = getUploadControls(pageInstance)
+  const uploadControls = getComponents(pageInstance)
     .filter(({_type}) => _type === 'fileupload')
 
   jsonPath.apply(uploadControls, '$[*]', val => {

--- a/lib/page/set-fileuploads/set-fileuploads.js
+++ b/lib/page/set-fileuploads/set-fileuploads.js
@@ -3,15 +3,15 @@ require('@ministryofjustice/module-alias/register-module')(module)
 const bytes = require('bytes')
 
 const {
-  getUploadControlName
+  getComponentName
 } = require('~/fb-runner-node/page/utils/utils-controls')
 
 const {
-  getUploadControls,
-  getUploadedMaxFiles,
-  getUploadedMinFiles,
-  getUploadedFileCount,
-  getUploadedFiles
+  getComponents,
+  getComponentMaxFiles,
+  getComponentMinFiles,
+  countComponentFiles,
+  getComponentFiles
 } = require('~/fb-runner-node/page/utils/utils-uploads')
 
 const {
@@ -24,7 +24,7 @@ const {format} = require('~/fb-runner-node/format/format')
 const flattenDeep = (arr) => arr.reduce((acc, val) => Array.isArray(val) ? acc.concat(flattenDeep(val)) : acc.concat(val), [])
 
 module.exports = async function setFileUploadControls (pageInstance, userData) {
-  const uploadControls = getUploadControls(pageInstance)
+  const uploadControls = getComponents(pageInstance)
 
   uploadControls
     .filter(({_type}) => _type === 'fileupload')
@@ -76,10 +76,10 @@ module.exports = async function setFileUploadControls (pageInstance, userData) {
         control.accept = control.accept.join(',')
       }
 
-      const maxFiles = getUploadedMaxFiles(control)
-      const minFiles = getUploadedMinFiles(control)
-      const currentFiles = getUploadedFiles(control, userData)
-      const currentFileCount = getUploadedFileCount(control, userData)
+      const maxFiles = getComponentMaxFiles(control)
+      const minFiles = getComponentMinFiles(control)
+      const currentFiles = getComponentFiles(control, userData)
+      const currentFileCount = countComponentFiles(control, userData)
       const maxAvailableSlots = maxFiles - currentFileCount
       let slots = 0
 
@@ -94,7 +94,7 @@ module.exports = async function setFileUploadControls (pageInstance, userData) {
         }
 
         if (removeSlot) {
-          const removeSlotInvoked = getUploadControlName(removeSlot) === control.name
+          const removeSlotInvoked = getComponentName(removeSlot) === control.name
           if (removeSlotInvoked) {
             uploadSlots--
           }

--- a/lib/page/set-fileuploads/set-fileuploads.unit.spec.js
+++ b/lib/page/set-fileuploads/set-fileuploads.unit.spec.js
@@ -8,12 +8,12 @@ const serviceData = require('~/fb-runner-node/service-data/service-data')
 const getStringStub = stub(serviceData, 'getString')
 const getInstancePropertyStub = stub(serviceData, 'getInstanceProperty')
 
-const uploadUtils = require('~/fb-runner-node/page/utils/utils-uploads')
-const getUploadedFilesStub = stub(uploadUtils, 'getUploadedFiles')
+const utilsUploads = require('~/fb-runner-node/page/utils/utils-uploads')
+const getComponentFilesStub = stub(utilsUploads, 'getComponentFiles')
 
 const setFileUploads = proxyquire('./set-fileuploads', {
   '~/fb-runner-node/service-data/service-data': serviceData,
-  '~/fb-runner-node/page/utils/utils-uploads': uploadUtils
+  '~/fb-runner-node/page/utils/utils-uploads': utilsUploads
 })
 
 const setFileUploadInstancePropertyValues = (values) => {
@@ -68,7 +68,7 @@ const setupUserDataStubs = (options = {}) => {
   const body = options.body || {}
   const userData = getUserDataMethods()
 
-  getUploadedFilesStub.callsFake(() => files)
+  getComponentFilesStub.callsFake(() => files)
 
   const getSuccessfulUploadsCountStub = stub(userData, 'getSuccessfulUploadsCount')
   getSuccessfulUploadsCountStub.callsFake(() => files.length)
@@ -85,14 +85,14 @@ const setupUserDataStubs = (options = {}) => {
     stubs: {
       getString: getStringStub,
       getInstancePropert: getInstancePropertyStub,
-      getUploadedFiles: getUploadedFilesStub,
+      getComponentFiles: getComponentFilesStub,
       getSuccessfulUploadsCount: getSuccessfulUploadsCountStub
     }
   }
 }
 
 const resetGlobalStubs = (userData) => {
-  getUploadedFilesStub.restore()
+  getComponentFilesStub.restore()
   getStringStub.restore()
   getInstancePropertyStub.restore()
   Object.keys(userData).forEach(key => {

--- a/lib/page/set-multipart-form/set-multipart-form.js
+++ b/lib/page/set-multipart-form/set-multipart-form.js
@@ -1,9 +1,9 @@
 require('@ministryofjustice/module-alias/register-module')(module)
 
-const {getUploadControls} = require('~/fb-runner-node/page/utils/utils-uploads')
+const {getComponents} = require('~/fb-runner-node/page/utils/utils-uploads')
 
 module.exports = async function setMultipartForm (pageInstance, userData) {
-  const uploadControls = getUploadControls(pageInstance)
+  const uploadControls = getComponents(pageInstance)
 
   /**
    * All upload controls

--- a/lib/page/set-uploads/set-upload-controls-max-size.js
+++ b/lib/page/set-uploads/set-upload-controls-max-size.js
@@ -3,7 +3,7 @@ require('@ministryofjustice/module-alias/register-module')(module)
 const bytes = require('bytes')
 
 const {
-  getUploadControls
+  getComponents
 } = require('~/fb-runner-node/page/utils/utils-uploads')
 
 const {
@@ -16,7 +16,7 @@ module.exports = function setUploadControlsMaxSize (pageInstance) {
 
   setUploadControlsMaxSize.defaultMaxSize = defaultMaxSize
 
-  getUploadControls(pageInstance)
+  getComponents(pageInstance)
     .filter(({_type}) => _type === 'upload')
     .forEach((control) => {
       const {

--- a/lib/page/set-uploads/set-uploads.js
+++ b/lib/page/set-uploads/set-uploads.js
@@ -1,18 +1,18 @@
 require('@ministryofjustice/module-alias/register-module')(module)
 
 const {
-  getUploadControls,
-  getUploadedMaxFiles,
-  getUploadedMinFiles,
-  getUploadedMaxSize,
-  getUploadedFileCount,
-  getUploadedFiles,
-  hasUploadedMaxFiles,
-  hasUploadedMinFiles
+  getComponents,
+  getComponentMaxFiles,
+  getComponentMinFiles,
+  getComponentMaxSize,
+  countComponentFiles,
+  getComponentFiles,
+  hasComponentMaxFiles,
+  hasComponentMinFiles
 } = require('~/fb-runner-node/page/utils/utils-uploads')
 
 const {
-  getUploadFieldName
+  getFieldName
 } = require('~/fb-runner-node/page/utils/utils-controls')
 
 const {
@@ -26,7 +26,7 @@ const {
 
 const flattenDeep = (arr = []) => arr.reduce((acc, val) => Array.isArray(val) ? acc.concat(flattenDeep(val)) : acc.concat(val), [])
 
-function getFieldName (userData, controlName, maxFiles) {
+function getAcceptedFieldName (userData, controlName, maxFiles) {
   const {
     accepted = []
   } = userData.getUserData()
@@ -35,8 +35,8 @@ function getFieldName (userData, controlName, maxFiles) {
    *  Find the first available, or take the last
    */
   let i = 1
-  while (i < maxFiles && accepted.some(({fieldName}) => fieldName === getUploadFieldName(controlName, i))) i++
-  return getUploadFieldName(controlName, i)
+  while (i < maxFiles && accepted.some(({fieldName}) => fieldName === getFieldName(controlName, i))) i++
+  return getFieldName(controlName, i)
 }
 
 const resolveFileTypes = (accept) => flattenDeep(accept.map((type) => {
@@ -82,14 +82,14 @@ const trim = (text) => {
 }
 
 module.exports = async function setUploadControls (pageInstance, userData) {
-  getUploadControls(pageInstance)
+  getComponents(pageInstance)
     .filter(({_type}) => _type === 'upload')
     .forEach((control) => {
-      const maxFiles = getUploadedMaxFiles(control)
-      const minFiles = getUploadedMinFiles(control)
-      const maxSize = getUploadedMaxSize(control)
-      const currentFiles = getUploadedFiles(control, userData)
-      const currentFileCount = getUploadedFileCount(control, userData)
+      const maxFiles = getComponentMaxFiles(control)
+      const minFiles = getComponentMinFiles(control)
+      const maxSize = getComponentMaxSize(control)
+      const currentFiles = getComponentFiles(control, userData)
+      const currentFileCount = countComponentFiles(control, userData)
 
       if (Array.isArray(control.accept)) {
         const accept = control.accept.slice() // copy
@@ -125,7 +125,7 @@ module.exports = async function setUploadControls (pageInstance, userData) {
         label
       } = control
 
-      const fieldName = getFieldName(userData, name, maxFiles)
+      const fieldName = getAcceptedFieldName(userData, name, maxFiles)
 
       const fileUpload = {
         $skipValidation: true,
@@ -139,8 +139,8 @@ module.exports = async function setUploadControls (pageInstance, userData) {
       control.fileCount = currentFileCount
       control.fileUpload = fileUpload
       control.fieldName = fieldName
-      control.hasMaxFiles = hasUploadedMaxFiles(control, userData)
-      control.hasMinFiles = hasUploadedMinFiles(control, userData)
+      control.hasMaxFiles = hasComponentMaxFiles(control, userData)
+      control.hasMinFiles = hasComponentMinFiles(control, userData)
     })
 
   const {

--- a/lib/page/set-uploads/set-uploads.unit.spec.js
+++ b/lib/page/set-uploads/set-uploads.unit.spec.js
@@ -8,12 +8,12 @@ const serviceData = require('~/fb-runner-node/service-data/service-data')
 const getStringStub = stub(serviceData, 'getString')
 const getInstancePropertyStub = stub(serviceData, 'getInstanceProperty')
 
-const uploadUtils = require('~/fb-runner-node/page/utils/utils-uploads')
-const getUploadedFilesStub = stub(uploadUtils, 'getUploadedFiles')
+const utilsUploads = require('~/fb-runner-node/page/utils/utils-uploads')
+const getComponentFilesStub = stub(utilsUploads, 'getComponentFiles')
 
 const setUploads = proxyquire('./set-uploads', {
   '~/fb-runner-node/service-data/service-data': serviceData,
-  '~/fb-runner-node/page/utils/utils-uploads': uploadUtils
+  '~/fb-runner-node/page/utils/utils-uploads': utilsUploads
 })
 
 const setUploadInstancePropertyValues = (values) => {
@@ -65,7 +65,7 @@ const setupUserDataStubs = (options = {}) => {
   const body = options.body || {}
   const userData = getUserDataMethods()
 
-  getUploadedFilesStub.callsFake(() => files)
+  getComponentFilesStub.callsFake(() => files)
 
   const getSuccessfulUploadsCountStub = stub(userData, 'getSuccessfulUploadsCount')
   getSuccessfulUploadsCountStub.callsFake(() => files.length)
@@ -85,14 +85,14 @@ const setupUserDataStubs = (options = {}) => {
     stubs: {
       getString: getStringStub,
       getInstancePropert: getInstancePropertyStub,
-      getUploadedFiles: getUploadedFilesStub,
+      getComponentFiles: getComponentFilesStub,
       getSuccessfulUploadsCount: getSuccessfulUploadsCountStub
     }
   }
 }
 
 const resetGlobalStubs = (userData) => {
-  getUploadedFilesStub.restore()
+  getComponentFilesStub.restore()
   getStringStub.restore()
   getInstancePropertyStub.restore()
   Object.keys(userData).forEach(key => {

--- a/lib/page/utils/utils-controls.js
+++ b/lib/page/utils/utils-controls.js
@@ -1,19 +1,19 @@
 const jsonPath = require('jsonpath')
 
-const getUploadFieldName = (controlName, count = 1) => `${controlName}[${count}]`
-const getUploadControlName = (fieldName = '') => fieldName.replace(/\[\d+\]$/g, '')
-const getUploadControlType = (pageInstance, fieldName = '') => {
-  const controlName = getUploadControlName(fieldName)
-  const uploadControls = jsonPath.query(pageInstance, '$..[?(@._type === "fileupload"||@._type === "upload")]')
-  if (uploadControls.some(({name}) => name === controlName)) {
-    const {_type} = uploadControls.find(({name}) => name === controlName)
+const getFieldName = (componentName, count = 1) => `${componentName}[${count}]`
+const getComponentName = (fieldName = '') => fieldName.replace(/\[\d+\]$/g, '')
+const getComponentType = (pageInstance, fieldName = '') => {
+  const componentName = getComponentName(fieldName)
+  const components = jsonPath.query(pageInstance, '$..[?(@._type === "fileupload"||@._type === "upload")]')
+  if (components.some(({name}) => name === componentName)) {
+    const {_type} = components.find(({name}) => name === componentName)
 
     return _type
   }
 }
 
 module.exports = {
-  getUploadFieldName,
-  getUploadControlName,
-  getUploadControlType
+  getFieldName,
+  getComponentName,
+  getComponentType
 }

--- a/lib/page/utils/utils-uploads.js
+++ b/lib/page/utils/utils-uploads.js
@@ -63,6 +63,8 @@ const hasComponentAcceptedMaxFiles = (component, userData) => countComponentAcce
 
 const hasComponentAcceptedMinFiles = (component, userData) => countComponentAcceptedFiles(component, userData) >= getComponentMinFiles(component)
 
+const hasComponentAcceptedAnyFiles = (component, userData) => !!countComponentAcceptedFiles(component, userData)
+
 const getComponentsAcceptedMaxFiles = (...args) => getComponentsMaxFiles(...args)
 
 const getComponentsAcceptedMinFiles = (...args) => getComponentsMinFiles(...args)
@@ -132,6 +134,7 @@ module.exports = {
   getComponentAcceptedMinFiles,
   hasComponentAcceptedMaxFiles,
   hasComponentAcceptedMinFiles,
+  hasComponentAcceptedAnyFiles,
   getComponentsAcceptedMaxFiles,
   getComponentsAcceptedMinFiles,
   hasComponentsAcceptedMaxFiles,

--- a/lib/page/utils/utils-uploads.js
+++ b/lib/page/utils/utils-uploads.js
@@ -1,73 +1,77 @@
 const jsonPath = require('jsonpath')
 
 const {
-  getUploadControlName
+  getComponentName
 } = require('./utils-controls')
 
-const getUploadControls = (pageInstance) => jsonPath.query(pageInstance, '$..[?(@._type === "fileupload"||@._type === "upload")]')
+/*
+ *  'components'
+ */
+
+const getComponents = (pageInstance) => jsonPath.query(pageInstance, '$..[?(@._type === "fileupload"||@._type === "upload")]')
+
+const getComponentsMaxFiles = (pageInstance) => getComponents(pageInstance).reduce((max, component) => Math.max(max, getComponentMaxFiles(component)), 0)
+
+const getComponentsMinFiles = (pageInstance) => getComponents(pageInstance).reduce((min, component) => Math.max(min, getComponentMinFiles(component)), 0) // Math.max!
+
+const hasComponentsMaxFiles = (pageInstance, userData) => getComponents(pageInstance).every((component) => hasComponentMaxFiles(component, userData))
+
+const hasComponentsMinFiles = (pageInstance, userData) => getComponents(pageInstance).every((component) => hasComponentMinFiles(component, userData))
+
+/*
+ *  'component'
+ */
 
 const getComponentMaxFiles = ({maxFiles}) => maxFiles || 1 // not zero
 
 const getComponentMinFiles = ({minFiles = 1}) => minFiles // possibly zero, not undefined
 
-const getComponentMaxFilesForUploadControls = (pageInstance) => getUploadControls(pageInstance).reduce((max, component) => Math.max(max, getComponentMaxFiles(component)), 0)
+const hasComponentMaxFiles = (component, userData) => countComponentFiles(component, userData) === getComponentMaxFiles(component)
 
-const getComponentMinFilesForUploadControls = (pageInstance) => getUploadControls(pageInstance).reduce((min, component) => Math.max(min, getComponentMinFiles(component)), 0) // Math.max!
+const hasComponentMinFiles = (component, userData) => countComponentFiles(component, userData) >= getComponentMinFiles(component)
 
-const getUploadedMaxFiles = (...args) => getComponentMaxFiles(...args)
+const getComponentMaxSize = ({validation: {maxSize} = {}}) => maxSize
 
-const getUploadedMinFiles = (...args) => getComponentMinFiles(...args)
+const getComponentFiles = ({name}, {getUserDataProperty}) => getUserDataProperty(name) || []
 
-const hasUploadedMaxFiles = (component, userData) => getUploadedFileCount(component, userData) === getComponentMaxFiles(component)
+const setComponentFiles = ({name}, files = [], {setUserDataProperty}) => setUserDataProperty(name, files)
 
-const hasUploadedMinFiles = (component, userData) => getUploadedFileCount(component, userData) >= getComponentMinFiles(component)
+const countComponentFiles = (...args) => getComponentFiles(...args).length
 
-const getUploadedMaxSize = ({validation: {maxSize} = {}}) => maxSize
+const clearComponentFiles = ({name}, {unsetUserDataProperty}) => unsetUserDataProperty(name)
 
-const getUploadedFiles = ({name}, {getUserDataProperty}) => getUserDataProperty(name) || []
+/*
+ *  'accepted'
+ */
 
-const setUploadedFiles = ({name}, files = [], {setUserDataProperty}) => setUserDataProperty(name, files)
-
-const getUploadedFileCount = (...args) => getUploadedFiles(...args).length
-
-const clearUploadedFiles = ({name}, {unsetUserDataProperty}) => unsetUserDataProperty(name)
-
-const getUploadedMaxFilesForUploadControls = (...args) => getComponentMaxFilesForUploadControls(...args)
-
-const getUploadedMinFilesForUploadControls = (...args) => getComponentMinFilesForUploadControls(...args)
-
-const hasUploadControlsMaxFiles = (pageInstance, userData) => getUploadControls(pageInstance).every((component) => hasUploadedMaxFiles(component, userData))
-
-const hasUploadControlsMinFiles = (pageInstance, userData) => getUploadControls(pageInstance).every((component) => hasUploadedMinFiles(component, userData))
-
-function getAcceptedFiles ({name}, {getUserData}) {
+function getComponentAcceptedFiles ({name}, {getUserData}) {
   const {
     accepted = []
   } = getUserData()
 
   return accepted
-    .filter(({fieldname = '', fieldName = fieldname}) => getUploadControlName(fieldName) === name)
+    .filter(({fieldname = '', fieldName = fieldname}) => getComponentName(fieldName) === name)
 }
 
-const getAcceptedFileCount = (...args) => getAcceptedFiles(...args).length
+const countComponentAcceptedFiles = (...args) => getComponentAcceptedFiles(...args).length
 
-const getAcceptedMaxFiles = (...args) => getComponentMaxFiles(...args)
+const getComponentAcceptedMaxFiles = (...args) => getComponentMaxFiles(...args)
 
-const getAcceptedMinFiles = (...args) => getComponentMinFiles(...args)
+const getComponentAcceptedMinFiles = (...args) => getComponentMinFiles(...args)
 
-const hasAcceptedMaxFiles = (component, userData) => getAcceptedFileCount(component, userData) === getComponentMaxFiles(component)
+const hasComponentAcceptedMaxFiles = (component, userData) => countComponentAcceptedFiles(component, userData) === getComponentMaxFiles(component)
 
-const hasAcceptedMinFiles = (component, userData) => getAcceptedFileCount(component, userData) >= getComponentMinFiles(component)
+const hasComponentAcceptedMinFiles = (component, userData) => countComponentAcceptedFiles(component, userData) >= getComponentMinFiles(component)
 
-const getAcceptedMaxFilesForUploadControls = (...args) => getComponentMaxFilesForUploadControls(...args)
+const getComponentsAcceptedMaxFiles = (...args) => getComponentsMaxFiles(...args)
 
-const getAcceptedMinFilesForUploadControls = (...args) => getComponentMinFilesForUploadControls(...args)
+const getComponentsAcceptedMinFiles = (...args) => getComponentsMinFiles(...args)
 
-const hasAcceptedMaxFilesForUploadControls = (pageInstance, userData) => getUploadControls(pageInstance).every((component) => hasAcceptedMaxFiles(component, userData))
+const hasComponentsAcceptedMaxFiles = (pageInstance, userData) => getComponents(pageInstance).every((component) => hasComponentAcceptedMaxFiles(component, userData))
 
-const hasAcceptedMinFilesForUploadControls = (pageInstance, userData) => getUploadControls(pageInstance).every((component) => hasAcceptedMinFiles(component, userData))
+const hasComponentsAcceptedMinFiles = (pageInstance, userData) => getComponents(pageInstance).every((component) => hasComponentAcceptedMinFiles(component, userData))
 
-const addToAcceptedFiles = ({getUserData, setUserDataProperty}, {fieldname, fieldName = fieldname, ...file}) => {
+function addToComponentAcceptedFiles ({getUserData, setUserDataProperty}, {fieldname, fieldName = fieldname, ...file}) {
   const {accepted = []} = getUserData()
 
   if (accepted.some(({fieldName: accepted}) => accepted === fieldName)) accepted.splice(accepted.findIndex(({fieldName: accepted}) => accepted === fieldName), 1)
@@ -75,7 +79,7 @@ const addToAcceptedFiles = ({getUserData, setUserDataProperty}, {fieldname, fiel
   setUserDataProperty('accepted', accepted.concat({...file, fieldName}))
 }
 
-const removeFromAcceptedFiles = ({getUserData, setUserDataProperty}, {fieldname, fieldName = fieldname}) => {
+function removeFromComponentAcceptedFiles ({getUserData, setUserDataProperty}, {fieldname, fieldName = fieldname}) {
   const {accepted = []} = getUserData()
 
   if (accepted.some(({fieldName: accepted}) => accepted === fieldName)) accepted.splice(accepted.findIndex(({fieldName: accepted}) => accepted === fieldName), 1)
@@ -83,59 +87,59 @@ const removeFromAcceptedFiles = ({getUserData, setUserDataProperty}, {fieldname,
   setUserDataProperty('accepted', accepted)
 }
 
-const hasAcceptedFile = ({getUserData}, fieldName) => {
+function hasComponentAcceptedFile ({getUserData}, fieldName) {
   const {accepted = []} = getUserData()
 
   return accepted.some(({fieldName: accepted}) => accepted === fieldName)
 }
 
-const getAcceptedFile = ({getUserData}, fieldName) => {
+function getComponentAcceptedFile ({getUserData}, fieldName) {
   const {accepted = []} = getUserData()
 
   return accepted.find(({fieldName: accepted}) => accepted === fieldName)
 }
 
-const hasAcceptedFileByUUID = ({getUserData}, uuid) => {
+function hasComponentAcceptedFileByUUID ({getUserData}, uuid) {
   const {accepted = []} = getUserData()
 
   return accepted.some(({uuid: accepted}) => accepted === uuid)
 }
 
-const getAcceptedFileByUUID = ({getUserData}, uuid) => {
+function getComponentAcceptedFileByUUID ({getUserData}, uuid) {
   const {accepted = []} = getUserData()
 
   return accepted.find(({uuid: accepted}) => accepted === uuid)
 }
 
 module.exports = {
-  getUploadControls,
-  getUploadedMaxFiles,
-  getUploadedMinFiles,
-  hasUploadedMaxFiles,
-  hasUploadedMinFiles,
-  getUploadedMaxSize,
-  getUploadedFiles,
-  setUploadedFiles,
-  getUploadedFileCount,
-  clearUploadedFiles,
-  getUploadedMaxFilesForUploadControls,
-  getUploadedMinFilesForUploadControls,
-  hasUploadControlsMaxFiles,
-  hasUploadControlsMinFiles,
-  getAcceptedFiles,
-  getAcceptedFileCount,
-  getAcceptedMaxFiles,
-  getAcceptedMinFiles,
-  hasAcceptedMaxFiles,
-  hasAcceptedMinFiles,
-  getAcceptedMaxFilesForUploadControls,
-  getAcceptedMinFilesForUploadControls,
-  hasAcceptedMaxFilesForUploadControls,
-  hasAcceptedMinFilesForUploadControls,
-  addToAcceptedFiles,
-  removeFromAcceptedFiles,
-  hasAcceptedFile,
-  getAcceptedFile,
-  hasAcceptedFileByUUID,
-  getAcceptedFileByUUID
+  getComponents,
+  getComponentMaxFiles,
+  getComponentMinFiles,
+  hasComponentMaxFiles,
+  hasComponentMinFiles,
+  getComponentMaxSize,
+  getComponentFiles,
+  setComponentFiles,
+  countComponentFiles,
+  clearComponentFiles,
+  getComponentsMaxFiles,
+  getComponentsMinFiles,
+  hasComponentsMaxFiles,
+  hasComponentsMinFiles,
+  getComponentAcceptedFiles,
+  countComponentAcceptedFiles,
+  getComponentAcceptedMaxFiles,
+  getComponentAcceptedMinFiles,
+  hasComponentAcceptedMaxFiles,
+  hasComponentAcceptedMinFiles,
+  getComponentsAcceptedMaxFiles,
+  getComponentsAcceptedMinFiles,
+  hasComponentsAcceptedMaxFiles,
+  hasComponentsAcceptedMinFiles,
+  addToComponentAcceptedFiles,
+  removeFromComponentAcceptedFiles,
+  hasComponentAcceptedFile,
+  getComponentAcceptedFile,
+  hasComponentAcceptedFileByUUID,
+  getComponentAcceptedFileByUUID
 }

--- a/lib/page/validate-input/validate-input.js
+++ b/lib/page/validate-input/validate-input.js
@@ -73,6 +73,13 @@ function validateInput (pageInstance, userData) {
     }
   })
 
+  pageInstance.$hasErrors = false
+  pageInstance.$validated = false
+
+  /*
+   *  Either it has errors (and is not validated)
+   *  or it has validated (and has no errors)
+   */
   if (hasErrors || pageInstance.errorTitle) {
     pageInstance.$hasErrors = true
   } else {

--- a/lib/page/validate-input/validate-input.unit.spec.js
+++ b/lib/page/validate-input/validate-input.unit.spec.js
@@ -240,8 +240,8 @@ test('When getting the errors for an instance that has an invalid value', t => {
 
   const componentInstance = validateInput(pageInstance, {})
 
-  t.deepEqual(setErrorsStub.setErrors.getCall(0).args, [{components: [{name: 'foo'}], $hasErrors: true}, [{errorType: 'component', instance: 'foo'}]], 'it should invoke setErrors with the correct args')
-  t.deepEqual(componentInstance, {components: [{name: 'foo'}], $hasErrors: true}, 'it should annotate the page instance with $hasErrors')
+  t.deepEqual(setErrorsStub.setErrors.getCall(0).args, [{components: [{name: 'foo'}], $hasErrors: true, $validated: false}, [{errorType: 'component', instance: 'foo'}]], 'it should invoke setErrors with the correct args')
+  t.deepEqual(componentInstance, {components: [{name: 'foo'}], $hasErrors: true, $validated: false}, 'it should annotate the page instance with $hasErrors')
 
   t.end()
 })

--- a/lib/page/validate-input/validate-required/validate-required.js
+++ b/lib/page/validate-input/validate-required/validate-required.js
@@ -12,9 +12,11 @@ const isRequired = (instance, userData) => {
   if (instance._type === 'checkbox') {
     return false
   }
+
   if (instance._type === 'button') {
     return false
   }
+
   if (instance.$conditionalShow) {
     const conditionallyShow = userData.evaluate(instance.$conditionalShow, {
       instance
@@ -23,6 +25,7 @@ const isRequired = (instance, userData) => {
       return false
     }
   }
+
   instance.validation = instance.validation || {}
   let requiredCondition = instance.validation.required
   if (requiredCondition === undefined) {


### PR DESCRIPTION
- Single file uploads sometimes do, sometimes don't redirect to the next page of the journey
- This is connected to the validation of uploads
- I've renamed some methods to make it clearer what they are for
- The solution for the _bug_ is to ensure that uploads are _unset_ from `userData` before the user tries to progress to the next step. There is a separate list of accepted files which is what the application should interrogate beyond the upload steps
- I want a neater way of doing all of this but we are hampered by the underlying libraries and having to support _two_ upload mechanisms