### PR TITLE
Editor showing incorrect step in `/edit` view

### DIFF
--- a/lib/middleware/routes-metadata/routes-metadata.js
+++ b/lib/middleware/routes-metadata/routes-metadata.js
@@ -430,8 +430,10 @@ async function pageHandler (req, res) {
       pageInstance = skipComponents(pageInstance, userData)
     }
 
-    pageInstance = await executeSetContents(pageInstance, userData, POST)
-    if (hasRedirect(pageInstance)) return handleRedirect(res, pageInstance, userData)
+    if (!EDITMODE) {
+      pageInstance = await executeSetContents(pageInstance, userData, POST)
+      if (hasRedirect(pageInstance)) return handleRedirect(res, pageInstance, userData)
+    }
 
     if (POST) {
       // handle inbound values


### PR DESCRIPTION
- Intermittently redirects to non-`/edit` page

This is to do with how the mechanism populates/references user data. Switching between `run` and `edit` modes causes some data to be populated which should not then be referenced in `edit` mode