### PR TITLE
Ensure `upload` steps for `/change` journeys

### DIFF
--- a/lib/middleware/routes-metadata/routes-metadata.js
+++ b/lib/middleware/routes-metadata/routes-metadata.js
@@ -430,8 +430,10 @@ async function pageHandler (req, res) {
       pageInstance = skipComponents(pageInstance, userData)
     }
 
-    pageInstance = await executeSetContents(pageInstance, userData, POST)
-    if (hasRedirect(pageInstance)) return handleRedirect(res, pageInstance, userData)
+    if (!EDITMODE) {
+      pageInstance = await executeSetContents(pageInstance, userData, POST)
+      if (hasRedirect(pageInstance)) return handleRedirect(res, pageInstance, userData)
+    }
 
     if (POST) {
       // handle inbound values

--- a/lib/page/redirect-from-page-to-page/redirect-from-page-to-page.js
+++ b/lib/page/redirect-from-page-to-page/redirect-from-page-to-page.js
@@ -79,13 +79,13 @@ module.exports = async function getRedirectFromPageToPage (fromInstance, toInsta
       url = getUrlForChangePage(transformChangePageData(getData(changePage)), {_id, params}, userData)
 
       if (url !== changePage) {
-        url = getRedirectUrl(url, changePage)
+        fromInstance.redirect = getRedirectUrl(url, changePage)
+
+        return fromInstance
       }
-    } else {
-      url = getUrl(_id, params, userData.contentLang)
     }
 
-    if (url) {
+    if (url || (url = getUrl(_id, params, userData.contentLang))) {
       fromInstance.redirect = url
     }
   }

--- a/lib/page/redirect-next-page/redirect-next-page.js
+++ b/lib/page/redirect-next-page/redirect-next-page.js
@@ -20,7 +20,10 @@ const setRepeatable = require('~/fb-runner-node/page/set-repeatable/set-repeatab
 const skipComponents = require('~/fb-runner-node/page/skip-components/skip-components')
 const validateInput = require('~/fb-runner-node/page/validate-input/validate-input')
 
-const transformChangePageData = ({route: _id, params} = {}) => ({_id, params})
+const transformChangePageData = ({route: _id, params = {}} = {}) => ({_id, params})
+
+const isUploadCheckPage = ({_type}) => _type === 'page.uploadCheck'
+const isUploadSummaryPage = ({_type}) => _type === 'page.uploadSummary'
 const hasUploadComponents = ({components = []} = {}) => components.some(({_type, ...component}) => _type === 'upload' || hasUploadComponents({...component, _type}))
 
 function checkNextPage (changePage, currentPage, userData) {
@@ -51,10 +54,9 @@ function checkNextPage (changePage, currentPage, userData) {
    *  to either of the steps) the form data for the uploads does not exist,
    *  so it can't be revalidated
    *
-   *  Consequently, pages containing `upload` components are "skipped over" for
-   *  re-validation here -- they are presumed to be valid
-   *
-   *  At some point it may be necessary to create a better mechanism!
+   *  Pages containing `upload` components are dealt with in `getRedirectForNextPage`
+   *  such that execution should not reach here. Regardless, they are presumed to be
+   *  valid (because a journey can't proceed beyond an upload step until it is valid)
    */
   if (!hasUploadComponents(pageInstance)) {
     pageInstance = skipPage(pageInstance, userData)
@@ -106,20 +108,58 @@ module.exports = async function getRedirectForNextPage (pageInstance, userData) 
       params
     }
 
+    /*
+     *  Does the route have a `/change` part?
+     */
     if (changePage) {
+      /*
+       *  If this page has upload components, ensure that the user proceeds to the check step
+       */
+      if (hasUploadComponents(pageInstance)) {
+        const {_id} = getNextPage(pageInstance, userData)
+        if (isUploadCheckPage(getInstance(_id))) {
+          pageInstance.redirect = getRedirectUrl(getUrl(_id, params, userData.contentLang), changePage)
+
+          return pageInstance
+        }
+      }
+
+      /*
+       *  If this is the check step, ensure the user proceeds to the summary step
+       *  (if it is present)
+       */
+      if (isUploadCheckPage(pageInstance)) {
+        const {_id} = getNextPage(pageInstance, userData)
+        if (isUploadSummaryPage(getInstance(_id))) {
+          pageInstance.redirect = getRedirectUrl(getUrl(_id, params, userData.contentLang), changePage)
+
+          return pageInstance
+        }
+      }
+
+      /*
+       *  The page does not have upload components nor is it a check step
+       */
       nextUrl = getNextUrlForChangePage(transformChangePageData(getData(changePage)), currentPage, userData)
 
       if (nextUrl !== changePage) {
-        nextUrl = getRedirectUrl(nextUrl, changePage)
+        pageInstance.redirect = getRedirectUrl(nextUrl, changePage)
+
+        return pageInstance
       }
-    } else {
-      nextUrl = getNextUrl(currentPage, userData)
     }
 
-    if (nextUrl) {
+    /*
+     *  Either `nextUrl` is defined so we can redirect there
+     *  or we can try defining `nextUrl` with `getNextUrl`
+     */
+    if (nextUrl || (nextUrl = getNextUrl(currentPage, userData))) {
       pageInstance.redirect = nextUrl
     }
   }
 
+  /*
+   *  There is no next page
+   */
   return pageInstance
 }

--- a/lib/page/redirect-previous-page/redirect-previous-page.js
+++ b/lib/page/redirect-previous-page/redirect-previous-page.js
@@ -20,7 +20,10 @@ const setRepeatable = require('~/fb-runner-node/page/set-repeatable/set-repeatab
 const skipComponents = require('~/fb-runner-node/page/skip-components/skip-components')
 const validateInput = require('~/fb-runner-node/page/validate-input/validate-input')
 
-const transformChangePageData = ({route: _id, params} = {}) => ({_id, params})
+const transformChangePageData = ({route: _id, params = {}} = {}) => ({_id, params})
+
+const isUploadCheckPage = ({_type}) => _type === 'page.uploadCheck'
+const isUploadSummaryPage = ({_type}) => _type === 'page.uploadSummary'
 const hasUploadComponents = ({components = []} = {}) => components.some(({_type, ...component}) => _type === 'upload' || hasUploadComponents({...component, _type}))
 
 function checkPreviousPage (changePage, currentPage, userData) {
@@ -51,10 +54,9 @@ function checkPreviousPage (changePage, currentPage, userData) {
    *  to either of the steps) the form data for the uploads does not exist,
    *  so it can't be revalidated
    *
-   *  Consequently, pages containing `upload` components are "skipped over" for
-   *  re-validation here -- they are presumed to be valid
-   *
-   *  At some point it may be necessary to create a better mechanism!
+   *  `upload` component check and summary pages are dealt with in `getRedirectForPreviousPage`
+   *  such that execution should not reach here. Regardless, pages containing `upload` components
+   *  are presumed to be valid (because a journey can't proceed beyond an upload step until it is valid)
    */
   if (!hasUploadComponents(pageInstance)) {
     pageInstance = skipPage(pageInstance, userData)
@@ -106,20 +108,41 @@ module.exports = async function getRedirectForPreviousPage (pageInstance, userDa
       params
     }
 
+    /*
+     *  Does the route have a `/change` part?
+     */
     if (changePage) {
+      /*
+       *  If this is the check step or summary step ensure the user proceeds to the upload step
+       */
+      if (isUploadCheckPage(pageInstance) || isUploadSummaryPage(pageInstance)) {
+        const {_id} = getPreviousPage(pageInstance, userData)
+        if (hasUploadComponents(getInstance(_id))) {
+          pageInstance.redirect = getRedirectUrl(getUrl(_id, params, userData.contentLang), changePage)
+
+          return pageInstance
+        }
+      }
+
+      /*
+       *  The page is not a check step or summary step
+       */
       previousUrl = getPreviousUrlForChangePage(transformChangePageData(getData(changePage)), currentPage, userData)
 
       if (previousUrl !== changePage) {
-        previousUrl = getRedirectUrl(previousUrl, changePage)
+        pageInstance.redirect = getRedirectUrl(previousUrl, changePage)
+
+        return pageInstance
       }
-    } else {
-      previousUrl = getPreviousUrl(currentPage, userData)
     }
 
-    if (previousUrl) {
+    if (previousUrl || (previousUrl = getPreviousUrl(currentPage, userData))) {
       pageInstance.redirect = previousUrl
     }
   }
 
+  /*
+   *  There is no previous page
+   */
   return pageInstance
 }


### PR DESCRIPTION
Answers on a `summary` page have _change_ links, including `upload` answers

When the user follows the link to _change_ an `upload` the app redirects them back to the summary page. This is incorrect in the upload pattern: the user _must_ go to the check step before they can return to the summary (because otherwise the upload is discarded)

I have amended the mechanism to ensure that (for pages containing `upload` components) the journey from a _change_ link proceeds to the check step before it resolves back to the summary page