### PR TITLE
Deprecate `eslint-config-fb`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/fb-runner-node",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -170,9 +170,9 @@
       }
     },
     "@ministryofjustice/fb-deploy-utils": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/@ministryofjustice/fb-deploy-utils/-/fb-deploy-utils-1.0.14.tgz",
-      "integrity": "sha512-StlDetzkzIhC2HysKt1QlZb4HrlCXJoOoy7Mh2NzG5PLvH04eTlLkg4TcB2Qemq9PVuGG+ONRMzW8DHmjrVgDg==",
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/fb-deploy-utils/-/fb-deploy-utils-1.0.16.tgz",
+      "integrity": "sha512-Da5lX6C5MWQ3jlwz1lWAPbBLTnX7z8kDvXslxHC4LRXilhghw6IVskFuHa85JKWphXqQzMiFBsya4cnebitedg==",
       "dev": true,
       "requires": {
         "yargs": "^15.1.0"

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "write-file-atomic": "^3.0.1"
   },
   "devDependencies": {
-    "@ministryofjustice/fb-deploy-utils": "^1.0.14",
+    "@ministryofjustice/fb-deploy-utils": "^1.0.16",
     "babel-eslint": "^10.0.3",
     "eslint": "^6.8.0",
     "eslint-config-standard": "^14.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/fb-runner-node",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "engines": {
     "node": "12.4.0"
   },


### PR DESCRIPTION
- Implements `fb-deploy-utils` (the one with the fixes for the one I did earlier)