### PR TITLE
Use ECR repo for docker image in test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,10 @@ jobs:
           command: npm run test
   build_to_test:
     docker:
-      - image: asmega/fb-builder:latest
+      - image: $AWS_ECR_ACCOUNT_URL
+        aws_auth:
+          aws_access_key_id: $AWS_ACCESS_KEY_ID
+          aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
     steps:
       - checkout
       - setup_remote_docker


### PR DESCRIPTION
We no longer want to use the private docker hub repo