### PR TITLE
Adjust dependabot schedule

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -4,7 +4,10 @@ update_configs:
   - package_manager: "javascript"
     directory: "/"
     update_schedule: "live"
-    default_reviewers:
+    allowed_updates: &security_updates
+      - match:
+          update_type: "security"
+    default_reviewers: &default_reviewers
     - asmega
     - sequencemedialimited
     - mattempty
@@ -13,11 +16,14 @@ update_configs:
     - brenetic
   - package_manager: "docker"
     directory: "/"
-    update_schedule: "daily"
-    default_reviewers:
-    - asmega
-    - sequencemedialimited
-    - mattempty
-    - form-builder-developers
-    - tomas-stefano
-    - brenetic
+    update_schedule: "live"
+    allowed_updates: *security_updates
+    default_reviewers: *default_reviewers
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "weekly"
+    default_reviewers: *default_reviewers
+  - package_manager: "docker"
+    directory: "/"
+    update_schedule: "weekly"
+    default_reviewers: *default_reviewers


### PR DESCRIPTION
Dependabot is a little noisy for general updates. This adjusts the
schedule so that security updates are live but more general version
updates are done weekly.