### PR TITLE
Revert dependabot config changes

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -4,9 +4,6 @@ update_configs:
   - package_manager: "javascript"
     directory: "/"
     update_schedule: "live"
-    allowed_updates:
-      - match:
-          update_type: "security"
     default_reviewers:
     - asmega
     - sequencemedialimited
@@ -16,30 +13,7 @@ update_configs:
     - brenetic
   - package_manager: "docker"
     directory: "/"
-    update_schedule: "live"
-    allowed_updates:
-      - match:
-          update_type: "security"
-    default_reviewers:
-    - asmega
-    - sequencemedialimited
-    - mattempty
-    - form-builder-developers
-    - tomas-stefano
-    - brenetic
-  - package_manager: "javascript"
-    directory: "/"
-    update_schedule: "weekly"
-    default_reviewers:
-    - asmega
-    - sequencemedialimited
-    - mattempty
-    - form-builder-developers
-    - tomas-stefano
-    - brenetic
-  - package_manager: "docker"
-    directory: "/"
-    update_schedule: "weekly"
+    update_schedule: "daily"
     default_reviewers:
     - asmega
     - sequencemedialimited


### PR DESCRIPTION
It turns out that we cannot currently achieve what we would like with
the multiple schedules per package.

There is an issue about it here:

https://github.com/dependabot/feedback/issues/433

But it was closed recently :(

For the moment revert back to how it was.