### PR TITLE
Maintenance page improvements

### DIFF
--- a/lib/constants/constants.js
+++ b/lib/constants/constants.js
@@ -223,4 +223,8 @@ REALM
 
 LOG_LEVEL
   Level at which bunyan should log at
+
+MAINTENANCE_MODE
+  Flag to put a form under maintenace and make sure that all pages redirect
+  to the maintenance page (with the exception of ping and healthcheck url)
 */

--- a/lib/server/server-middleware.js
+++ b/lib/server/server-middleware.js
@@ -99,6 +99,12 @@ const configureMiddleware = (options = {}) => {
     middleware.push(options.postStaticRoutes())
   }
 
+  // Ping route
+  middleware.push([PING_URL, ping.init()])
+
+  // Healthcheck route
+  middleware.push([HEALTHCHECK_URL, healthcheck.init(options.validateHealthcheck, options)])
+
   const maintenanceUrl = '/restricted/maintenance'
   if (MAINTENANCE_MODE) {
     middleware.push((req, res, next) => {
@@ -198,12 +204,6 @@ disallow: /public`
     res.clearCookie('sessionId')
     res.redirect('/')
   }])
-
-  // Ping route
-  middleware.push([PING_URL, ping.init()])
-
-  // Healthcheck route
-  middleware.push([HEALTHCHECK_URL, healthcheck.init(options.validateHealthcheck, options)])
 
   // Add user data methods to req.user
   middleware.push(useAsync(userData.loadUserData))


### PR DESCRIPTION
The alerts depend on having the /ping.json and /healthcheck.json available so adding them before the maintenance middleware.

Plus added the maintenance mode to the constants basic doc.