### PR TITLE
Add Form Builder Team GA tracking ID

### DIFF
--- a/lib/constants/constants.js
+++ b/lib/constants/constants.js
@@ -134,6 +134,10 @@ insertions,
 
 CONSTANTS.RUNNER_URL = getEnv().RUNNER_OVERRIDE_URL || `http://${SERVICE_SLUG}.formbuilder-services-${PLATFORM_ENV}-${DEPLOYMENT_ENV}:${CONSTANTS.PORT}`
 
+if (DEPLOYMENT_ENV === 'production' || getEnvVarAsBoolean(processEnv.FB_GA_TEST, false)) {
+  CONSTANTS.FORM_BUILDER_GA_TRACKING_ID = processEnv.FORM_BUILDER_GA_TRACKING_ID || 'UA-162688961-1'
+}
+
 Object.freeze(CONSTANTS)
 
 module.exports = CONSTANTS
@@ -210,8 +214,15 @@ ENV
 PORT
   port to listen on - defaults to 3000
 
+FB_GA_TEST
+  Enables the Form Builder GA tracking if required for testing
+
+FORM_BUILDER_GA_TRACKING_ID
+  Form Builder Team Google Analytics ID
+
 GA_TRACKING_ID
-  Google Analytics ID
+  Google Analytics ID for form owners only.
+  Usually entered by the form owner via config params in Publisher
 
 SENTRY_DSN
   Sentry ID

--- a/lib/constants/constants.set.values.unit.spec.js
+++ b/lib/constants/constants.set.values.unit.spec.js
@@ -30,6 +30,7 @@ const processEnv = {
   NUNJUCKS_NOCACHE: 'false',
   NUNJUCKS_WATCH: 'true',
   GA_TRACKING_ID: 'UA-1234',
+  FORM_BUILDER_TRACKING_ID: 'UA-5678',
   SENTRY_DSN: 'raven-maven',
   USERNAME: 'user',
   PASSWORD: '1234',
@@ -130,6 +131,11 @@ test('When the NUNJUCKS_WATCH ENV variable is set', t => {
 
 test('When the GA_TRACKING_ID ENV variable is set', t => {
   t.equal(constants.GA_TRACKING_ID, 'UA-1234', 'constants should set GA_TRACKING_ID to that value')
+  t.end()
+})
+
+test('When the FORM_BUILDER_TRACKING_ID ENV variable is set', t => {
+  t.equal(constants.FORM_BUILDER_TRACKING_ID, 'UA-5678', 'constants should set FORM_BUILDER_TRACKING_ID to that value')
   t.end()
 })
 

--- a/lib/middleware/routes-metadata/routes-metadata.js
+++ b/lib/middleware/routes-metadata/routes-metadata.js
@@ -74,6 +74,7 @@ const CONSTANTS = require('~/fb-runner-node/constants/constants') // this is als
 
 const {
   PLATFORM_ENV,
+  FORM_BUILDER_GA_TRACKING_ID,
   GA_TRACKING_ID
 } = CONSTANTS
 
@@ -609,6 +610,7 @@ async function pageHandler (req, res) {
     const userdata = userData.getUserData()
     const { _scopes } = userData.getScopedUserData()
     const context = {
+      FORM_BUILDER_GA_TRACKING_ID,
       GA_TRACKING_ID,
       userdata,
       _scopes,

--- a/package-lock.json
+++ b/package-lock.json
@@ -148,9 +148,9 @@
       }
     },
     "@ministryofjustice/fb-components": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@ministryofjustice/fb-components/-/fb-components-1.2.1.tgz",
-      "integrity": "sha512-dm19olN+L0sjPxFTo+EZqugE7aMAzx69G2M5d1HNQJrHDH0FXywPhNTG00nEgVCBguVODQvzm19AJIWbBDjYUQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/fb-components/-/fb-components-1.3.0.tgz",
+      "integrity": "sha512-rdZ/WuWdEvI4/KWheO2q1OMLSCN6+LNPaaYNEszIox/JLUCWmUVlqtijuLNzJwdZzb5fO8KpnZwmtnDVyOaKcg==",
       "requires": {
         "@ministryofjustice/module-alias": "^1.0.13",
         "accessible-autocomplete": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "license": "MIT",
   "dependencies": {
     "@ministryofjustice/fb-client": "2.0.5",
-    "@ministryofjustice/fb-components": "1.2.1",
+    "@ministryofjustice/fb-components": "1.3.0",
     "@ministryofjustice/module-alias": "^1.0.13",
     "@promster/express": "^4.1.2",
     "@sentry/node": "^5.15.0",


### PR DESCRIPTION
This adds the google analytics form builder specific tracking ID.

It will be injected into the production containers. Form owner analytics
should still continue to work as normal.

https://trello.com/c/AG3VbQ8b/343-metrics-no-of-users-per-form-per-week-per-day-per-hour