### PR TITLE
Make sure CSV submissions can accept multiple destinations

### DIFF
--- a/lib/controller/page/type/page.summary/index.js
+++ b/lib/controller/page/type/page.summary/index.js
@@ -299,6 +299,24 @@ module.exports = class SummaryController extends CommonController {
     const emailFrom = defaultEmailAddress ? formatEmail(defaultEmailAddress) : '"Form Builder" <form-builder-team@digital.justice.gov.uk>'
     const emailTo = formatEmail(SERVICE_OUTPUT_EMAIL)
 
+    let toTeamParts = emailTo.split(/,\s*/)
+
+    toTeamParts = toTeamParts
+      .map((address) => {
+        address = address.trim()
+        if (!address.match(/^e\[.+\]$/)) {
+          return address
+        }
+        const addressLookup = address.replace(/^e\[(.+)\]$/, '$1')
+        return CONSTANTS[addressLookup] || address
+      })
+      .filter((address) => address)
+      .map((address) => address.split(/,\s*/))
+
+    // flatten
+    toTeamParts = [].concat(...toTeamParts)
+    toTeamParts = [...new Set(toTeamParts)]
+
     const submission = {
       type: 'csv',
       recipientType: 'team',
@@ -312,7 +330,9 @@ module.exports = class SummaryController extends CommonController {
       attachments: []
     }
 
-    submissions.push(submission)
+    toTeamParts.forEach((to) => {
+      submissions.push(Object.assign({}, submission, { to }))
+    })
   }
 
   async postValidation (pageInstance, userData) {

--- a/lib/controller/page/type/page.summary/index.unit.spec.js
+++ b/lib/controller/page/type/page.summary/index.unit.spec.js
@@ -528,3 +528,98 @@ test('actions contains email and json actions', async t => {
   submitterClientSpy.resetHistory()
   t.end()
 })
+
+test('split emails from json, csv and normal submissions', async t => {
+  submitterClientSpy.resetHistory()
+
+  const PageSummaryController = proxyquire('.', {
+    '~/fb-runner-node/presenter/pdf-payload': { pdfPayload: pdfPayloadStub },
+    '~/fb-runner-node/presenter/submission-data-with-labels': { submissionDataWithLabels: submissionDataWithLabelsStub },
+    '~/fb-runner-node/page/check-submits/check-submits': { checkSubmits: checkSubmitsStub },
+    '~/fb-runner-node/constants/constants': {
+      SERVICE_OUTPUT_JSON_ENDPOINT: 'https://example.com/adaptor',
+      SERVICE_OUTPUT_JSON_KEY: 'shared_key',
+      SERVICE_OUTPUT_EMAIL: 'bob@gov.uk,bob@justice.gov.uk',
+      SERVICE_OUTPUT_CSV: 'true'
+    }
+  })
+
+  getInstancePropertyStub.withArgs('service', 'emailTemplateUser').returns('you ({firstname}) submitted!')
+
+  const userdata = getUserDataMethods({
+    input: {
+      firstname: 'bob',
+      email: 'test@emample.com'
+    }
+  })
+
+  const pageSummaryController = new PageSummaryController()
+
+  await pageSummaryController.postValidation({}, userdata)
+
+  const submissions = submitterClientSpy.getCall(0).args[0]
+
+  t.equals(submissions.actions.length, 6)
+
+  // remove deprecated fields
+  submissions.actions.map(action => {
+    delete action.attachments
+    delete action.user_answers
+  })
+
+  t.deepEquals(submissions.actions, [
+    {
+      recipientType: 'team',
+      type: 'email',
+      from: '"Form Builder" <form-builder-team@digital.justice.gov.uk>',
+      subject: 'undefined submission',
+      email_body: 'user bob submitted!',
+      include_pdf: true,
+      include_attachments: true,
+      to: 'bob@gov.uk'
+    }, {
+      recipientType: 'team',
+      type: 'email',
+      from: '"Form Builder" <form-builder-team@digital.justice.gov.uk>',
+      subject: 'undefined submission',
+      email_body: 'user bob submitted!',
+      include_pdf: true,
+      include_attachments: true,
+      to: 'bob@justice.gov.uk'
+    }, {
+      recipientType: 'user',
+      type: 'email',
+      from: '"Form Builder" <form-builder-team@digital.justice.gov.uk>',
+      subject: 'Your undefined submission',
+      email_body: 'you (bob) submitted!',
+      include_pdf: false,
+      include_attachments: false,
+      to: 'test@emample.com'
+    }, {
+      type: 'json',
+      url: 'https://example.com/adaptor',
+      encryption_key: 'shared_key'
+    }, {
+      type: 'csv',
+      recipientType: 'team',
+      from: '"Form Builder" <form-builder-team@digital.justice.gov.uk>',
+      to: 'bob@gov.uk',
+      email_body: '',
+      include_pdf: false,
+      subject: 'undefined submission',
+      include_attachments: true
+    }, {
+      type: 'csv',
+      recipientType: 'team',
+      from: '"Form Builder" <form-builder-team@digital.justice.gov.uk>',
+      to: 'bob@justice.gov.uk',
+      email_body: '',
+      include_pdf: false,
+      subject: 'undefined submission',
+      include_attachments: true
+    }
+  ])
+
+  submitterClientSpy.resetHistory()
+  t.end()
+})


### PR DESCRIPTION
[Trello Card](https://trello.com/c/EyxBPYSR/398-fix-csv-email-sending-bug-13-bug-classification)

## Context

In the runner node the to field for csv attachments does not split
multiple email addresses on the comma therefore when the payload reaches
AWS SES it throws and InvalidParameter exception.

This causes the submission to get put on the failed queue which in turn
keeps trying a number of times.

## Next steps

- [ ] Add acceptance tests for this