### PR TITLE
Make sure conditional flow works after upload check pages

### DIFF
--- a/lib/page/skip-page/skip-page.js
+++ b/lib/page/skip-page/skip-page.js
@@ -10,7 +10,9 @@ const skipPage = (pageInstance, userData) => {
     if (!showPage) {
       pageInstance.$skipPage = true
       if (!pageInstance.nextpage) {
-        throw new Error(404)
+        if (pageInstance._type !== 'page.uploadCheck') {
+          throw new Error(404)
+        }
       } else {
         pageInstance.redirect = pageInstance.nextpage
       }


### PR DESCRIPTION
[https://trello.com/c/kPrl3gco/448-bug-check-answers-page-does-not-render-in-pa-form]()

## Context

The latest version of the P&A E-File upload form is not rendering the summary page.

Reproduce
1. Visit https://apply-to-become-a-p-and-a-deputy.dev.form.service.justice.gov.uk/
2. Answer questions (No answer) until hit the summary page.

## The fix

When the runner tries to identify the page flow (conditional and upload pages) it breaks because it doesn't know what it comes after the check upload page. Create the conditional on the skip page module fix the issue without affecting other forms.

## Draft PR

Creating a draft PR because I want to make sure all acceptance test are passing before anything.