### PR TITLE
Fix conditional with upload component

### DIFF
--- a/lib/page/redirect-next-page/redirect-next-page.js
+++ b/lib/page/redirect-next-page/redirect-next-page.js
@@ -140,7 +140,11 @@ module.exports = async function getRedirectForNextPage (pageInstance, userData) 
       /*
        *  The page does not have upload components nor is it a check step
        */
-      nextUrl = getNextUrlForChangePage(transformChangePageData(getData(changePage)), currentPage, userData)
+      nextUrl = getNextUrlForChangePage(
+        transformChangePageData(getData(changePage)),
+        currentPage,
+        userData
+      )
 
       if (nextUrl !== changePage) {
         pageInstance.redirect = getRedirectUrl(nextUrl, changePage)

--- a/lib/page/redirect-next-page/redirect-next-page.js
+++ b/lib/page/redirect-next-page/redirect-next-page.js
@@ -153,6 +153,28 @@ module.exports = async function getRedirectForNextPage (pageInstance, userData) 
       }
     }
 
+    const checkNextPage = getInstance(getNextPage(currentPage, userData)._id)
+
+    // if the next page has upload components
+    if (hasUploadComponents(checkNextPage)) {
+      // And the next page has a conditionality.
+      // We don't want to do anything if the next page don't have conditionals.
+      if (checkNextPage.show) {
+        const verifyCondition = userData.evaluate(
+          checkNextPage.show, {
+            pageInstance,
+            instance: pageInstance
+          })
+
+        // if the next page match the criteria
+        if (verifyCondition) {
+          pageInstance.redirect = checkNextPage.url
+
+          return pageInstance
+        }
+      }
+    }
+
     /*
      *  Either `nextUrl` is defined so we can redirect there
      *  or we can try defining `nextUrl` with `getNextUrl`

--- a/lib/route/route.js
+++ b/lib/route/route.js
@@ -507,7 +507,13 @@ function getNextPage (currentPage, userData, recurse) {
   if (checkPageVisibility(nextPage, userData)) {
     return nextPage
   } else {
-    return getNextPage(nextPage, userData)
+    const possibleNextPage = getNextPage(nextPage, userData)
+
+    if (possibleNextPage._type === 'page.uploadCheck' || possibleNextPage._type === 'page.uploadSummary') {
+      const skipUploadConditionalBranch = getNextPage(possibleNextPage, userData)
+      return skipUploadConditionalBranch
+    }
+    return possibleNextPage
   }
 }
 


### PR DESCRIPTION
[https://trello.com/c/kPrl3gco/448-bug-check-answers-page-does-not-render-in-pa-form]()

## Context

The latest version of the P&A E-File upload form is not rendering the summary page.

Reproduce
1. Visit https://apply-to-become-a-p-and-a-deputy.dev.form.service.justice.gov.uk/
2. Answer questions (No answer) until hit the summary page.

## The fix

When the runner tries to identify the page flow (conditional and upload pages) it breaks because it doesn't know what it comes after the check upload page. Create the conditional on the skip page module fix the issue without affecting other forms.

## Draft PR

Creating a draft PR because I want to make sure all acceptance test are passing before anything.