### PR TITLE
Add ability to exclude specific forms from search engine results

### DIFF
--- a/lib/constants/constants.js
+++ b/lib/constants/constants.js
@@ -138,6 +138,8 @@ if (DEPLOYMENT_ENV === 'production' || getEnvVarAsBoolean(processEnv.FB_GA_TEST,
   CONSTANTS.FORM_BUILDER_GA_TRACKING_ID = processEnv.FORM_BUILDER_GA_TRACKING_ID || 'UA-162688961-1'
 }
 
+CONSTANTS.EXCLUDE_FROM_SEARCH_RESULTS = getEnvVarAsBoolean(processEnv.EXCLUDE_FROM_SEARCH_RESULTS, false)
+
 Object.freeze(CONSTANTS)
 
 module.exports = CONSTANTS
@@ -222,6 +224,10 @@ FORM_BUILDER_GA_TRACKING_ID
 
 GA_TRACKING_ID
   Google Analytics ID for form owners only.
+  Usually entered by the form owner via config params in Publisher
+
+EXCLUDE_FROM_SEARCH_RESULTS
+  Stop forms from appearing in search engine results
   Usually entered by the form owner via config params in Publisher
 
 SENTRY_DSN

--- a/lib/constants/constants.unit.spec.js
+++ b/lib/constants/constants.unit.spec.js
@@ -43,6 +43,7 @@ test('When constants is called', t => {
     ASSET_PATH: 'public',
     ASSET_SRC_PATH: '/assets',
     RUNNER_URL: 'http://slug.formbuilder-services-undefined-undefined:3000',
+    EXCLUDE_FROM_SEARCH_RESULTS: false,
     SERVICE_SLUG: 'slug',
     USER_DATASTORE_URL: 'some-url.com',
     SAVE_RETURN_URL: 'some-url.com',

--- a/lib/middleware/routes-metadata/routes-metadata.js
+++ b/lib/middleware/routes-metadata/routes-metadata.js
@@ -75,7 +75,8 @@ const CONSTANTS = require('~/fb-runner-node/constants/constants') // this is als
 const {
   PLATFORM_ENV,
   FORM_BUILDER_GA_TRACKING_ID,
-  GA_TRACKING_ID
+  GA_TRACKING_ID,
+  EXCLUDE_FROM_SEARCH_RESULTS
 } = CONSTANTS
 
 const timeoutWarningExcludedPages = [
@@ -612,6 +613,7 @@ async function pageHandler (req, res) {
     const context = {
       FORM_BUILDER_GA_TRACKING_ID,
       GA_TRACKING_ID,
+      EXCLUDE_FROM_SEARCH_RESULTS,
       userdata,
       _scopes,
       req

--- a/package-lock.json
+++ b/package-lock.json
@@ -148,9 +148,9 @@
       }
     },
     "@ministryofjustice/fb-components": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@ministryofjustice/fb-components/-/fb-components-1.3.0.tgz",
-      "integrity": "sha512-rdZ/WuWdEvI4/KWheO2q1OMLSCN6+LNPaaYNEszIox/JLUCWmUVlqtijuLNzJwdZzb5fO8KpnZwmtnDVyOaKcg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/fb-components/-/fb-components-1.3.1.tgz",
+      "integrity": "sha512-6mzR590QIbYjKEfddjbO6vVRc7hlg/YDR5ux8r7MwhctuFqoPdLaUsMhkd41ptMn14DBYWUyAgtF7Oa6HXnryw==",
       "requires": {
         "@ministryofjustice/module-alias": "^1.0.13",
         "accessible-autocomplete": "^2.0.2",
@@ -1532,9 +1532,9 @@
       }
     },
     "date-fns": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.11.1.tgz",
-      "integrity": "sha512-3RdUoinZ43URd2MJcquzBbDQo+J87cSzB8NkXdZiN5ia1UNyep0oCyitfiL88+R7clGTeq/RniXAc16gWyAu1w=="
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.12.0.tgz",
+      "integrity": "sha512-qJgn99xxKnFgB1qL4jpxU7Q2t0LOn1p8KMIveef3UZD7kqjT3tpFNNdXJelEHhE+rUgffriXriw/sOSU+cS1Hw=="
     },
     "debug": {
       "version": "4.1.1",
@@ -1637,9 +1637,9 @@
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
     "dialog-polyfill": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/dialog-polyfill/-/dialog-polyfill-0.5.0.tgz",
-      "integrity": "sha512-fOj68T8KB6UIsDFmK7zYbmORJMLYkRmtsLM1W6wbCVUWu4Hdcud5bqbvuueTxO84JXtK9HcpCHV9vNwlWUdCIw=="
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/dialog-polyfill/-/dialog-polyfill-0.5.1.tgz",
+      "integrity": "sha512-1+VxuUxUz1aUpVoZZADSx/PAtMJedtvOFzLJ/HYWboXxmWwtxBPnYzK8IDgxvojcpetewaJJg30f2pIvo4zbLw=="
     },
     "dicer": {
       "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "license": "MIT",
   "dependencies": {
     "@ministryofjustice/fb-client": "2.0.5",
-    "@ministryofjustice/fb-components": "1.3.0",
+    "@ministryofjustice/fb-components": "1.3.1",
     "@ministryofjustice/module-alias": "^1.0.13",
     "@promster/express": "^4.1.2",
     "@sentry/node": "^5.15.0",


### PR DESCRIPTION
Conditionally add the robots meta tag to the head of each page in a form.

This will be set in Publisher when deploying the form.

[Corresponding FB Components PR](https://github.com/ministryofjustice/fb-components/pull/153)

https://trello.com/c/tfYNqqlc/498-stop-search-engines-indexing-the-cop-form