### PR TITLE
Fix all date validations!

### DIFF
--- a/lib/page/validate-input/validate-input.js
+++ b/lib/page/validate-input/validate-input.js
@@ -17,7 +17,7 @@ const {
   validateInstanceValue
 } = require('./validate-value/validate-value')
 
-const getPageController = require('~/fb-runner-node/controller/page/get-controller')
+const getPageController = require('~/fb-runner-node/controller/component/get-controller')
 
 const flattenDeep = (arr) => arr.reduce((acc, val) => Array.isArray(val) ? acc.concat(flattenDeep(val)) : acc.concat(val), [])
 
@@ -33,18 +33,16 @@ function validateInput (pageInstance, userData) {
     const requiredErrors = validateRequired(pageInstance, userData)
     const valueErrors = validateValue(pageInstance, userData)
 
-    componentErrors = flattenDeep(
-      nameInstances
-        .reduce((accumulator, component) => {
-          const {
-            validate
-          } = getPageController(component)
-
-          return validate
-            ? accumulator.concat(validate(component, userData, pageInstance))
-            : accumulator
-        }, [])
-    )
+    componentErrors = flattenDeep(nameInstances.reduce((accumulator, component) => {
+      const controller = getPageController(component)
+      if (controller.validate) {
+        const possibleError = controller.validate(component, userData, pageInstance)
+        if (possibleError) {
+          return accumulator.concat(possibleError)
+        }
+      }
+      return accumulator
+    }, []))
 
     errors.push(...requiredErrors)
     errors.push(...valueErrors)

--- a/lib/page/validate-input/validate-input.unit.spec.js
+++ b/lib/page/validate-input/validate-input.unit.spec.js
@@ -42,7 +42,7 @@ function initStubs () {
     '~/fb-runner-node/page/set-errors/set-errors': stubs.setErrorsStub,
     './validate-required/validate-required': stubs.validateRequiredStub,
     './validate-value/validate-value': stubs.validateValueStub,
-    '~/fb-runner-node/controller/page/get-controller': stubs.getPageControllerStub
+    '~/fb-runner-node/controller/component/get-controller': stubs.getPageControllerStub
   }
 
   for (const [stubName, stubValue] of Object.entries(stubConfig)) {

--- a/lib/page/validate-input/validate-value/validate-value.js
+++ b/lib/page/validate-input/validate-value/validate-value.js
@@ -20,6 +20,7 @@ const validateValue = (pageInstance, userData) => {
     if (nameInstance.error) {
       return errors
     }
+
     // don't check composite values
     if (nameInstance.$originalName) {
       return errors


### PR DESCRIPTION
[Trello Card](https://trello.com/c/yO1QTjp8/616-bug-date-component-no-error-validation-seen-in-cff-14-points)

## Context

When a user enters a date in the date field, they should not be able to enter impossible dates
eg 40 03 2020
eg 31 02 2018
eg One Feb 2018

## Consequences

All date field validations are not working in any form.

Forms affected:

Leaver's form
CFF form
CICA form
When I wrote above "all date field validations" I mean the:

Value validation (as stated in the ticket already)
The "before date" validation
The "after date" validation
The "within next" date validation
The "within last" date validation

## Code considerations

Before this PR, the code was trying to find components on page controller which
will never find. Change to components and the syntax of calling the
validation makes the date validation work as we expected.

## Next steps

- [ ] By seeing the code maybe other component validations were not working before this fix. I'll check tomorrow.
- [ ] Add a test on our acceptance repo

