### PR TITLE
Support for Google Tag Manager analytics

### DIFF
--- a/lib/constants/constants.js
+++ b/lib/constants/constants.js
@@ -226,6 +226,10 @@ GA_TRACKING_ID
   Google Analytics ID for form owners only.
   Usually entered by the form owner via config params in Publisher
 
+GTM_TRACKING_ID
+  Google Tag Manager ID for form owners only.
+  Usually entered by the form owner via config params in Publisher
+
 EXCLUDE_FROM_SEARCH_RESULTS
   Stop forms from appearing in search engine results
   Usually entered by the form owner via config params in Publisher

--- a/lib/constants/constants.set.values.unit.spec.js
+++ b/lib/constants/constants.set.values.unit.spec.js
@@ -30,6 +30,7 @@ const processEnv = {
   NUNJUCKS_NOCACHE: 'false',
   NUNJUCKS_WATCH: 'true',
   GA_TRACKING_ID: 'UA-1234',
+  GTM_TRACKING_ID: 'GTM-1234',
   FORM_BUILDER_TRACKING_ID: 'UA-5678',
   SENTRY_DSN: 'raven-maven',
   USERNAME: 'user',
@@ -131,6 +132,11 @@ test('When the NUNJUCKS_WATCH ENV variable is set', t => {
 
 test('When the GA_TRACKING_ID ENV variable is set', t => {
   t.equal(constants.GA_TRACKING_ID, 'UA-1234', 'constants should set GA_TRACKING_ID to that value')
+  t.end()
+})
+
+test('When the GTM_TRACKING_ID ENV variable is set', t => {
+  t.equal(constants.GTM_TRACKING_ID, 'GTM-1234', 'constants should set GTM_TRACKING_ID to that value')
   t.end()
 })
 

--- a/lib/middleware/error-handler/error-handler.js
+++ b/lib/middleware/error-handler/error-handler.js
@@ -12,7 +12,10 @@ const {
 } = require('~/fb-runner-node/page/page')
 
 const errorHandler = (options = {}) => {
-  const { GA_TRACKING_ID } = options
+  const {
+    GA_TRACKING_ID,
+    GTM_TRACKING_ID
+  } = options
   const external = {}
 
   external._fallbackError = (req, res, errCode = 500) => {
@@ -46,7 +49,8 @@ const errorHandler = (options = {}) => {
       try {
         const output = await nunjucksConfiguration.renderPage(errorInstance, Object.assign({}, res.locals, {
           errCode,
-          GA_TRACKING_ID
+          GA_TRACKING_ID,
+          GTM_TRACKING_ID
         }))
         res.send(output)
         return

--- a/lib/middleware/error-handler/error-handler.unit.spec.js
+++ b/lib/middleware/error-handler/error-handler.unit.spec.js
@@ -103,7 +103,9 @@ test('When render method is called and an error instance exists', async t => {
 
   try {
     await errorHandlerInstance.render(req, res, 404)
-    t.true(nunjucksRenderStub.calledWithExactly(errorInstance, { errCode: 404, GA_TRACKING_ID: undefined }), 'should invoke the nunjucks render method with the correct arguments')
+    t.true(nunjucksRenderStub.calledWithExactly(
+      errorInstance, { errCode: 404, GA_TRACKING_ID: undefined, GTM_TRACKING_ID: undefined }
+    ), 'should invoke the nunjucks render method with the correct arguments')
     t.true(resSendSpy.calledWith(errorOutput), 'it should send the correct output')
   } catch (e) {
     t.notOk(true, 'it should not throw an error')
@@ -145,7 +147,9 @@ test('When render method is called and an error instance exists', async t => {
   try {
     await errorHandlerInstance.render(req, res, 500)
 
-    t.true(nunjucksRenderStub.calledWithExactly(errorInstance, { errCode: 500, GA_TRACKING_ID: undefined }), 'should invoke the nunjucks render method with the correct arguments')
+    t.true(nunjucksRenderStub.calledWithExactly(
+      errorInstance, { errCode: 500, GA_TRACKING_ID: undefined, GTM_TRACKING_ID: undefined }
+    ), 'should invoke the nunjucks render method with the correct arguments')
     t.true(resSendSpy.calledWith(errorOutput), 'it should send the correct output')
   } catch (e) {
     t.notOk(true, 'it should not throw an error')
@@ -157,7 +161,9 @@ test('When render method is called and an error instance exists', async t => {
   try {
     await errorHandlerInstance.render(req, res, 503)
 
-    t.true(nunjucksRenderStub.calledWithExactly(errorInstance, { errCode: 503, GA_TRACKING_ID: undefined }), 'should invoke the nunjucks render method with the correct arguments')
+    t.true(nunjucksRenderStub.calledWithExactly(
+      errorInstance, { errCode: 503, GA_TRACKING_ID: undefined, GTM_TRACKING_ID: undefined }
+    ), 'should invoke the nunjucks render method with the correct arguments')
     t.true(resSendSpy.calledWith(errorOutput), 'it should send the correct output')
   } catch (e) {
     t.notOk(true, 'it should not throw an error')
@@ -169,7 +175,9 @@ test('When render method is called and an error instance exists', async t => {
   try {
     await errorHandlerInstance.render(req, res, 404)
 
-    t.true(nunjucksRenderStub.calledWithExactly(errorInstance, { errCode: 404, GA_TRACKING_ID: undefined }), 'should invoke the nunjucks render method with the correct arguments')
+    t.true(nunjucksRenderStub.calledWithExactly(
+      errorInstance, { errCode: 404, GA_TRACKING_ID: undefined, GTM_TRACKING_ID: undefined }
+    ), 'should invoke the nunjucks render method with the correct arguments')
     t.true(resSendSpy.calledWith(errorOutput), 'it should send the correct output')
   } catch (e) {
     t.notOk(true, 'it should not throw an error')

--- a/lib/middleware/routes-metadata/routes-metadata.js
+++ b/lib/middleware/routes-metadata/routes-metadata.js
@@ -76,6 +76,7 @@ const {
   PLATFORM_ENV,
   FORM_BUILDER_GA_TRACKING_ID,
   GA_TRACKING_ID,
+  GTM_TRACKING_ID,
   EXCLUDE_FROM_SEARCH_RESULTS
 } = CONSTANTS
 
@@ -613,6 +614,7 @@ async function pageHandler (req, res) {
     const context = {
       FORM_BUILDER_GA_TRACKING_ID,
       GA_TRACKING_ID,
+      GTM_TRACKING_ID,
       EXCLUDE_FROM_SEARCH_RESULTS,
       userdata,
       _scopes,

--- a/lib/server/server-middleware.js
+++ b/lib/server/server-middleware.js
@@ -52,7 +52,8 @@ const configureMiddleware = (options = {}) => {
     ASSET_PATH,
     ASSET_SRC_PATH,
     SENTRY_DSN,
-    GA_TRACKING_ID
+    GA_TRACKING_ID,
+    GTM_TRACKING_ID
   } = options
 
   const middleware = []
@@ -235,7 +236,7 @@ disallow: /public`
   middleware.push(routesNunjucks.init())
 
   // Configure error handler GA usage
-  const errorHandlerInstance = errorHandler.init({ GA_TRACKING_ID })
+  const errorHandlerInstance = errorHandler.init({ GA_TRACKING_ID, GTM_TRACKING_ID })
 
   // if reached, it's not found
   middleware.push(errorHandlerInstance.notFound)

--- a/package-lock.json
+++ b/package-lock.json
@@ -148,9 +148,9 @@
       }
     },
     "@ministryofjustice/fb-components": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@ministryofjustice/fb-components/-/fb-components-1.3.4.tgz",
-      "integrity": "sha512-/ZFyufj6LrGkkm015NAzq7gCuZiTrxJ1b8xEn3EabvZ3zNK3DMHRNABHqp15GzsFThEPaOS8/sHZ5kpDM1at2Q==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/fb-components/-/fb-components-1.3.5.tgz",
+      "integrity": "sha512-xibzefF2IdlQqs03OWhdzgumIXsXnvP2moekuqAfwa/BSPH6VVvyn50OLtM10/VZbwF6GIcyW9ZpWWcy5cZPrQ==",
       "requires": {
         "@ministryofjustice/module-alias": "^1.0.13",
         "accessible-autocomplete": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "license": "MIT",
   "dependencies": {
     "@ministryofjustice/fb-client": "2.0.6",
-    "@ministryofjustice/fb-components": "1.3.4",
+    "@ministryofjustice/fb-components": "1.3.5",
     "@ministryofjustice/module-alias": "^1.0.13",
     "@promster/express": "^4.1.2",
     "@sentry/node": "^5.15.0",


### PR DESCRIPTION
Support for Google Tag Manager analytics was added in [this PR](ministryofjustice/fb-components#171).

Here we make the necessary adjustments to surface the environment variable in the views.

https://trello.com/c/9ixojbqC/643-test-the-google-tag-manager-changes