### PR TITLE
Handle save and return no email error

### DIFF
--- a/lib/middleware/nunjucks-configuration/nunjucks-configuration.js
+++ b/lib/middleware/nunjucks-configuration/nunjucks-configuration.js
@@ -13,6 +13,9 @@ const nunjucksHelpers = require('@ministryofjustice/fb-components/templates/nunj
 
 const cloneDeep = require('lodash.clonedeep')
 
+const debug = require('debug')
+const error = debug('runner:nunjucks-configuration:error')
+
 let nunjucksAppEnv
 
 const nunjucksConfiguration = (app, components = [], options = {}) => {
@@ -129,8 +132,7 @@ const getPageOutput = async (pageInstance, context = {}) => {
     const renderContext = Object.assign({}, context, { page })
     nunjucksAppEnv.render(templatePath, renderContext, (err, output) => {
       if (err) {
-      // TODO: log error not console.log(err)
-      // console.log({templatePath, page})
+        error(`${templatePath} -> ${err.message}`)
         reject(err)
       }
       Object.keys(sanitizeMatches).forEach(property => {

--- a/lib/module/savereturn/controller/page/type/return.start/return.start.controller.js
+++ b/lib/module/savereturn/controller/page/type/return.start/return.start.controller.js
@@ -3,9 +3,13 @@ require('@ministryofjustice/module-alias/register-module')(module)
 const cloneDeep = require('lodash.clonedeep')
 
 const CommonController = require('~/fb-runner-node/module/savereturn/controller/page/common')
+const {
+  setErrors
+} = require('~/fb-runner-node/page/set-errors/set-errors')
 
 const {
   client,
+  handleValidationError,
   sendEmail,
   getConfig
 } = require('~/fb-runner-node/module/savereturn/controller/savereturn')
@@ -20,14 +24,31 @@ module.exports = class StartController extends CommonController {
     try {
       const token = await client.createMagiclink(email, duration, userData.logger)
       await sendEmail('email.return.signin.email', userData, { token })
-    } catch (e) {
-      const { code } = e
+    } catch (error) {
+      const { code } = error
 
       if (code !== 'ENOENCRYPTVALUE') {
-        throw e
+        const errorsInstance = handleValidationError(error, 'error')
+        pageInstance = registerReturnStartErrors(errorsInstance, pageInstance, error)
+        return pageInstance
       }
     }
 
     return pageInstance
   }
+}
+
+function registerReturnStartErrors (errorsInstance, pageInstance, error) {
+  const component = pageInstance.components[0] // single component on the page currently
+  errorsInstance.instance = {
+    _id: component._id,
+    _type: component._type,
+    name: component.name
+  }
+  errorsInstance.errorType = error.message
+
+  pageInstance = setErrors(pageInstance, [errorsInstance])
+  // This stops the page from redirecting to the next step
+  pageInstance.$validated = false
+  return pageInstance
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -148,9 +148,9 @@
       }
     },
     "@ministryofjustice/fb-components": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@ministryofjustice/fb-components/-/fb-components-1.3.2.tgz",
-      "integrity": "sha512-k/sSC9cqoJKrPk7XAbxPoA5V4Uj8S16+/jcbVb8ZS0X1IW4SvBN+eRkHeK/Iek1fPwv+yDfMKTda6Hm3lyi/3Q==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/fb-components/-/fb-components-1.3.3.tgz",
+      "integrity": "sha512-LLFYRx9GDi8sOlRwdh3+HJVkTbDGlgHv0B0MlUeiwLYC0udbH83G327T2dOeKWVjkvUPSQyTWzPFiWvKxxTD6A==",
       "requires": {
         "@ministryofjustice/module-alias": "^1.0.13",
         "accessible-autocomplete": "^2.0.2",
@@ -163,7 +163,7 @@
         "glob-promise": "^3.4.0",
         "govuk-frontend": "^3.6.0",
         "json-schema-merge-allof": "^0.7.0",
-        "json-schema-ref-parser": "^8.0.0",
+        "json-schema-ref-parser": "^9.0.1",
         "jsonlint": "^1.6.3",
         "jsonpath": "^1.0.2",
         "markdown-it": "^11.0.0",
@@ -171,26 +171,6 @@
         "nunjucks": "^3.2.1",
         "shelljs": "^0.8.3",
         "yargs": "^15.3.1"
-      },
-      "dependencies": {
-        "@apidevtools/json-schema-ref-parser": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-8.0.0.tgz",
-          "integrity": "sha512-n4YBtwQhdpLto1BaUCyAeflizmIbaloGShsPyRtFf5qdFJxfssj+GgLavczgKJFa3Bq+3St2CKcpRJdjtB4EBw==",
-          "requires": {
-            "@jsdevtools/ono": "^7.1.0",
-            "call-me-maybe": "^1.0.1",
-            "js-yaml": "^3.13.1"
-          }
-        },
-        "json-schema-ref-parser": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-8.0.0.tgz",
-          "integrity": "sha512-2P4icmNkZLrBr6oa5gSZaDSol/oaBHYkoP/8dsw63E54NnHGRhhiFuy9yFoxPuSm+uHKmeGxAAWMDF16SCHhcQ==",
-          "requires": {
-            "@apidevtools/json-schema-ref-parser": "8.0.0"
-          }
-        }
       }
     },
     "@ministryofjustice/fb-deploy-utils": {
@@ -3562,9 +3542,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.6.0.tgz",
-      "integrity": "sha512-wTxufdY8vFvKJ2EmmQKmarrQ7n30kzg+vvqgGib2dawl7c5Wst8dffkEJQpy9Zs99TE/yEEFgj0VUO4GRUO22A=="
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.7.0.tgz",
+      "integrity": "sha512-G3bqoKGGF8YQ18UJH9tTARrwB8i7iPwN1xc8RXwWyx91q0p/Xl10uNywZLkzGWcJDzEz1vwmBTTL3SLDU/KxNg=="
     },
     "graceful-fs": {
       "version": "4.2.3",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "license": "MIT",
   "dependencies": {
     "@ministryofjustice/fb-client": "2.0.6",
-    "@ministryofjustice/fb-components": "1.3.2",
+    "@ministryofjustice/fb-components": "1.3.3",
     "@ministryofjustice/module-alias": "^1.0.13",
     "@promster/express": "^4.1.2",
     "@sentry/node": "^5.15.0",


### PR DESCRIPTION
# What

When the datastore is not able to find an email in returns a 401 with the message `email.missing`.

Previously the return.start controller would just throw the error without properly handling it. This resulted in the Runner defaulting back to the `error.500` and presenting that to the user.

Now we handle the returned error, register the error instance with the page instance and then return that so the runner understands to show the user the start page again and present the error message to the user.

Also add error logging in a place where someone said there should be error

# Before

<img width="989" alt="Screenshot 2020-06-10 at 22 48 36" src="https://user-images.githubusercontent.com/3466862/84322549-13c9d200-ab6d-11ea-9c64-6c846e0d23ff.png">

# After

<img width="984" alt="Screenshot 2020-06-10 at 22 49 20" src="https://user-images.githubusercontent.com/3466862/84322571-1af0e000-ab6d-11ea-8fb3-b9ba12f0725d.png">

https://trello.com/c/vpTqfNHA/336-bug-save-and-return-13-points-bug-classification-timebox-3hrs

Co-authored-by Tomas Destefi <tomas.destefi@digital.justice.gov.uk>