### PR TITLE
Trigger acceptance tests only if test job passes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,11 +132,13 @@ workflows:
   version: 2
   test_and_build:
     jobs:
+      - test
       - trigger_acceptance_tests:
+          requires:
+            - test
           filters:
             branches:
               only: master
-      - test
       - publish:
           requires:
             - test


### PR DESCRIPTION
We only want to trigger acceptance tests if the test job step has actually passed.