### PR TITLE
Call correct method to clear session data

### DIFF
--- a/lib/module/savereturn/controller/page/type/return.signout/return.signout.controller.js
+++ b/lib/module/savereturn/controller/page/type/return.signout/return.signout.controller.js
@@ -7,7 +7,7 @@ const CommonController = require('~/fb-runner-node/module/savereturn/controller/
 module.exports = class SignoutController extends CommonController {
   async preUpdateContents (instance, userData) {
     const pageInstance = cloneDeep(instance)
-    userData.clearSession()
+    userData.clearSessionCookie()
     userData.unsetUserDataProperty('authenticated')
     userData.unsetUserDataProperty('email')
 

--- a/lib/module/savereturn/controller/page/type/return.signout/return.signout.controller.unit.spec.js
+++ b/lib/module/savereturn/controller/page/type/return.signout/return.signout.controller.unit.spec.js
@@ -18,7 +18,7 @@ const SignoutController = proxyquire('./return.signout.controller', {
 
 const userData = {
   unsetUserDataProperty: unsetUserDataPropertyStub,
-  clearSession: clearSessionStub
+  clearSessionCookie: clearSessionStub
 }
 
 const resetStubs = () => {


### PR DESCRIPTION
`clearSessionCookie()` is the correct function name

https://trello.com/c/8GfjPdmW/721-save-and-return-sign-out-functionality-doesnt-allow-a-user-to-sign-out-bug-classification-13