### PR TITLE
Fix check your answers

### DIFF
--- a/lib/page/redirect-next-page/redirect-next-page.js
+++ b/lib/page/redirect-next-page/redirect-next-page.js
@@ -183,7 +183,7 @@ module.exports = async function getRedirectForNextPage (pageInstance, userData) 
     // want to halt execution when saving your progress. Then we continue the
     // flow when the next page contains save and return scope.
     //
-    if (checkNextPage && checkNextPage._type === 'page.exit' && checkNextPage.scope !== 'savereturn') {
+    if (checkNextPage && checkNextPage.show) {
       const verifyCondition = userData.evaluate(
         checkNextPage.show, { pageInstance, instance: pageInstance }
       )


### PR DESCRIPTION
[Trello card]()

## Context

When the user goes to check your answer and user change one of the answers and this changes branches a conditional. Then the user should be redirected to the conditional branch and NOT to check your answers page.

## Acceptance test

https://github.com/ministryofjustice/fb-acceptance-tests/pull/101
