### PR TITLE
Bump runner to 0.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/fb-runner-node",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/fb-runner-node",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "engines": {
     "node": ">=12.4.0"
   },


### PR DESCRIPTION
[Trello Card](https://trello.com/c/dJQpbFdT/779-releasing-a-new-version-of-the-runner-and-update-runner-in-the-editor)

## Context

The Runner is used when you click "Run form" in the editor.

The problem is that the Runner is extremely outdated in the editor. (It is using a version from April 6).
This PR is about to update the Runner to the latest on the editor.

