### PR TITLE
Reduce default session timeout

### DIFF
--- a/lib/middleware/keep-alive/keep-alive.js
+++ b/lib/middleware/keep-alive/keep-alive.js
@@ -4,18 +4,15 @@ const express = require('express')
 const router = express.Router()
 const cookieParser = require('cookie-parser')
 
-const { getInstanceProperty } = require('~/fb-runner-node/service-data/service-data')
-
 const { getSessionOptions } = require('~/fb-runner-node/middleware/user-session/user-session')
 
 function init (options = {}) {
-  const sessionDuration = getInstanceProperty('service', 'sessionDuration')
   const {
     sessionName,
     secure,
     cookiePath,
     cookieMaxAge
-  } = getSessionOptions(options, sessionDuration)
+  } = getSessionOptions(options)
 
   return router
     .use(cookieParser())

--- a/lib/middleware/routes-metadata/routes-metadata.js
+++ b/lib/middleware/routes-metadata/routes-metadata.js
@@ -16,6 +16,10 @@ const {
   getInstanceProperty
 } = require('~/fb-runner-node/service-data/service-data')
 
+const {
+  sessionDuration
+} = require('~/fb-runner-node/middleware/user-session/user-session')
+
 const { format } = require('~/fb-runner-node/format/format')
 const useAsync = require('~/fb-runner-node/middleware/use-async/use-async')
 
@@ -299,7 +303,7 @@ async function pageHandler (req, res) {
 
     let pageInstance = cloneDeep(getInstance(route))
 
-    pageInstance.sessionDuration = getInstanceProperty('service', 'sessionDuration')
+    pageInstance.sessionDuration = sessionDuration()
 
     pageInstance.showTimeoutWarning = true
     if (pageInstance._type && (timeoutWarningExcludedPages.includes(pageInstance._type))) {

--- a/lib/middleware/user-session/user-session.js
+++ b/lib/middleware/user-session/user-session.js
@@ -23,7 +23,7 @@ const {
 // This is a fallback. The actual default session duration is defined here:
 // https://github.com/ministryofjustice/fb-components/blob/master/metadata/config/service.json
 // Can be overriden by a forms own service.json definition
-const defaultSessionTimeout = 20
+const defaultSessionDuration = 20
 
 let serviceSecret
 
@@ -81,7 +81,7 @@ function addUserIdTokenMethods (req, userId, userToken) {
 }
 
 function sessionDuration () {
-  return getInstanceProperty('service', 'sessionDuration', defaultSessionTimeout)
+  return getInstanceProperty('service', 'sessionDuration', defaultSessionDuration)
 }
 
 function getSessionOptions (options = {}) {

--- a/lib/middleware/user-session/user-session.js
+++ b/lib/middleware/user-session/user-session.js
@@ -19,7 +19,11 @@ const {
   }
 } = require('~/fb-runner-node/constants/constants')
 
-const defaultSessionTimeout = 20 // minutes
+// In minutes
+// This is a fallback. The actual default session duration is defined here:
+// https://github.com/ministryofjustice/fb-components/blob/master/metadata/config/service.json
+// Can be overriden by a forms own service.json definition
+const defaultSessionTimeout = 20
 
 let serviceSecret
 
@@ -76,19 +80,22 @@ function addUserIdTokenMethods (req, userId, userToken) {
   req.getUserToken = () => userToken
 }
 
-function getSessionOptions (options = {}, cookieMaxAge = 60) {
+function sessionDuration () {
+  return getInstanceProperty('service', 'sessionDuration', defaultSessionTimeout)
+}
+
+function getSessionOptions (options = {}) {
   return Object.assign({}, {
     sessionName: 'sessionId',
     secure: !!PLATFORM_ENV,
     cookiePath: '/',
-    cookieMaxAge
+    cookieMaxAge: sessionDuration()
   }, options)
 }
 
 function init (options = {}) {
   // set secure: true when proper environments
-  const sessionDuration = getInstanceProperty('service', 'sessionDuration', defaultSessionTimeout)
-  const sessionOptions = getSessionOptions(options, sessionDuration)
+  const sessionOptions = getSessionOptions(options)
 
   sessionName = sessionOptions.sessionName
   secure = sessionOptions.secure
@@ -155,7 +162,8 @@ const external = {
   clearSessionAndRedirect,
   createSessionCookie,
   createSessionAndRedirect,
-  getSessionOptions
+  getSessionOptions,
+  sessionDuration
 }
 
 module.exports = external

--- a/lib/middleware/user-session/user-session.js
+++ b/lib/middleware/user-session/user-session.js
@@ -19,7 +19,7 @@ const {
   }
 } = require('~/fb-runner-node/constants/constants')
 
-const defaultSessionTimeout = 60 // minutes
+const defaultSessionTimeout = 20 // minutes
 
 let serviceSecret
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/fb-runner-node",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -157,9 +157,9 @@
       }
     },
     "@ministryofjustice/fb-components": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/@ministryofjustice/fb-components/-/fb-components-1.3.6.tgz",
-      "integrity": "sha512-4ipXLgZVt+1YVZmCBReY9uSNABDYbof7WjKA8ugGzeCVs+ZcKS1M5reZk0+lhP+ezDQ3yQOu5tOi2bWQG6a1UA==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/fb-components/-/fb-components-1.3.7.tgz",
+      "integrity": "sha512-OA5nQYCNZ/MoT8zOTKwI1xZJjfIt98F/3DdS/1nIeaOV146L+C7JpFihpRcneqf+D8KUuNIAqD0SDDwZuqS4Dg==",
       "requires": {
         "@ministryofjustice/module-alias": "^1.0.13",
         "accessible-autocomplete": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "license": "MIT",
   "dependencies": {
     "@ministryofjustice/fb-client": "2.0.6",
-    "@ministryofjustice/fb-components": "1.3.6",
+    "@ministryofjustice/fb-components": "1.3.7",
     "@ministryofjustice/module-alias": "^1.0.13",
     "@promster/express": "^4.1.2",
     "@sentry/node": "^5.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/fb-runner-node",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "engines": {
     "node": ">=12.4.0"
   },


### PR DESCRIPTION
This was previously increased to cater for forms that have large text fields and may take some time for the user to input the required information.

There are not many forms with this requirement so we can set the session timeout individually for those particular forms without having to do it globally.

- Use fb-components 1.3.7
- Make sure that sessionDuration is only defined in one place
- Rename for consistence

It will also update the dynamic wording on the save and return page:

<img width="994" alt="Screenshot 2020-07-13 at 14 54 45" src="https://user-images.githubusercontent.com/3466862/87314774-9bfc1800-c51b-11ea-8af7-7ffd299e0de9.png">


https://trello.com/c/QoSSTIXg/746-default-session-timeout