### PR TITLE
Fix content/exit pages rendering

### DIFF
--- a/lib/route/route.js
+++ b/lib/route/route.js
@@ -509,7 +509,7 @@ function getNextPage (currentPage, userData, recurse) {
   } else {
     const possibleNextPage = getNextPage(nextPage, userData)
 
-    if (possibleNextPage._type === 'page.uploadCheck' || possibleNextPage._type === 'page.uploadSummary') {
+    if (possibleNextPage && (possibleNextPage._type === 'page.uploadCheck' || possibleNextPage._type === 'page.uploadSummary')) {
       const skipUploadConditionalBranch = getNextPage(possibleNextPage, userData)
       return skipUploadConditionalBranch
     }


### PR DESCRIPTION
Before this fixes the exit pages was returning an error

## How to reproduce

1. Create normal pages.
2. Create a conditional page that if the answer is Yes (or No) it goes to the exit pate
3. Tries to edit or view the exit page.

## Fix

The fix is because the possible next page doesn't exist and then possible next page is undefined. 


## What is left

Maybe reproducing in the acceptance tests?