### PR TITLE
Surface SUBMISSION_ENCRYPTION_KEY in the runner container 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,7 @@
 export SERVICE_SLUG=slug
 export SERVICE_SECRET=secret
 export SERVICE_TOKEN=token
+export SUBMISSION_ENCRYPTION_KEY=key
 
 ####################################
 #                                  #

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ In **Runner**, create an `.envmocks` file at the root of the project:
 export SERVICE_SLUG=slug
 export SERVICE_SECRET=secret
 export SERVICE_TOKEN=token
+export SUBMISSION_ENCRYPTION_KEY=key
 export USER_DATASTORE_URL=http://localhost:44444
 export USER_FILESTORE_URL=http://localhost:44445
 export SUBMITTER_URL=http://localhost:44446

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
 #       SUBMITTER_URL: http://localhost:44446
 #       SERVICE_SECRET: sekrit
 #       SERVICE_SLUG: slug
+#       SUBMISSION_ENCRYPTION_KEY: key
     volumes:
       - '.:/app'
       - 'node_modules:/usr/src/app/node_modules'

--- a/lib/client/submitter/submitter.js
+++ b/lib/client/submitter/submitter.js
@@ -8,11 +8,18 @@ const {
   SERVICE_SECRET,
   SERVICE_SLUG,
   SUBMITTER_URL,
-  ENCODED_PRIVATE_KEY
+  ENCODED_PRIVATE_KEY,
+  SUBMISSION_ENCRYPTION_KEY
 } = require('~/fb-runner-node/constants/constants')
 
 const submitterClient = SUBMITTER_URL
-  ? new FBSubmitterClient(SERVICE_SECRET, SERVICE_SLUG, SUBMITTER_URL, ENCODED_PRIVATE_KEY)
+  ? new FBSubmitterClient(
+    SERVICE_SECRET,
+    SERVICE_SLUG,
+    SUBMITTER_URL,
+    ENCODED_PRIVATE_KEY,
+    SUBMISSION_ENCRYPTION_KEY
+  )
   : FBSubmitterClient.offline()
 
 const {

--- a/lib/constants/constants.js
+++ b/lib/constants/constants.js
@@ -26,7 +26,8 @@ const {
   PLATFORM_ENV,
   DEPLOYMENT_ENV,
   UPLOADS_DIR = '/tmp/uploads',
-  MAINTENANCE_MODE
+  MAINTENANCE_MODE,
+  SUBMISSION_ENCRYPTION_KEY
 } = processEnv
 
 // Ensure that both datastore url are both set or unset
@@ -41,6 +42,12 @@ if (USER_DATASTORE_URL || SUBMITTER_URL) {
     throw new ConstantsError({
       code: 'ENOSERVICESLUG',
       message: 'No service slug provided'
+    })
+  }
+  if (!SUBMISSION_ENCRYPTION_KEY) {
+    throw new ConstantsError({
+      code: 'ENOSUBMISSION_ENCRYPTION_KEY',
+      message: 'No submission encryption key provided'
     })
   }
   if (!SERVICE_SECRET) {
@@ -248,4 +255,7 @@ LOG_LEVEL
 MAINTENANCE_MODE
   Flag to put a form under maintenace and make sure that all pages redirect
   to the maintenance page (with the exception of ping and healthcheck url)
+
+SUBMISSION_ENCRYPTION_KEY
+  Encryption key used to encrypt the submission before sending to the Submitter
 */

--- a/lib/constants/constants.set.values.unit.spec.js
+++ b/lib/constants/constants.set.values.unit.spec.js
@@ -36,7 +36,8 @@ const processEnv = {
   USERNAME: 'user',
   PASSWORD: '1234',
   REALM: 'secret-garden',
-  UPLOADS_DIR: '/uploads'
+  UPLOADS_DIR: '/uploads',
+  SUBMISSION_ENCRYPTION_KEY: 'key'
 }
 
 const getEnvStub = sinon.stub().returns(processEnv)
@@ -147,6 +148,11 @@ test('When the FORM_BUILDER_TRACKING_ID ENV variable is set', t => {
 
 test('When the SENTRY_DSN ENV variable is set', t => {
   t.equal(constants.SENTRY_DSN, 'raven-maven', 'constants should set SENTRY_DSN to that value')
+  t.end()
+})
+
+test('When the SUBMISSION_ENCRYPTION_KEY ENV variable is set', t => {
+  t.equal(constants.SUBMISSION_ENCRYPTION_KEY, 'key', 'constants should set SUBMISSION_ENCRYPTION_KEY to that value')
   t.end()
 })
 

--- a/lib/constants/constants.unit.spec.js
+++ b/lib/constants/constants.unit.spec.js
@@ -16,7 +16,8 @@ test('When constants is called', t => {
     SERVICE_SLUG: 'slug',
     SERVICE_SECRET: 'secret',
     USER_DATASTORE_URL: 'some-url.com',
-    SUBMITTER_URL: 'other-url.com'
+    SUBMITTER_URL: 'other-url.com',
+    SUBMISSION_ENCRYPTION_KEY: 'awesome-encryption-key'
   })
 
   const constants = proxyquire('./constants', {
@@ -49,7 +50,8 @@ test('When constants is called', t => {
     SAVE_RETURN_URL: 'some-url.com',
     EMAIL_URL: 'other-url.com',
     SMS_URL: 'other-url.com',
-    SUBMITTER_URL: 'other-url.com'
+    SUBMITTER_URL: 'other-url.com',
+    SUBMISSION_ENCRYPTION_KEY: 'awesome-encryption-key'
   }, 'it should set the correct values')
 
   t.end()
@@ -61,7 +63,8 @@ test('Overriding the callback URL', t => {
     SERVICE_SLUG: 'slug',
     SERVICE_SECRET: 'secret',
     USER_DATASTORE_URL: 'some-url.com',
-    SUBMITTER_URL: 'other-url.com'
+    SUBMITTER_URL: 'other-url.com',
+    SUBMISSION_ENCRYPTION_KEY: 'awesome-encryption-key'
   })
 
   const constants = proxyquire('./constants', {

--- a/package-lock.json
+++ b/package-lock.json
@@ -128,9 +128,9 @@
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
     },
     "@ministryofjustice/fb-client": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@ministryofjustice/fb-client/-/fb-client-2.0.8.tgz",
-      "integrity": "sha512-lB4ZQRgJ1N3u/KibJJtPDnZOivkr2x09gQi6CyPh5s5s8/Obsqq/171Y5J0i3CIIBu17ggXXhU77zx1OyGCyXw==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/fb-client/-/fb-client-2.0.9.tgz",
+      "integrity": "sha512-pUlPkXDDcFMrLNJd/uCFLGNeuhVWaN2X0OFFOdZ4mvxc3dJSQyj4ROt6NzAmGACP3ofaP2DBE8J2hVTpNEtzwQ==",
       "requires": {
         "aes256": "^1.0.4",
         "debug": "^4.1.1",
@@ -3414,9 +3414,9 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
     "get-stream": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-      "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
       "requires": {
         "pump": "^3.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@ministryofjustice/fb-client": "2.0.8",
+    "@ministryofjustice/fb-client": "2.0.9",
     "@ministryofjustice/fb-components": "1.3.12",
     "@ministryofjustice/module-alias": "^1.0.16",
     "@promster/express": "^4.1.2",


### PR DESCRIPTION
Required when encrypting the submission payload being sent to the submitter.

[Trello Card](https://trello.com/c/j6VCPRja/806-encrypt-between-the-runner-the-submitter)