### PR TITLE
Fix/redirect issue

### DIFF
--- a/lib/middleware/error-handler/error-handler.js
+++ b/lib/middleware/error-handler/error-handler.js
@@ -85,14 +85,7 @@ const errorHandler = (options = {}) => {
     }
   }
 
-  const compromisedRegex = /([ ,\\/\\.]|%20)+$/
   external.notFound = (req, res) => {
-    // check that url has not been compromised by poor email formatting
-    if (req.url.match(compromisedRegex)) {
-      const redirect = req.url.replace(compromisedRegex, '')
-      res.redirect(redirect)
-      return
-    }
     external.render(req, res, 404)
   }
 

--- a/lib/middleware/error-handler/error-handler.unit.spec.js
+++ b/lib/middleware/error-handler/error-handler.unit.spec.js
@@ -120,8 +120,7 @@ test('When render method is called and an error instance exists', async t => {
   t.end()
 })
 
-test('When render method is called and an error instance exists', async t => {
-  t.plan(6)
+test('When render method is called and an error instance  with 500 exists', async t => {
   const { req, res, errorHandlerInstance } = errorMocks()
   req.user = {}
   const errorInstance = {
@@ -142,7 +141,6 @@ test('When render method is called and an error instance exists', async t => {
 
   const nunjucksRenderStub = sinon.stub(nunjucksConfiguration, 'renderPage')
   nunjucksRenderStub.returns(errorOutput)
-  const fallbackErrorStub = sinon.stub(errorHandlerInstance, '_fallbackError')
 
   try {
     await errorHandlerInstance.render(req, res, 500)
@@ -155,8 +153,34 @@ test('When render method is called and an error instance exists', async t => {
     t.notOk(true, 'it should not throw an error')
   }
 
-  nunjucksRenderStub.resetHistory()
+  nunjucksRenderStub.restore()
+  getInstanceStub.restore()
   resSendSpy.resetHistory()
+
+  t.end()
+})
+
+test('When render method is called and an error instance  with 503 exists', async t => {
+  const { req, res, errorHandlerInstance } = errorMocks()
+  req.user = {}
+  const errorInstance = {
+    _id: 'error.503',
+    _type: 'page.error',
+    heading: 'Server error',
+    lede: 'Please check you’ve entered the correct web address.'
+  }
+  const errorOutput = 'Hello world'
+
+  const resSendSpy = sinon.spy(res, 'send')
+  const getInstanceStub = sinon.stub(serviceData, 'getInstance')
+  getInstanceStub.callsFake(_id => {
+    if (_id === 'error.503') {
+      return errorInstance
+    }
+  })
+
+  const nunjucksRenderStub = sinon.stub(nunjucksConfiguration, 'renderPage')
+  nunjucksRenderStub.returns(errorOutput)
 
   try {
     await errorHandlerInstance.render(req, res, 503)
@@ -170,7 +194,35 @@ test('When render method is called and an error instance exists', async t => {
   }
 
   nunjucksRenderStub.resetHistory()
+  nunjucksRenderStub.restore()
+  getInstanceStub.restore()
   resSendSpy.resetHistory()
+
+  t.end()
+})
+
+test('When render method is called and an error instance  with 404 exists', async t => {
+  const { req, res, errorHandlerInstance } = errorMocks()
+  req.user = {}
+  const errorInstance = {
+    _id: 'error.404',
+    _type: 'page.error',
+    heading: 'Server error',
+    lede: 'Please check you’ve entered the correct web address.'
+  }
+  const errorOutput = 'Hello world'
+
+  const resSendSpy = sinon.spy(res, 'send')
+  const getInstanceStub = sinon.stub(serviceData, 'getInstance')
+  getInstanceStub.callsFake(_id => {
+    if (_id === 'error.404') {
+      return errorInstance
+    }
+  })
+
+  const nunjucksRenderStub = sinon.stub(nunjucksConfiguration, 'renderPage')
+  nunjucksRenderStub.returns(errorOutput)
+  const fallbackErrorStub = sinon.stub(errorHandlerInstance, '_fallbackError')
 
   try {
     await errorHandlerInstance.render(req, res, 404)

--- a/lib/middleware/error-handler/error-handler.unit.spec.js
+++ b/lib/middleware/error-handler/error-handler.unit.spec.js
@@ -234,19 +234,14 @@ test('When notFound handler called but the url contains mangled output', t => {
   const renderSpy = sinon.spy(errorHandlerInstance, 'render')
   const redirectStub = sinon.stub(res, 'redirect')
 
-  const testDemangle = (url, mangled) => {
+  const testDemangle = (url) => {
     req.url = url
     errorHandlerInstance.notFound(req, res)
-    t.true(renderSpy.notCalled, 'it should not call the error render method')
-    t.true(redirectStub.calledWith('/foo'), `it should strip the ${mangled} from the url and redirect`)
+    t.true(renderSpy.calledWith(req, res, 404), 'it should render a 404 page')
+    t.true(redirectStub.notCalled, 'it should not attempt a redirect')
     redirectStub.resetHistory()
   }
-  testDemangle('/foo ', 'space')
-  testDemangle('/foo  ', 'spaces')
-  testDemangle('/foo,', 'comma')
-  testDemangle('/foo/', 'slash')
-  testDemangle('/foo//', 'slashes')
-  testDemangle('/foo/ ,/  ,,,/   ', 'combination of unwanted characters')
+  testDemangle('//////////////////////yahoo.com/')
 
   renderSpy.restore()
   redirectStub.restore()


### PR DESCRIPTION
## Do not redirect if path is not found

This is to cater for the ability to send a user to the following:

http://service-name.form.service.justice.gov.uk///////////////yahoo.com/”

yahoo.com could be a malicious site that can contain a form asking the user data and capture if the user is not aware of. And the domain is a authentic one but not the URL

## Add test for external domain

We do not want the runner to do a redirect to any pages that do not exist in the metadata. This is especially true if anything after the `/` is somehow an external domain.

## Break out the error handling tests into their own tests

Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>