### PR TITLE
Set RUNNER_TYPE in the deployment pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,7 @@ jobs:
             PLATFORM_ENV: test
             DEPLOYMENT_ENV: dev
             K8S_NAMESPACE: formbuilder-services-test-dev
+            RUNNER_TYPE: fb-runner-node
           command: './deploy-scripts/bin/restart_all_pods'
       - run:
           name: Restart the runners in test production
@@ -60,6 +61,7 @@ jobs:
             PLATFORM_ENV: test
             DEPLOYMENT_ENV: production
             K8S_NAMESPACE: formbuilder-services-test-production
+            RUNNER_TYPE: fb-runner-node
           command: './deploy-scripts/bin/restart_all_pods'
       - slack/status: *slack_status
   build_and_deploy_to_live:
@@ -81,6 +83,7 @@ jobs:
             PLATFORM_ENV: live
             DEPLOYMENT_ENV: dev
             K8S_NAMESPACE: formbuilder-services-live-dev
+            RUNNER_TYPE: fb-runner-node
           command: './deploy-scripts/bin/restart_all_pods'
       - run:
           name: Restart the runners in live production
@@ -88,6 +91,7 @@ jobs:
             PLATFORM_ENV: live
             DEPLOYMENT_ENV: production
             K8S_NAMESPACE: formbuilder-services-live-production
+            RUNNER_TYPE: fb-runner-node
           command: './deploy-scripts/bin/restart_all_pods'
       - slack/status:
           only_for_branches: master


### PR DESCRIPTION
After [this PR](https://github.com/ministryofjustice/fb-deploy/pull/37)
the deployment pipeline now needs to have the RUNNER_TYPE set in the
environment in order to target the specific containers related to this
runner