### PR TITLE
Changed the default email address

### DIFF
--- a/lib/controller/page/type/page.summary/index.js
+++ b/lib/controller/page/type/page.summary/index.js
@@ -189,7 +189,7 @@ module.exports = class SummaryController extends CommonController {
       getInstanceProperty('service', 'emailSubjectTeam') || `${serviceName} submission`
     )
     const defaultEmailAddress = getString('email.address.from')
-    const emailFrom = defaultEmailAddress ? formatEmail(defaultEmailAddress) : '"Form Builder" <form-builder-team@digital.justice.gov.uk>'
+    const emailFrom = defaultEmailAddress ? formatEmail(defaultEmailAddress) : '"MOJ Forms" <moj-forms@digital.justice.gov.uk>'
     let emailTo = SERVICE_OUTPUT_EMAIL || ''
 
     try {
@@ -296,7 +296,7 @@ module.exports = class SummaryController extends CommonController {
       getInstanceProperty('service', 'emailSubjectTeam') || `${serviceName} submission`
     )
     const defaultEmailAddress = getString('email.address.from')
-    const emailFrom = defaultEmailAddress ? formatEmail(defaultEmailAddress) : '"Form Builder" <form-builder-team@digital.justice.gov.uk>'
+    const emailFrom = defaultEmailAddress ? formatEmail(defaultEmailAddress) : '"MOJ Forms" <moj-forms@digital.justice.gov.uk>'
     const emailTo = formatEmail(SERVICE_OUTPUT_EMAIL)
 
     let toTeamParts = emailTo.split(/,\s*/)


### PR DESCRIPTION
The product name has been rebranded and this change updates the default
email address that sends emails to moj-forms@digital.justice.gov.uk.

Ticket: https://trello.com/c/L2TUpOkp