### PR TITLE
Add cookie message and banner

### DIFF
--- a/lib/middleware/routes-metadata/routes-metadata.js
+++ b/lib/middleware/routes-metadata/routes-metadata.js
@@ -81,7 +81,8 @@ const {
   FORM_BUILDER_GA_TRACKING_ID,
   GA_TRACKING_ID,
   GTM_TRACKING_ID,
-  EXCLUDE_FROM_SEARCH_RESULTS
+  EXCLUDE_FROM_SEARCH_RESULTS,
+  SERVICE_SLUG
 } = CONSTANTS
 
 const timeoutWarningExcludedPages = [
@@ -89,6 +90,8 @@ const timeoutWarningExcludedPages = [
   'page.start',
   'page.confirmation'
 ]
+
+const analyticsCookie = `analytics-${SERVICE_SLUG}`
 
 let defaultLang
 
@@ -304,6 +307,10 @@ async function pageHandler (req, res) {
     let pageInstance = cloneDeep(getInstance(route))
 
     pageInstance.sessionDuration = sessionDuration()
+
+    pageInstance.analyticsCookie = analyticsCookie
+    pageInstance.useAnalytics = req.cookies[analyticsCookie] === undefined || req.cookies[analyticsCookie] === 'accepted'
+    pageInstance.showCookieBanner = req.cookies[analyticsCookie] === undefined
 
     pageInstance.showTimeoutWarning = true
     if (pageInstance._type && (timeoutWarningExcludedPages.includes(pageInstance._type))) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@ministryofjustice/fb-client": "2.1.5",
-        "@ministryofjustice/fb-components": "1.4.8",
+        "@ministryofjustice/fb-components": "1.4.11",
         "@ministryofjustice/module-alias": "^1.0.22",
         "@promster/express": "^4.1.2",
         "@sentry/node": "^5.15.0",
@@ -94,6 +94,82 @@
         "sinon": "^9.0.1",
         "supertest": "^6.0.0",
         "tape": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=14.5.0"
+      }
+    },
+    "../fb-components": {
+      "name": "@ministryofjustice/fb-components",
+      "version": "1.4.8",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ministryofjustice/module-alias": "^1.0.22",
+        "accessible-autocomplete": "^2.0.2",
+        "ajv": "^6.12.0",
+        "concurrently": "^5.1.0",
+        "cross-env": "^7.0.2",
+        "dialog-polyfill": "^0.5.0",
+        "glob": "^7.1.6",
+        "glob-all": "^3.2.1",
+        "glob-promise": "^3.4.0",
+        "govuk-frontend": "^3.6.0",
+        "json-schema-merge-allof": "^0.8.1",
+        "json-schema-ref-parser": "^9.0.1",
+        "jsonlint-mod": "^1.7.6",
+        "jsonpath": "^1.0.2",
+        "markdown-it": "^12.0.0",
+        "mkdirp": "^1.0.3",
+        "nunjucks": "^3.2.1",
+        "shelljs": "^0.8.3",
+        "yargs": "^17.3.1"
+      },
+      "devDependencies": {
+        "@babel/core": "^7.9.0",
+        "@babel/plugin-proposal-class-properties": "^7.8.3",
+        "@babel/plugin-transform-react-jsx": "^7.9.1",
+        "@babel/preset-env": "^7.9.0",
+        "ajv-cli": "^5.0.0",
+        "autoprefixer": "^10.4.2",
+        "babel-eslint": "^10.1.0",
+        "babel-loader": "^8.1.0",
+        "babel-preset-preact": "^2.0.0",
+        "chai": "^4.2.0",
+        "clean-webpack-plugin": "^3.0.0",
+        "cssnano": "^4.1.10",
+        "del": "^6.0.0",
+        "eslint": "^7.2.0",
+        "eslint-config-standard": "^16.0.1",
+        "eslint-plugin-import": "^2.20.1",
+        "eslint-plugin-json": "^2.1.1",
+        "eslint-plugin-node": "^11.0.0",
+        "eslint-plugin-promise": "^4.2.1",
+        "eslint-plugin-standard": "^5.0.0",
+        "gulp": "^4.0.2",
+        "gulp-clean-css": "^4.3.0",
+        "gulp-css-purge": "^3.0.9",
+        "gulp-debug": "^4.0.0",
+        "gulp-postcss": "^9.0.1",
+        "gulp-rename": "^2.0.0",
+        "gulp-sass": "^4.0.2",
+        "gulp-sourcemaps": "^3.0.0",
+        "husky": "^4.2.3",
+        "mocha": "^8.0.1",
+        "postcss": "^8.4.5",
+        "postcss-normalize": "^10.0.1",
+        "postcss-scss": "^3.0.0",
+        "proxyquire": "^2.1.3",
+        "sinon": "^9.0.1",
+        "sinon-chai": "^3.5.0",
+        "stylelint": "^13.13.1",
+        "stylelint-config-recommended-scss": "^4.2.0",
+        "stylelint-scss": "^3.16.0",
+        "terser-webpack-plugin": "^5.0.0",
+        "vinyl-paths": "^3.0.1",
+        "webpack": "^5.1.0",
+        "webpack-cli": "^4.0.0",
+        "webpack-merge": "^5.0.9"
       },
       "engines": {
         "node": ">=14.5.0"
@@ -300,9 +376,9 @@
       }
     },
     "node_modules/@ministryofjustice/fb-components": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/@ministryofjustice/fb-components/-/fb-components-1.4.8.tgz",
-      "integrity": "sha512-lhDCWH1kqI8vL22xAmOvepiZDcu5Uuj3Xu14BKZHWUOPQue45yTHHGY9MmQZ4f0owW+OUWOIDYaNfi47aLmv0g==",
+      "version": "1.4.11",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/fb-components/-/fb-components-1.4.11.tgz",
+      "integrity": "sha512-GC9TGgjGiXRCvrqw1ynXhGxfa0AVg0c05rrT1ya516cQu1QhV/JO2SA8sRmWuEueEg8GmlfCILkYUAwGgXMvVQ==",
       "dependencies": {
         "@ministryofjustice/module-alias": "^1.0.22",
         "accessible-autocomplete": "^2.0.2",
@@ -451,9 +527,9 @@
       }
     },
     "node_modules/@ministryofjustice/fb-components/node_modules/yargs": {
-      "version": "17.3.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.1.tgz",
-      "integrity": "sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==",
+      "version": "17.4.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.4.0.tgz",
+      "integrity": "sha512-WJudfrk81yWFSOkZYpAZx4Nt7V4xp7S/uJkX0CnxovMCt1wCE8LNftPpNuF9X/u9gN5nsD7ycYtRcDf2pL3UiA==",
       "dependencies": {
         "cliui": "^7.0.2",
         "escalade": "^3.1.1",
@@ -11961,9 +12037,9 @@
       }
     },
     "@ministryofjustice/fb-components": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/@ministryofjustice/fb-components/-/fb-components-1.4.8.tgz",
-      "integrity": "sha512-lhDCWH1kqI8vL22xAmOvepiZDcu5Uuj3Xu14BKZHWUOPQue45yTHHGY9MmQZ4f0owW+OUWOIDYaNfi47aLmv0g==",
+      "version": "1.4.11",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/fb-components/-/fb-components-1.4.11.tgz",
+      "integrity": "sha512-GC9TGgjGiXRCvrqw1ynXhGxfa0AVg0c05rrT1ya516cQu1QhV/JO2SA8sRmWuEueEg8GmlfCILkYUAwGgXMvVQ==",
       "requires": {
         "@ministryofjustice/module-alias": "^1.0.22",
         "accessible-autocomplete": "^2.0.2",
@@ -12076,9 +12152,9 @@
           "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
         },
         "yargs": {
-          "version": "17.3.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.1.tgz",
-          "integrity": "sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==",
+          "version": "17.4.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.4.0.tgz",
+          "integrity": "sha512-WJudfrk81yWFSOkZYpAZx4Nt7V4xp7S/uJkX0CnxovMCt1wCE8LNftPpNuF9X/u9gN5nsD7ycYtRcDf2pL3UiA==",
           "requires": {
             "cliui": "^7.0.2",
             "escalade": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "license": "MIT",
   "dependencies": {
     "@ministryofjustice/fb-client": "2.1.5",
-    "@ministryofjustice/fb-components": "1.4.8",
+    "@ministryofjustice/fb-components": "1.4.11",
     "@ministryofjustice/module-alias": "^1.0.22",
     "@promster/express": "^4.1.2",
     "@sentry/node": "^5.15.0",


### PR DESCRIPTION
This adds the cookie message and banner to the runner.

By default we will always show the banner if there is no anlaytics
confirmation or rejection cookie set. Only once a user has rejected the
analytics do we then set the corresponding variables on the page
instance