### PR TITLE
Unpin Docker version in CircleCi config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,6 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker: &remote_docker
-          version: 20.10.11
           docker_layer_caching: true
       - run: &base_environment_variables
           name: Setup base environment variable


### PR DESCRIPTION
CircleCI will be keeping the Docker executor up to date on a rolling basis.

Checklist
- [x] [CircleCI run](https://app.circleci.com/pipelines/github/ministryofjustice/fb-runner-node/2732/workflows/bfb2f432-d194-4e81-98d6-76d25a737afa)
- [x] Access forms in test-dev and test-production