### PR TITLE
Bump tap, replace request-promise-native, fix deprecation warnings

### DIFF
--- a/bin/service-data/specification/validate-specifications.js
+++ b/bin/service-data/specification/validate-specifications.js
@@ -33,7 +33,7 @@ schemas.forEach(schema => {
 
     return validateSchema(schema, options)
       .then(results => {
-        t.is(results, undefined, 'should have no errors')
+        t.equal(results, undefined, 'should have no errors')
       })
   })
 })

--- a/lib/bracket-notation-path/bracket-notation-path.unit.spec.js
+++ b/lib/bracket-notation-path/bracket-notation-path.unit.spec.js
@@ -25,15 +25,15 @@ const data = {
 test('When getting the value of a path', t => {
   const testData = cloneDeep(data)
 
-  t.deepEqual(getBracketNotationPath(testData, 'a[b]'), [{ c: true }, { c: false }], 'it should handle paths containing brackets without quotes')
-  t.deepEqual(getBracketNotationPath(testData, 'a["b"]'), [{ c: true }, { c: false }], 'it should handle paths containing brackets with double quotes')
-  t.deepEqual(getBracketNotationPath(testData, 'a[\'b\']'), [{ c: true }, { c: false }], 'it should handle paths containing brackets with single quotes')
-  t.deepEqual(getBracketNotationPath(testData, 'a[b][0]'), { c: true }, 'it should handle array items - paths containing brackets with numeric values')
-  t.deepEqual(getBracketNotationPath(testData, 'a[b][0][c]'), true, 'it should handle paths containing properties of array items')
-  t.deepEqual(getBracketNotationPath(testData, 'a[d]'), undefined, 'it should handle paths that evaluate to undefined')
-  t.deepEqual(getBracketNotationPath(testData, 'a[d]', 'default value'), 'default value', 'it should return a default value when requested for undefined values')
-  t.deepEqual(getBracketNotationPath(testData, 'a[empty][string]', 'default value'), '', 'it should not return a default value when result is an empty string')
-  t.deepEqual(getBracketNotationPath(testData, 'a[empty][number]', 'default value'), 0, 'it should not return a default value when result is zero')
+  t.same(getBracketNotationPath(testData, 'a[b]'), [{ c: true }, { c: false }], 'it should handle paths containing brackets without quotes')
+  t.same(getBracketNotationPath(testData, 'a["b"]'), [{ c: true }, { c: false }], 'it should handle paths containing brackets with double quotes')
+  t.same(getBracketNotationPath(testData, 'a[\'b\']'), [{ c: true }, { c: false }], 'it should handle paths containing brackets with single quotes')
+  t.same(getBracketNotationPath(testData, 'a[b][0]'), { c: true }, 'it should handle array items - paths containing brackets with numeric values')
+  t.same(getBracketNotationPath(testData, 'a[b][0][c]'), true, 'it should handle paths containing properties of array items')
+  t.same(getBracketNotationPath(testData, 'a[d]'), undefined, 'it should handle paths that evaluate to undefined')
+  t.same(getBracketNotationPath(testData, 'a[d]', 'default value'), 'default value', 'it should return a default value when requested for undefined values')
+  t.same(getBracketNotationPath(testData, 'a[empty][string]', 'default value'), '', 'it should not return a default value when result is an empty string')
+  t.same(getBracketNotationPath(testData, 'a[empty][number]', 'default value'), 0, 'it should not return a default value when result is zero')
   t.end()
 })
 
@@ -41,26 +41,26 @@ test('When setting the value of a path', t => {
   const testData = cloneDeep(data)
 
   const setUndefined = setBracketNotationPath(testData, 'a[d]', 'value')
-  t.deepEqual(getBracketNotationPath(testData, 'a[d]'), 'value', 'it should return the value that has been set')
-  t.deepEqual(setUndefined, 'value', 'it should handle paths containing brackets without quotes')
+  t.same(getBracketNotationPath(testData, 'a[d]'), 'value', 'it should return the value that has been set')
+  t.same(setUndefined, 'value', 'it should handle paths containing brackets without quotes')
 
   setBracketNotationPath(testData, 'a["z"]', 'value')
-  t.deepEqual(testData.a.z, 'value', 'it should handle paths containing brackets with double quotes')
+  t.same(testData.a.z, 'value', 'it should handle paths containing brackets with double quotes')
 
   setBracketNotationPath(testData, 'a[\'y\']', 'value')
-  t.deepEqual(testData.a.y, 'value', 'it should handle paths containing brackets with single quotes')
+  t.same(testData.a.y, 'value', 'it should handle paths containing brackets with single quotes')
 
   setBracketNotationPath(testData, 'a[b][0][c]', false)
-  t.deepEqual(testData.a.b[0].c, false, 'it should handle paths containing properties of array items')
+  t.same(testData.a.b[0].c, false, 'it should handle paths containing properties of array items')
 
   setBracketNotationPath(testData, 'a[b][0]', { e: true, f: [1, 2] })
-  t.deepEqual(testData.a.b[0], { e: true, f: [1, 2] }, 'it should handle array items - paths containing brackets with numeric values')
+  t.same(testData.a.b[0], { e: true, f: [1, 2] }, 'it should handle array items - paths containing brackets with numeric values')
 
   setBracketNotationPath(testData, 'a[b][0][c]', true)
-  t.deepEqual(testData.a.b[0].c, true, 'it should handle paths where the intervening properties need to be created')
+  t.same(testData.a.b[0].c, true, 'it should handle paths where the intervening properties need to be created')
 
   setBracketNotationPath(testData, 'a["b"][0][\'c\']', false)
-  t.deepEqual(testData.a.b[0].c, false, 'it should handle paths containing brackets with single quotes')
+  t.same(testData.a.b[0].c, false, 'it should handle paths containing brackets with single quotes')
 
   t.end()
 })
@@ -69,21 +69,21 @@ test('When unsetting the value of a path', t => {
   const testData = cloneDeep(data)
 
   unsetBracketNotationPath(testData, 'a[b][0][c]')
-  t.deepEqual(testData.a.b[0].c, undefined, 'it should handle paths containing properties of array items')
+  t.same(testData.a.b[0].c, undefined, 'it should handle paths containing properties of array items')
 
   unsetBracketNotationPath(testData, 'a[b][0]')
-  t.deepEqual(testData.a.b[0], undefined, 'it should handle array items - paths containing brackets with numeric values')
+  t.same(testData.a.b[0], undefined, 'it should handle array items - paths containing brackets with numeric values')
 
   unsetBracketNotationPath(testData, 'a[b]')
-  t.deepEqual(testData.a.b, undefined, 'it should handle paths containing brackets without quotes')
+  t.same(testData.a.b, undefined, 'it should handle paths containing brackets without quotes')
 
   const testDataB = cloneDeep(data)
 
   unsetBracketNotationPath(testDataB, 'a[b][0][\'c\']')
-  t.deepEqual(testDataB.a.b[0].c, undefined, 'it should handle paths containing brackets with single quotes')
+  t.same(testDataB.a.b[0].c, undefined, 'it should handle paths containing brackets with single quotes')
 
   unsetBracketNotationPath(testDataB, 'a["b"][0]')
-  t.deepEqual(testDataB.a.b[0], undefined, 'it should handle paths containing brackets with double quotes')
+  t.same(testDataB.a.b[0], undefined, 'it should handle paths containing brackets with double quotes')
 
   t.equal(unsetBracketNotationPath(testDataB, 'a[z][z]'), true, 'it should handle paths that evaluate to undefined')
 

--- a/lib/client/metrics/metrics.unit.spec.js
+++ b/lib/client/metrics/metrics.unit.spec.js
@@ -28,11 +28,11 @@ test('When the metrics client is requested', t => {
     buckets: [0.1, 0.25, 0.5, 1, 2, 5, 10]
   }
 
-  t.deepEqual(apiMetrics, Object.assign({
+  t.same(apiMetrics, Object.assign({
     name: 'jwt_api_requests',
     help: 'API calls using FB JWT Client'
   }, baseValues), 'it should return the instantiated apiMetrics object')
-  t.deepEqual(requestMetrics, Object.assign({
+  t.same(requestMetrics, Object.assign({
     name: 'jwt_client_requests',
     help: 'HTTP requests using FB JWT Client'
   }, baseValues), 'it should return the instantiated requestMetrics object')

--- a/lib/constants/constants.unit.spec.js
+++ b/lib/constants/constants.unit.spec.js
@@ -24,7 +24,7 @@ test('When constants is called', t => {
     './get-env': getEnvStub
   })
 
-  t.deepEqual(constants, {
+  t.same(constants, {
     PORT: 3000,
     SERVICE_SECRET: 'secret',
     RUNNER_DIR: runnerDir,
@@ -71,7 +71,7 @@ test('Overriding the callback URL', t => {
     './get-env': getEnvStub
   })
 
-  t.deepEqual(constants.RUNNER_URL, 'some-url.com', 'it should override the Runner callback URL')
+  t.same(constants.RUNNER_URL, 'some-url.com', 'it should override the Runner callback URL')
 
   t.end()
 })

--- a/lib/constants/get-env.unit.spec.js
+++ b/lib/constants/get-env.unit.spec.js
@@ -3,6 +3,6 @@ const test = require('tape')
 const getEnv = require('./get-env')
 
 test('When getEnv is called', t => {
-  t.deepEqual(process.env, getEnv(), 'it should return process.env')
+  t.same(process.env, getEnv(), 'it should return process.env')
   t.end()
 })

--- a/lib/controller/component/common/any-of.unit.spec.js
+++ b/lib/controller/component/common/any-of.unit.spec.js
@@ -66,7 +66,7 @@ test('is redacted', (t) => {
 
   t.equal(anyOfController.isRedacted(componentInstance, userData), 'mock return value', 'returns the value from super')
 
-  t.deepEqual(isRedactedStub.firstCall.args, [componentInstance, userData], 'calls super')
+  t.same(isRedactedStub.firstCall.args, [componentInstance, userData], 'calls super')
 
   isRedactedStub.restore()
 
@@ -158,7 +158,7 @@ test('is redacted item', (t) => {
 
   t.equal(anyOfController.isRedactedItem(componentInstanceItem, userData), 'mock return value', 'returns the value from super')
 
-  t.deepEqual(isRedactedStub.firstCall.args, [componentInstanceItem, userData], 'calls super')
+  t.same(isRedactedStub.firstCall.args, [componentInstanceItem, userData], 'calls super')
 
   isRedactedStub.restore()
 
@@ -190,13 +190,13 @@ test('get answered display value when the instance title summary is defined', (t
 
   t.equal(anyOfController.getAnsweredDisplayValue(componentInstance, userData), 'mock formatted value', 'returns the value')
 
-  t.deepEqual(isMultiLineStub.firstCall.args, [componentInstance, 'mock instance title summary'], 'gets is multiline')
+  t.same(isMultiLineStub.firstCall.args, [componentInstance, 'mock instance title summary'], 'gets is multiline')
 
   const { firstCall: { args: [id] } } = getInstanceTitleSummaryStub
   t.equal(id, 'mock anyOf item id', 'gets the instance title summary')
 
   const { firstCall: { args } } = formatStub
-  t.deepEqual(args, ['mock instance title summary', {}, { multiline: false, substitution: true, markdown: true, lang: 'mock content lang' }])
+  t.same(args, ['mock instance title summary', {}, { multiline: false, substitution: true, markdown: true, lang: 'mock content lang' }])
 
   t.end()
 })
@@ -226,13 +226,13 @@ test('get answered display value when the instance title summary is not defined 
 
   t.equal(anyOfController.getAnsweredDisplayValue(componentInstance, userData), 'mock formatted value', 'returns the value')
 
-  t.deepEqual(isMultiLineStub.firstCall.args, [componentInstance, 'mock anyOf value'], 'gets is multiline')
+  t.same(isMultiLineStub.firstCall.args, [componentInstance, 'mock anyOf value'], 'gets is multiline')
 
   const { firstCall: { args: [id] } } = getInstanceTitleSummaryStub
   t.equal(id, 'mock anyOf item id', 'gets the instance title summary')
 
   const { firstCall: { args } } = formatStub
-  t.deepEqual(args, ['mock anyOf value', {}, { multiline: false, substitution: true, markdown: true, lang: 'mock content lang' }])
+  t.same(args, ['mock anyOf value', {}, { multiline: false, substitution: true, markdown: true, lang: 'mock content lang' }])
 
   t.end()
 })
@@ -262,13 +262,13 @@ test('get answered display value when the instance title summary is not defined 
 
   t.equal(anyOfController.getAnsweredDisplayValue(componentInstance, userData), 'mock formatted value', 'returns the value')
 
-  t.deepEqual(isMultiLineStub.firstCall.args, [componentInstance, ''], 'gets is multiline')
+  t.same(isMultiLineStub.firstCall.args, [componentInstance, ''], 'gets is multiline')
 
   const { firstCall: { args: [id] } } = getInstanceTitleSummaryStub
   t.equal(id, 'mock anyOf item id', 'gets the instance title summary')
 
   const { firstCall: { args } } = formatStub
-  t.deepEqual(args, ['', {}, { multiline: false, substitution: true, markdown: true, lang: 'mock content lang' }])
+  t.same(args, ['', {}, { multiline: false, substitution: true, markdown: true, lang: 'mock content lang' }])
 
   t.end()
 })
@@ -313,7 +313,7 @@ test('get answered display value when the instance title summary is defined and 
 
   t.equal(anyOfController.getAnsweredDisplayValue(componentInstance, userData), '<p class="govuk-body">mock formatted value</p>', 'returns the value')
 
-  t.deepEqual(isMultiLineStub.firstCall.args, [componentInstance, 'mock instance title summary\n\nmock instance title summary'], 'gets is multiline')
+  t.same(isMultiLineStub.firstCall.args, [componentInstance, 'mock instance title summary\n\nmock instance title summary'], 'gets is multiline')
 
   const { firstCall: { args: [one] } } = getInstanceTitleSummaryStub
   t.equal(one, 'mock anyOf item id one', 'gets the instance title summary')
@@ -322,7 +322,7 @@ test('get answered display value when the instance title summary is defined and 
   t.equal(two, 'mock anyOf item id two', 'gets the instance title summary')
 
   const { firstCall: { args } } = formatStub
-  t.deepEqual(args, ['mock instance title summary\n\nmock instance title summary', {}, { multiline: true, substitution: true, markdown: true, lang: 'mock content lang' }])
+  t.same(args, ['mock instance title summary\n\nmock instance title summary', {}, { multiline: true, substitution: true, markdown: true, lang: 'mock content lang' }])
 
   t.end()
 })
@@ -367,7 +367,7 @@ test('get answered display value when the instance title summary is not defined 
 
   t.equal(anyOfController.getAnsweredDisplayValue(componentInstance, userData), '<p class="govuk-body">mock formatted value</p>', 'returns the value')
 
-  t.deepEqual(isMultiLineStub.firstCall.args, [componentInstance, 'mock anyOf value one\n\nmock anyOf value two'], 'gets is multiline')
+  t.same(isMultiLineStub.firstCall.args, [componentInstance, 'mock anyOf value one\n\nmock anyOf value two'], 'gets is multiline')
 
   const { firstCall: { args: [one] } } = getInstanceTitleSummaryStub
   t.equal(one, 'mock anyOf item id one', 'gets the instance title summary')
@@ -376,7 +376,7 @@ test('get answered display value when the instance title summary is not defined 
   t.equal(two, 'mock anyOf item id two', 'gets the instance title summary')
 
   const { firstCall: { args } } = formatStub
-  t.deepEqual(args, ['mock anyOf value one\n\nmock anyOf value two', {}, { multiline: true, substitution: true, markdown: true, lang: 'mock content lang' }])
+  t.same(args, ['mock anyOf value one\n\nmock anyOf value two', {}, { multiline: true, substitution: true, markdown: true, lang: 'mock content lang' }])
 
   t.end()
 })
@@ -416,7 +416,7 @@ test('get answered display value when the instance title summary is not defined 
 
   t.equal(anyOfController.getAnsweredDisplayValue(componentInstance, userData), '<p class="govuk-body">mock formatted value</p>', 'returns the value')
 
-  t.deepEqual(isMultiLineStub.firstCall.args, [componentInstance, '\n\n'], 'gets is multiline')
+  t.same(isMultiLineStub.firstCall.args, [componentInstance, '\n\n'], 'gets is multiline')
 
   const { firstCall: { args: [one] } } = getInstanceTitleSummaryStub
   t.equal(one, 'mock anyOf item id one', 'gets the instance title summary')
@@ -425,7 +425,7 @@ test('get answered display value when the instance title summary is not defined 
   t.equal(two, 'mock anyOf item id two', 'gets the instance title summary')
 
   const { firstCall: { args } } = formatStub
-  t.deepEqual(args, ['\n\n', {}, { multiline: true, substitution: true, markdown: true, lang: 'mock content lang' }])
+  t.same(args, ['\n\n', {}, { multiline: true, substitution: true, markdown: true, lang: 'mock content lang' }])
 
   t.end()
 })
@@ -454,7 +454,7 @@ test('get answered display value for item when the instance title summary is def
   t.equal(id, 'mock anyOf item id', 'gets the instance title summary')
 
   const { firstCall: { args } } = formatStub
-  t.deepEqual(args, ['mock instance title summary', {}, { multiline: false, substitution: true, markdown: true, lang: 'mock content lang' }])
+  t.same(args, ['mock instance title summary', {}, { multiline: false, substitution: true, markdown: true, lang: 'mock content lang' }])
 
   t.end()
 })
@@ -483,7 +483,7 @@ test('get answered display value for item when the instance title summary is not
   t.equal(id, 'mock anyOf item id', 'gets the instance title summary')
 
   const { firstCall: { args } } = formatStub
-  t.deepEqual(args, ['mock anyOf value', {}, { multiline: false, substitution: true, markdown: true, lang: 'mock content lang' }])
+  t.same(args, ['mock anyOf value', {}, { multiline: false, substitution: true, markdown: true, lang: 'mock content lang' }])
 
   t.end()
 })
@@ -512,7 +512,7 @@ test('get answered display value for item when the instance title summary is not
   t.equal(id, 'mock anyOf item id', 'gets the instance title summary')
 
   const { firstCall: { args } } = formatStub
-  t.deepEqual(args, [undefined, {}, { multiline: false, substitution: true, markdown: true, lang: 'mock content lang' }])
+  t.same(args, [undefined, {}, { multiline: false, substitution: true, markdown: true, lang: 'mock content lang' }])
 
   t.end()
 })
@@ -527,7 +527,7 @@ test('get redacted display value', (t) => {
 
   t.equal(anyOfController.getRedactedDisplayValue(componentInstance, userData), 'mock return value', 'returns the value from super')
 
-  t.deepEqual(getRedactedDisplayValueStub.firstCall.args, [componentInstance, userData], 'calls super')
+  t.same(getRedactedDisplayValueStub.firstCall.args, [componentInstance, userData], 'calls super')
 
   getRedactedDisplayValueStub.restore()
 
@@ -544,7 +544,7 @@ test('get redacted display value for item', (t) => {
 
   t.equal(anyOfController.getRedactedDisplayValueForItem(componentInstanceItem, userData), 'mock return value', 'returns the value from super')
 
-  t.deepEqual(getRedactedDisplayValueStub.firstCall.args, [componentInstanceItem, userData], 'calls super')
+  t.same(getRedactedDisplayValueStub.firstCall.args, [componentInstanceItem, userData], 'calls super')
 
   getRedactedDisplayValueStub.restore()
 

--- a/lib/controller/component/common/get-composite.unit.spec.js
+++ b/lib/controller/component/common/get-composite.unit.spec.js
@@ -90,7 +90,7 @@ test('An instance has a composite', (t) => {
 
   t.equal(getCompositeStub.getCall(0).args[0], componentInstance, 'gets the composite from the controller')
 
-  t.deepEqual(composite, mockComposite, 'returns the composite')
+  t.same(composite, mockComposite, 'returns the composite')
 
   getServiceSchemaStub.reset()
   getCompositeStub.reset()
@@ -155,7 +155,7 @@ test('An instance does not have a composite', (t) => {
   t.equal(one, mockServiceSchema, 'calls `Reflect.has` with the service schema')
   t.equal(two, 'composite', 'calls `Reflect.has` with the composite field key')
 
-  t.deepEqual(composite, undefined, 'returns undefined')
+  t.same(composite, undefined, 'returns undefined')
 
   hasStub.restore()
   getStub.restore()

--- a/lib/controller/component/common/index.unit.spec.js
+++ b/lib/controller/component/common/index.unit.spec.js
@@ -27,15 +27,15 @@ test('Common Controller', (t) => {
 test('is multiline', (t) => {
   const commonController = new CommonController()
 
-  t.equals(commonController.isMultiLine({ multiline: true }), true, 'returns true when the component has a multiline field and the value is true')
+  t.equal(commonController.isMultiLine({ multiline: true }), true, 'returns true when the component has a multiline field and the value is true')
 
-  t.equals(commonController.isMultiLine({ multiline: false }), false, 'returns false when the component has a multiline field and the value is false')
+  t.equal(commonController.isMultiLine({ multiline: false }), false, 'returns false when the component has a multiline field and the value is false')
 
-  t.equals(commonController.isMultiLine({}), false, 'returns false when the component does not have a multiline field')
+  t.equal(commonController.isMultiLine({}), false, 'returns false when the component does not have a multiline field')
 
-  t.equals(commonController.isMultiLine({}, 'Yes\n\nYes'), true, 'returns true when the component value contains contiguous carriage return characters')
+  t.equal(commonController.isMultiLine({}, 'Yes\n\nYes'), true, 'returns true when the component value contains contiguous carriage return characters')
 
-  t.equals(commonController.isMultiLine({}, 'No\nNo'), false, 'returns false when the component value does not contain contiguous carriage return characters')
+  t.equal(commonController.isMultiLine({}, 'No\nNo'), false, 'returns false when the component value does not contain contiguous carriage return characters')
 
   t.end()
 })
@@ -79,9 +79,9 @@ test('is answered', (t) => {
 test('is redacted', (t) => {
   const commonController = new CommonController()
 
-  t.equals(commonController.isRedacted({ redacted: 'mock redacted pattern' }), true, 'returns true when the component has a redacted pattern')
+  t.equal(commonController.isRedacted({ redacted: 'mock redacted pattern' }), true, 'returns true when the component has a redacted pattern')
 
-  t.equals(commonController.isRedacted({}), false, 'returns false when the component does not have a redacted pattern')
+  t.equal(commonController.isRedacted({}), false, 'returns false when the component does not have a redacted pattern')
 
   t.end()
 })

--- a/lib/controller/component/common/one-of.unit.spec.js
+++ b/lib/controller/component/common/one-of.unit.spec.js
@@ -81,13 +81,13 @@ test('get answered display value', (t) => {
 
   t.equal(oneOfController.getAnsweredDisplayValue(componentInstance, userData), 'mock formatted value', 'returns the value')
 
-  t.deepEqual(isMultiLineStub.firstCall.args, [componentInstance, 'mock instance title summary'], 'gets is multiline')
+  t.same(isMultiLineStub.firstCall.args, [componentInstance, 'mock instance title summary'], 'gets is multiline')
 
   const { firstCall: { args: [id] } } = getInstanceTitleSummaryStub
   t.equal(id, 'mock oneOf item id', 'gets the instance title summary')
 
   const { firstCall: { args } } = formatStub
-  t.deepEqual(args, ['mock instance title summary', {}, { multiline: false, substitution: true, markdown: true, lang: 'mock content lang' }])
+  t.same(args, ['mock instance title summary', {}, { multiline: false, substitution: true, markdown: true, lang: 'mock content lang' }])
 
   t.end()
 })
@@ -129,13 +129,13 @@ test('get answered display value when there is more than one answer', (t) => {
 
   t.equal(oneOfController.getAnsweredDisplayValue(componentInstance, userData), 'mock formatted value', 'returns the value')
 
-  t.deepEqual(isMultiLineStub.firstCall.args, [componentInstance, 'mock instance title summary'], 'gets is multiline')
+  t.same(isMultiLineStub.firstCall.args, [componentInstance, 'mock instance title summary'], 'gets is multiline')
 
   const { firstCall: { args: [two] } } = getInstanceTitleSummaryStub
   t.equal(two, 'mock oneOf item id two', 'gets the instance title summary')
 
   const { firstCall: { args } } = formatStub
-  t.deepEqual(args, ['mock instance title summary', {}, { multiline: false, substitution: true, markdown: true, lang: 'mock content lang' }])
+  t.same(args, ['mock instance title summary', {}, { multiline: false, substitution: true, markdown: true, lang: 'mock content lang' }])
 
   t.end()
 })

--- a/lib/controller/component/type/answers/answers.common.unit.spec.js
+++ b/lib/controller/component/type/answers/answers.common.unit.spec.js
@@ -145,13 +145,13 @@ test('Populating the parent deletable answers when the parent deletable paramete
 
   const returnValue = populateParentDeletableAnswers(questionInstance, answersStub)
 
-  t.deepEqual(answersStub.push.firstCall.args, [
+  t.same(answersStub.push.firstCall.args, [
     {
       remove: 'parent delete value',
       repeatableDelete: 'parent repeatable delete'
     }
   ], 'populates the answers array')
-  t.equals(returnValue, true, 'returns true')
+  t.equal(returnValue, true, 'returns true')
 
   t.end()
 })
@@ -165,8 +165,8 @@ test('Populating the parent deletable answers when the parent deletable paramete
 
   const returnValue = populateParentDeletableAnswers(questionInstance, answersStub)
 
-  t.equals(answersStub.push.notCalled, true, 'does not populate the answers array')
-  t.equals(returnValue, false, 'returns false')
+  t.equal(answersStub.push.notCalled, true, 'does not populate the answers array')
+  t.equal(returnValue, false, 'returns false')
 
   t.end()
 })
@@ -180,8 +180,8 @@ test('Populating the step add answers when the step add parameter is defined', (
 
   const returnValue = populateStepAddAnswers(stepAdd, answersStub)
 
-  t.equals(answersStub.push.firstCall.args[0], stepAdd, 'populates the answers array')
-  t.equals(returnValue, true, 'returns true')
+  t.equal(answersStub.push.firstCall.args[0], stepAdd, 'populates the answers array')
+  t.equal(returnValue, true, 'returns true')
 
   t.end()
 })
@@ -195,8 +195,8 @@ test('Populating the step add answers when the step add parameter is not defined
 
   const returnValue = populateStepAddAnswers(stepAdd, answersStub)
 
-  t.equals(answersStub.push.notCalled, true, 'does not populate the answers array')
-  t.equals(returnValue, false, 'returns false')
+  t.equal(answersStub.push.notCalled, true, 'does not populate the answers array')
+  t.equal(returnValue, false, 'returns false')
 
   t.end()
 })
@@ -210,8 +210,8 @@ test('Populating the step remove answers when the step remove parameter is defin
 
   const returnValue = populateStepRemoveAnswers(stepRemove, answersStub)
 
-  t.equals(answersStub.push.firstCall.args[0], stepRemove, 'populates the answers array')
-  t.equals(returnValue, true, 'returns true')
+  t.equal(answersStub.push.firstCall.args[0], stepRemove, 'populates the answers array')
+  t.equal(returnValue, true, 'returns true')
 
   t.end()
 })
@@ -225,8 +225,8 @@ test('Populating the step remove answers when the step remove parameter is not d
 
   const returnValue = populateStepRemoveAnswers(stepRemove, answersStub)
 
-  t.equals(answersStub.push.notCalled, true, 'does not populate the answers array')
-  t.equals(returnValue, false, 'returns false')
+  t.equal(answersStub.push.notCalled, true, 'does not populate the answers array')
+  t.equal(returnValue, false, 'returns false')
 
   t.end()
 })
@@ -246,13 +246,13 @@ test('Populating the parent addable answers when the parent addable parameter is
 
   const returnValue = populateParentAddableAnswers(questionInstance, answersStub, currentInstance)
 
-  t.deepEqual(answersStub.push.firstCall.args, [
+  t.same(answersStub.push.firstCall.args, [
     {
       add: 'current instance id/parent add value',
       repeatableAdd: 'parent repeatable add'
     }
   ], 'populates the answers array')
-  t.equals(returnValue, true, 'returns true')
+  t.equal(returnValue, true, 'returns true')
 
   t.end()
 })
@@ -268,8 +268,8 @@ test('Populating the parent addable answers when the parent addable parameter is
 
   const returnValue = populateParentAddableAnswers(questionInstance, answersStub, currentInstance)
 
-  t.equals(answersStub.push.notCalled, true, 'does not populate the answers array')
-  t.equals(returnValue, false, 'returns false')
+  t.equal(answersStub.push.notCalled, true, 'does not populate the answers array')
+  t.equal(returnValue, false, 'returns false')
 
   t.end()
 })
@@ -287,14 +287,14 @@ test('Populating the parent repeatable heading answers when the parent repeatabl
 
   const returnValue = populateParentRepeatableHeadingAnswers(questionInstance, answersStub, level)
 
-  t.deepEqual(answersStub.push.firstCall.args, [
+  t.same(answersStub.push.firstCall.args, [
     {
       heading: 'parent repeatable heading',
       repeatable: true,
       level: 2
     }
   ], 'populates the answers array')
-  t.equals(returnValue, true, 'returns true')
+  t.equal(returnValue, true, 'returns true')
 
   t.end()
 })
@@ -310,8 +310,8 @@ test('Populating the parent repeatable heading answers when the parent repeatabl
 
   const returnValue = populateParentRepeatableHeadingAnswers(questionInstance, answersStub, level)
 
-  t.equals(answersStub.push.notCalled, true, 'does not populate the answers array')
-  t.equals(returnValue, false, 'returns false')
+  t.equal(answersStub.push.notCalled, true, 'does not populate the answers array')
+  t.equal(returnValue, false, 'returns false')
 
   t.end()
 })
@@ -333,8 +333,8 @@ test('Populating the repeatable heading answers with parameters and a repeatable
 
   const returnValue = populateRepeatableHeadingAnswers(questionInstance, pageHeading, answersStub, level)
 
-  t.equals(answersStub.push.notCalled, true, 'does not populate the answers array')
-  t.equals(returnValue, false, 'returns false')
+  t.equal(answersStub.push.notCalled, true, 'does not populate the answers array')
+  t.equal(returnValue, false, 'returns false')
 
   t.end()
 })
@@ -356,14 +356,14 @@ test('Populating the repeatable heading answers with parameters and a repeatable
 
   const returnValue = populateRepeatableHeadingAnswers(questionInstance, pageHeading, answersStub, level)
 
-  t.equals(answersStub.push.calledOnce, true, 'populates the answers array')
-  t.deepEqual(answersStub.push.firstCall.args, [
+  t.equal(answersStub.push.calledOnce, true, 'populates the answers array')
+  t.same(answersStub.push.firstCall.args, [
     {
       heading: 'repeatable heading',
       level: 3
     }
   ], 'populates the answers array')
-  t.equals(returnValue, true, 'returns true')
+  t.equal(returnValue, true, 'returns true')
 
   t.end()
 })
@@ -381,8 +381,8 @@ test('Populating the repeatable heading answers without parameters', (t) => {
 
   const returnValue = populateRepeatableHeadingAnswers(questionInstance, pageHeading, answersStub, level)
 
-  t.equals(answersStub.push.notCalled, true, 'does not populate the answers array')
-  t.equals(returnValue, false, 'returns false')
+  t.equal(answersStub.push.notCalled, true, 'does not populate the answers array')
+  t.equal(returnValue, false, 'returns false')
 
   t.end()
 })
@@ -412,10 +412,10 @@ test('Populating the answer bucket', (t) => {
 
   populateAnswerBucket(answerBucketStub, questionInstance, componentInstance, currentPage, currentInstance, userDataStub, pageInstance)
 
-  t.equals(striptagsStub.getCall(0).args[0], 'component label', 'removes html from the component label')
-  t.equals(striptagsStub.getCall(1).args[0], 'display value', 'removes html from the display value')
-  t.deepEqual(getUrlStub.firstCall.args, ['page id', 'params', undefined], 'gets the url')
-  t.deepEqual(answerBucketStub.push.firstCall.args[0], populateAnswerBucketExpectedData, 'populates the answers array')
+  t.equal(striptagsStub.getCall(0).args[0], 'component label', 'removes html from the component label')
+  t.equal(striptagsStub.getCall(1).args[0], 'display value', 'removes html from the display value')
+  t.same(getUrlStub.firstCall.args, ['page id', 'params', undefined], 'gets the url')
+  t.same(answerBucketStub.push.firstCall.args[0], populateAnswerBucketExpectedData, 'populates the answers array')
 
   t.end()
 })
@@ -446,10 +446,10 @@ test('Populating the answer bucket for an upload component when a file has not b
 
   populateAnswerBucket(answerBucketStub, questionInstance, componentInstance, currentPage, currentInstance, userDataStub, pageInstance)
 
-  t.equals(striptagsStub.getCall(0).args[0], 'component label', 'removes html from the component label')
-  t.equals(striptagsStub.getCall(1).args[0], 'display value', 'removes html from the display value')
-  t.deepEqual(getUrlStub.firstCall.args, ['page id', 'params', undefined], 'gets the url')
-  t.deepEqual(answerBucketStub.push.firstCall.args[0], populateFileUploadAnswerBucketExpectedData, 'populates the answers array')
+  t.equal(striptagsStub.getCall(0).args[0], 'component label', 'removes html from the component label')
+  t.equal(striptagsStub.getCall(1).args[0], 'display value', 'removes html from the display value')
+  t.same(getUrlStub.firstCall.args, ['page id', 'params', undefined], 'gets the url')
+  t.same(answerBucketStub.push.firstCall.args[0], populateFileUploadAnswerBucketExpectedData, 'populates the answers array')
 
   t.end()
 })
@@ -497,9 +497,9 @@ test('Populating the answer bucket for a checkboxes component with a value', (t)
     withLabel: expectedData
   } = populateCheckboxesAnswerBucketExpectedData
 
-  t.equals(striptagsStub.getCall(0).args[0], 'component label', 'removes html from the component label')
-  t.deepEqual(getUrlStub.firstCall.args, ['page id', 'params', undefined], 'gets the url')
-  t.deepEqual(answerBucketStub.push.firstCall.args[0], expectedData, 'populates the answers array')
+  t.equal(striptagsStub.getCall(0).args[0], 'component label', 'removes html from the component label')
+  t.same(getUrlStub.firstCall.args, ['page id', 'params', undefined], 'gets the url')
+  t.same(answerBucketStub.push.firstCall.args[0], expectedData, 'populates the answers array')
 
   t.end()
 })
@@ -545,9 +545,9 @@ test('Populating the answer bucket for a checkboxes component without a value', 
     withoutLabel: expectedData
   } = populateCheckboxesAnswerBucketExpectedData
 
-  t.equals(striptagsStub.getCall(0).args[0], 'component label', 'removes html from the component label')
-  t.deepEqual(getUrlStub.firstCall.args, ['page id', 'params', undefined], 'gets the url')
-  t.deepEqual(answerBucketStub.push.firstCall.args[0], expectedData, 'populates the answers array')
+  t.equal(striptagsStub.getCall(0).args[0], 'component label', 'removes html from the component label')
+  t.same(getUrlStub.firstCall.args, ['page id', 'params', undefined], 'gets the url')
+  t.same(answerBucketStub.push.firstCall.args[0], expectedData, 'populates the answers array')
 
   t.end()
 })
@@ -561,7 +561,7 @@ test('The current page is the last page', (t) => {
 
   const subsequentPage = getSubsequentPage(currentPage, userData, pageInstance)
 
-  t.deepEqual(getNextPageStub.firstCall.args, [currentPage, userData], 'calls `getNextPage`')
+  t.same(getNextPageStub.firstCall.args, [currentPage, userData], 'calls `getNextPage`')
   t.equal(subsequentPage, undefined, 'does not return a subsequent page')
 
   t.end()
@@ -576,8 +576,8 @@ test('The current page is not the last page', (t) => {
 
   const subsequentPage = getSubsequentPage(currentPage, userData, pageInstance)
 
-  t.deepEqual(getNextPageStub.firstCall.args, [currentPage, userData], 'calls `getNextPage`')
-  t.deepEqual(subsequentPage, { _id: 'next page id' }, 'returns a subsequent page')
+  t.same(getNextPageStub.firstCall.args, [currentPage, userData], 'calls `getNextPage`')
+  t.same(subsequentPage, { _id: 'next page id' }, 'returns a subsequent page')
 
   t.end()
 })
@@ -590,7 +590,7 @@ test('Creating an answer bucket', (t) => {
   const answerBucket = createAnswerBucket(answersStub)
 
   t.type(answerBucket, Array, 'returns an array')
-  t.deepEqual(answersStub.push.firstCall.args[0], { answers: answerBucket }, 'puts the answers bucket into the answers array')
+  t.same(answersStub.push.firstCall.args[0], { answers: answerBucket }, 'puts the answers bucket into the answers array')
 
   t.end()
 })
@@ -605,7 +605,7 @@ test('Creating an answer bucket item with a change action and a group', (t) => {
 
   const answerBucketItem = createAnswerBucketItem(page, component, key, value, changeAction, groupBy)
 
-  t.deepEqual(answerBucketItem, {
+  t.same(answerBucketItem, {
     page,
     component,
     key,
@@ -626,7 +626,7 @@ test('Creating an answer bucket item without a group', (t) => {
 
   const answerBucketItem = createAnswerBucketItem(page, component, key, value, changeAction)
 
-  t.deepEqual(answerBucketItem, {
+  t.same(answerBucketItem, {
     page,
     component,
     key,
@@ -646,7 +646,7 @@ test('Creating an answer bucket item without a change action', (t) => {
 
   const answerBucketItem = createAnswerBucketItem(page, component, key, value)
 
-  t.deepEqual(answerBucketItem, {
+  t.same(answerBucketItem, {
     page,
     component,
     key,
@@ -738,8 +738,8 @@ test('Formatting the section heading', (t) => {
 
   const formattedSectionHeading = formatSectionHeading(userDataStub, value, param)
 
-  t.deepEqual(userDataStub.getScopedUserData.firstCall.args, [{ param: 'param' }], 'calls `userData.getScopedUserData`')
-  t.deepEqual(formatStub.firstCall.args, ['value', 'scoped user data', { lang: 'content lang' }], 'calls `format`')
+  t.same(userDataStub.getScopedUserData.firstCall.args, [{ param: 'param' }], 'calls `userData.getScopedUserData`')
+  t.same(formatStub.firstCall.args, ['value', 'scoped user data', { lang: 'content lang' }], 'calls `format`')
   t.equal(formattedSectionHeading, 'formatted section heading', 'returns the formatted section heading')
 
   t.end()
@@ -753,7 +753,7 @@ test('Getting the answer key', (t) => {
   const questionText = 'question html'
   const answerKey = getAnswerKey(questionText)
 
-  t.deepEqual(answerKey, { html: 'question html', text: 'question text' }, 'returns the answer key object')
+  t.same(answerKey, { html: 'question html', text: 'question text' }, 'returns the answer key object')
 
   t.end()
 })
@@ -768,8 +768,8 @@ test('Getting the answer value when the value is undefined', (t) => {
 
   const answerValue = getAnswerValue(displayValue, value)
 
-  t.deepEqual(striptagsStub.firstCall.args[0], 'display value html', 'calls `striptags`')
-  t.deepEqual(answerValue, { html: 'display value html', text: 'display value text', machine: 'display value text' }, 'returns the answer value object')
+  t.same(striptagsStub.firstCall.args[0], 'display value html', 'calls `striptags`')
+  t.same(answerValue, { html: 'display value html', text: 'display value text', machine: 'display value text' }, 'returns the answer value object')
 
   t.end()
 })
@@ -784,8 +784,8 @@ test('Getting the answer value when the value is not undefined', (t) => {
 
   const answerValue = getAnswerValue(displayValue, value)
 
-  t.deepEqual(striptagsStub.firstCall.args[0], 'display value html', 'calls `striptags`')
-  t.deepEqual(answerValue, { html: 'display value html', text: 'display value text', machine: 'value' }, 'returns the answer value')
+  t.same(striptagsStub.firstCall.args[0], 'display value html', 'calls `striptags`')
+  t.same(answerValue, { html: 'display value html', text: 'display value text', machine: 'value' }, 'returns the answer value')
 
   t.end()
 })
@@ -802,7 +802,7 @@ test('Getting the change href in the default language', (t) => {
 
   const href = getChangeHref(currentPage, currentInstance, userData, pageInstance)
 
-  t.deepEqual(getUrlStub.firstCall.args, ['cid', 'params', 'content language'], 'gets the url')
+  t.same(getUrlStub.firstCall.args, ['cid', 'params', 'content language'], 'gets the url')
   t.equal(href, 'get-url/change/page-url', 'returns the href')
 
   t.end()
@@ -820,7 +820,7 @@ test('Getting the change href in Welsh', (t) => {
 
   const href = getChangeHref(currentPage, currentInstance, userData, pageInstance)
 
-  t.deepEqual(getUrlStub.firstCall.args, ['cid', 'params', 'cy'], 'gets the url')
+  t.same(getUrlStub.firstCall.args, ['cid', 'params', 'cy'], 'gets the url')
   t.equal(href, 'get-url/change/page-url', 'returns the href')
 
   t.end()

--- a/lib/controller/component/type/answers/answers.page-summary-list.unit.spec.js
+++ b/lib/controller/component/type/answers/answers.page-summary-list.unit.spec.js
@@ -143,28 +143,28 @@ test('When there are answers and headings and answers without answers', t => {
     const answersWithoutAnswers = [{ answers: [] }, { answers: [] }]
     const result = answersWithoutAnswers.filter(filterAnswers, [])
 
-    t.deepEqual(result, [], 'it removes the answers without answers')
+    t.same(result, [], 'it removes the answers without answers')
   }
 
   {
     const answersWithoutAnswers = [{ answers: [] }, answers, { answers: [] }, heading]
     const result = answersWithoutAnswers.filter(filterAnswers, [])
 
-    t.deepEqual(result, [answers, heading], 'it removes the answers without answers')
+    t.same(result, [answers, heading], 'it removes the answers without answers')
   }
 
   {
     const answersWithoutAnswers = [heading, { answers: [] }, heading, { answers: [] }]
     const result = answersWithoutAnswers.filter(filterAnswers, [])
 
-    t.deepEqual(result, [heading, heading], 'it removes the answers without answers')
+    t.same(result, [heading, heading], 'it removes the answers without answers')
   }
 
   {
     const answersWithoutAnswers = [{}, {}, {}]
     const result = answersWithoutAnswers.filter(filterAnswers, [])
 
-    t.deepEqual(result, [], 'it removes the answers without answers')
+    t.same(result, [], 'it removes the answers without answers')
   }
 
   t.end()
@@ -175,14 +175,14 @@ test('When there are answers without headings', t => {
     const singleAnswer = [answers]
     const result = singleAnswer.reduce(reduceHeadings, [])
 
-    t.deepEqual(result, [answers], 'it returns the single answer')
+    t.same(result, [answers], 'it returns the single answer')
   }
 
   {
     const multipleAnswers = [answers, answers, answers]
     const result = multipleAnswers.reduce(reduceHeadings, [])
 
-    t.deepEqual(result, multipleAnswers, 'it returns multiple answers')
+    t.same(result, multipleAnswers, 'it returns multiple answers')
   }
 
   t.end()
@@ -192,7 +192,7 @@ test('When there is a single leading heading', t => {
   const answersWithSingleLeadingHeading = [heading, answers]
   const result = answersWithSingleLeadingHeading.reduce(reduceHeadings, [])
 
-  t.deepEqual(result, [heading, answers], 'it returns both the leading heading and the answers')
+  t.same(result, [heading, answers], 'it returns both the leading heading and the answers')
 
   t.end()
 })
@@ -201,7 +201,7 @@ test('When there is a single trailing heading', t => {
   const answersWithSingleTrailingHeading = [answers, heading]
   const result = answersWithSingleTrailingHeading.reduce(reduceHeadings, [])
 
-  t.deepEqual(result, [answers], 'it removes the trailing heading and returns the answers')
+  t.same(result, [answers], 'it removes the trailing heading and returns the answers')
 
   t.end()
 })
@@ -210,7 +210,7 @@ test('When there are multiple trailing headings', t => {
   const answersWithMultipleTrailingHeadings = [answers, heading, heading, heading]
   const result = answersWithMultipleTrailingHeadings.reduce(reduceHeadings, [])
 
-  t.deepEqual(result, [answers, heading], 'it returns both a single trailing heading and the answers')
+  t.same(result, [answers, heading], 'it returns both a single trailing heading and the answers')
 
   t.end()
 })
@@ -219,7 +219,7 @@ test('When there are headings at different levels', t => {
   const input = [answers, headingLevel34, headingLevel33, headingLevel34, headingLevel33]
   const result = input.reduce(reduceHeadings, [])
 
-  t.deepEqual(result, [answers, headingLevel34, headingLevel33, headingLevel34], 'it returns headings at different levels')
+  t.same(result, [answers, headingLevel34, headingLevel33, headingLevel34], 'it returns headings at different levels')
 
   t.end()
 })
@@ -392,7 +392,7 @@ test('Answers component', async t => {
 
   const [questionInstance] = questionInstancesPage1
 
-  t.deepEqual(populateAnswerBucketStub.getCall(0).args, [
+  t.same(populateAnswerBucketStub.getCall(0).args, [
     answerBucket,
     questionInstance,
     componentInstance,
@@ -409,7 +409,7 @@ test('Answers component', async t => {
     questionInstanceFour
   ] = questionInstancesPage2
 
-  t.deepEqual(populateAnswerBucketStub.getCall(1).args, [
+  t.same(populateAnswerBucketStub.getCall(1).args, [
     answerBucket,
     questionInstanceOne,
     componentInstance,
@@ -419,7 +419,7 @@ test('Answers component', async t => {
     pageInstance
   ], 'calls `populateAnswerBucket` with the expected arguments (question instances page 2, component with `$originalId`)')
 
-  t.deepEqual(populateAnswerBucketStub.getCall(2).args, [
+  t.same(populateAnswerBucketStub.getCall(2).args, [
     answerBucket,
     questionInstanceTwo,
     componentInstance,
@@ -429,7 +429,7 @@ test('Answers component', async t => {
     pageInstance
   ], 'calls `populateAnswerBucket` with the expected arguments (question instances page 2, any component except checkboxes)')
 
-  t.deepEqual(populateAnswerBucketStub.getCall(3).args, [
+  t.same(populateAnswerBucketStub.getCall(3).args, [
     answerBucket,
     questionInstanceThree,
     componentInstance,
@@ -439,7 +439,7 @@ test('Answers component', async t => {
     pageInstance
   ], 'calls `populateAnswerBucket` with the expected arguments (question instances page 2, checkboxes component)')
 
-  t.deepEqual(populateAnswerBucketStub.getCall(4).args, [
+  t.same(populateAnswerBucketStub.getCall(4).args, [
     answerBucket,
     questionInstanceFour,
     componentInstance,
@@ -449,7 +449,7 @@ test('Answers component', async t => {
     pageInstance
   ], 'calls `populateAnswerBucket` with the expected arguments (question instances page 2, upload component)')
 
-  t.deepEqual(answers, expectedAnswers, 'answers should be correctly formed')
+  t.same(answers, expectedAnswers, 'answers should be correctly formed')
 
   t.end()
 })

--- a/lib/controller/component/type/answers/answers.page-summary.unit.spec.js
+++ b/lib/controller/component/type/answers/answers.page-summary.unit.spec.js
@@ -141,28 +141,28 @@ test('When there are answers and headings and answers without answers', t => {
     const answersWithoutAnswers = [{ answers: [] }, { answers: [] }]
     const result = answersWithoutAnswers.filter(filterAnswers, [])
 
-    t.deepEqual(result, [], 'it removes the answers without answers')
+    t.same(result, [], 'it removes the answers without answers')
   }
 
   {
     const answersWithoutAnswers = [{ answers: [] }, answers, { answers: [] }, heading]
     const result = answersWithoutAnswers.filter(filterAnswers, [])
 
-    t.deepEqual(result, [answers, heading], 'it removes the answers without answers')
+    t.same(result, [answers, heading], 'it removes the answers without answers')
   }
 
   {
     const answersWithoutAnswers = [heading, { answers: [] }, heading, { answers: [] }]
     const result = answersWithoutAnswers.filter(filterAnswers, [])
 
-    t.deepEqual(result, [heading, heading], 'it removes the answers without answers')
+    t.same(result, [heading, heading], 'it removes the answers without answers')
   }
 
   {
     const answersWithoutAnswers = [{}, {}, {}]
     const result = answersWithoutAnswers.filter(filterAnswers, [])
 
-    t.deepEqual(result, [], 'it removes the answers without answers')
+    t.same(result, [], 'it removes the answers without answers')
   }
 
   t.end()
@@ -173,14 +173,14 @@ test('When there are answers without headings', t => {
     const singleAnswer = [answers]
     const result = singleAnswer.reduce(reduceHeadings, [])
 
-    t.deepEqual(result, [answers], 'it returns the single answer')
+    t.same(result, [answers], 'it returns the single answer')
   }
 
   {
     const multipleAnswers = [answers, answers, answers]
     const result = multipleAnswers.reduce(reduceHeadings, [])
 
-    t.deepEqual(result, multipleAnswers, 'it returns multiple answers')
+    t.same(result, multipleAnswers, 'it returns multiple answers')
   }
 
   t.end()
@@ -190,7 +190,7 @@ test('When there is a single leading heading', t => {
   const answersWithSingleLeadingHeading = [heading, answers]
   const result = answersWithSingleLeadingHeading.reduce(reduceHeadings, [])
 
-  t.deepEqual(result, [heading, answers], 'it returns both the leading heading and the answers')
+  t.same(result, [heading, answers], 'it returns both the leading heading and the answers')
 
   t.end()
 })
@@ -199,7 +199,7 @@ test('When there is a single trailing heading', t => {
   const answersWithSingleTrailingHeading = [answers, heading]
   const result = answersWithSingleTrailingHeading.reduce(reduceHeadings, [])
 
-  t.deepEqual(result, [answers], 'it removes the trailing heading and returns the answers')
+  t.same(result, [answers], 'it removes the trailing heading and returns the answers')
 
   t.end()
 })
@@ -208,7 +208,7 @@ test('When there are multiple trailing headings', t => {
   const answersWithMultipleTrailingHeadings = [answers, heading, heading, heading]
   const result = answersWithMultipleTrailingHeadings.reduce(reduceHeadings, [])
 
-  t.deepEqual(result, [answers, heading], 'it returns both a single trailing heading and the answers')
+  t.same(result, [answers, heading], 'it returns both a single trailing heading and the answers')
 
   t.end()
 })
@@ -217,7 +217,7 @@ test('When there are headings at different levels', t => {
   const input = [answers, headingLevel34, headingLevel33, headingLevel34, headingLevel33]
   const result = input.reduce(reduceHeadings, [])
 
-  t.deepEqual(result, [answers, headingLevel34, headingLevel33, headingLevel34], 'it returns headings at different levels')
+  t.same(result, [answers, headingLevel34, headingLevel33, headingLevel34], 'it returns headings at different levels')
 
   t.end()
 })
@@ -358,7 +358,7 @@ test('when invoking the answers component', async t => {
 
   t.equal(pageStub.skipComponents.callCount, 2, 'skipComponents was called twice for three pages')
 
-  t.deepEqual(answers, expectedAnswers, 'answers should be correctly formed')
+  t.same(answers, expectedAnswers, 'answers should be correctly formed')
 
   t.end()
 })

--- a/lib/controller/component/type/answers/repeatable-actions/repeatable-actions.unit.spec.js
+++ b/lib/controller/component/type/answers/repeatable-actions/repeatable-actions.unit.spec.js
@@ -24,8 +24,8 @@ test('When there is no minimum or maximum set on an initial repeating page', t =
     namePrefix: 'bar'
   }, userData)
 
-  t.deepEqual(repeatableActions.stepRemove, undefined, 'it should not return a remove action')
-  t.deepEqual(repeatableActions.stepAdd, {
+  t.same(repeatableActions.stepRemove, undefined, 'it should not return a remove action')
+  t.same(repeatableActions.stepAdd, {
     add: 'foo/bar',
     repeatableAdd: 'Add another'
   }, 'it should return an add action')
@@ -42,11 +42,11 @@ test('When a repeating page has no minimumn and has a lower index than the curre
     namePrefix: 'bar[1]'
   }, userData)
 
-  t.deepEqual(repeatableActions.stepRemove, {
+  t.same(repeatableActions.stepRemove, {
     remove: 'bar=1',
     repeatableDelete: 'Remove'
   }, 'it should return a remove action')
-  t.deepEqual(repeatableActions.stepAdd, undefined, 'it should not return an add action')
+  t.same(repeatableActions.stepAdd, undefined, 'it should not return an add action')
 
   t.end()
 })
@@ -60,7 +60,7 @@ test('When a repeating page has a custom add string', t => {
     repeatableAdd: 'Push it'
   }, userData)
 
-  t.deepEqual(repeatableActions.stepAdd, {
+  t.same(repeatableActions.stepAdd, {
     add: 'foo/bar',
     repeatableAdd: 'Push it'
   }, 'it should return an add action if needed with the custom add string')
@@ -78,7 +78,7 @@ test('When a repeating page has a custom delete string', t => {
     repeatableDelete: 'Zap it'
   }, userData)
 
-  t.deepEqual(repeatableActions.stepRemove, {
+  t.same(repeatableActions.stepRemove, {
     remove: 'bar=1',
     repeatableDelete: 'Zap it'
   }, 'it should return a remove action if needed with the custom delete string')
@@ -95,7 +95,7 @@ test('When a repeating page has reached its maximum', t => {
     repeatableMaximum: 1
   }, userData)
 
-  t.deepEqual(repeatableActions.stepAdd, undefined, 'it should not return an add action')
+  t.same(repeatableActions.stepAdd, undefined, 'it should not return an add action')
 
   t.end()
 })
@@ -110,7 +110,7 @@ test('When a repeating page has a minimum and has an index less than that minimu
     namePrefix: 'bar[2]'
   }, userData)
 
-  t.deepEqual(repeatableActions.stepRemove, undefined, 'it should not return a remove action')
+  t.same(repeatableActions.stepRemove, undefined, 'it should not return a remove action')
 
   t.end()
 })
@@ -125,7 +125,7 @@ test('When a repeating page has a maximum and has an index that is equal to it',
     namePrefix: 'bar[2]'
   }, userData)
 
-  t.deepEqual(repeatableActions.stepAdd, undefined, 'it should not return an add action')
+  t.same(repeatableActions.stepAdd, undefined, 'it should not return an add action')
 
   t.end()
 })

--- a/lib/controller/component/type/date/index.unit.spec.js
+++ b/lib/controller/component/type/date/index.unit.spec.js
@@ -46,7 +46,7 @@ test('A date component is not required', t => {
 
   const errors = dateController.validate(dateComponent, getUserData())
 
-  t.deepEqual(errors, [], 'it should not record the field as having an error')
+  t.same(errors, [], 'it should not record the field as having an error')
   t.end()
 })
 
@@ -58,7 +58,7 @@ test('A date component is required and no input has been provided', t => {
 
   const errors = dateController.validate(dateComponent, getUserData())
 
-  t.deepEqual(errors, [
+  t.same(errors, [
     { compositeName: 'dob-day', error: true },
     { compositeName: 'dob-month', error: true },
     { compositeName: 'dob-year', error: true },
@@ -83,7 +83,7 @@ test('A date component is required', t => {
     'dob-year': '1980'
   }))
 
-  t.deepEqual(errors, [], 'it should not record the field as having a required error')
+  t.same(errors, [], 'it should not record the field as having a required error')
 
   t.end()
 })
@@ -97,7 +97,7 @@ test('A date component has a day value', t => {
     'dob-year': ''
   }))
 
-  t.deepEqual(errors, [{ compositeName: 'dob-month', error: true }, { compositeName: 'dob-year', error: true }, { errorType: 'date.missing.month.year', instance: 'dob', error: { compositeInput: 'month' } }], 'it should record the field as having a missing month and year error')
+  t.same(errors, [{ compositeName: 'dob-month', error: true }, { compositeName: 'dob-year', error: true }, { errorType: 'date.missing.month.year', instance: 'dob', error: { compositeInput: 'month' } }], 'it should record the field as having a missing month and year error')
 
   t.end()
 })
@@ -111,7 +111,7 @@ test('A date component has a month value', t => {
     'dob-year': ''
   }))
 
-  t.deepEqual(errors, [{ compositeName: 'dob-day', error: true }, { compositeName: 'dob-year', error: true }, { errorType: 'date.missing.day.year', instance: 'dob', error: { compositeInput: 'day' } }], 'it should record the field as having a missing day and year error')
+  t.same(errors, [{ compositeName: 'dob-day', error: true }, { compositeName: 'dob-year', error: true }, { errorType: 'date.missing.day.year', instance: 'dob', error: { compositeInput: 'day' } }], 'it should record the field as having a missing day and year error')
 
   t.end()
 })
@@ -125,7 +125,7 @@ test('A date component has a year value', t => {
     'dob-year': '2'
   }))
 
-  t.deepEqual(errors, [{ compositeName: 'dob-day', error: true }, { compositeName: 'dob-month', error: true }, { errorType: 'date.missing.day.month', instance: 'dob', error: { compositeInput: 'day' } }], 'it should record the field as having a missing day and month error')
+  t.same(errors, [{ compositeName: 'dob-day', error: true }, { compositeName: 'dob-month', error: true }, { errorType: 'date.missing.day.month', instance: 'dob', error: { compositeInput: 'day' } }], 'it should record the field as having a missing day and month error')
 
   t.end()
 })
@@ -139,7 +139,7 @@ test('A date component has no day', t => {
     'dob-year': '2'
   }))
 
-  t.deepEqual(errors, [{ compositeName: 'dob-day', error: true }, { errorType: 'date.missing.day', instance: 'dob', error: { compositeInput: 'day' } }], 'it should record the field as having a missing day error')
+  t.same(errors, [{ compositeName: 'dob-day', error: true }, { errorType: 'date.missing.day', instance: 'dob', error: { compositeInput: 'day' } }], 'it should record the field as having a missing day error')
 
   t.end()
 })
@@ -153,7 +153,7 @@ test('A date component has no month', t => {
     'dob-year': '2'
   }))
 
-  t.deepEqual(errors, [{ compositeName: 'dob-month', error: true }, { errorType: 'date.missing.month', instance: 'dob', error: { compositeInput: 'month' } }], 'it should record the field as having a missing month error')
+  t.same(errors, [{ compositeName: 'dob-month', error: true }, { errorType: 'date.missing.month', instance: 'dob', error: { compositeInput: 'month' } }], 'it should record the field as having a missing month error')
 
   t.end()
 })
@@ -166,7 +166,7 @@ test('A date component has no year', t => {
     'dob-month': '2',
     'dob-year': ''
   }))
-  t.deepEqual(errors, [{ compositeName: 'dob-year', error: true }, { errorType: 'date.missing.year', instance: 'dob', error: { compositeInput: 'year' } }], 'it should record the field as having a missing year error')
+  t.same(errors, [{ compositeName: 'dob-year', error: true }, { errorType: 'date.missing.year', instance: 'dob', error: { compositeInput: 'year' } }], 'it should record the field as having a missing year error')
   t.end()
 })
 
@@ -179,7 +179,7 @@ test('A date component has an invalid date', t => {
     'dob-year': '2'
   }))
 
-  t.deepEqual(errors, [{ compositeName: 'dob-day', error: true }, { compositeName: 'dob-month', error: true }, { compositeName: 'dob-year', error: true }, { errorType: 'date.invalid', instance: 'dob', error: { compositeInput: 'day' } }], 'it should record the field as having an invalid date error')
+  t.same(errors, [{ compositeName: 'dob-day', error: true }, { compositeName: 'dob-month', error: true }, { compositeName: 'dob-year', error: true }, { errorType: 'date.invalid', instance: 'dob', error: { compositeInput: 'day' } }], 'it should record the field as having an invalid date error')
 
   t.end()
 })

--- a/lib/controller/component/type/upload/index.unit.spec.js
+++ b/lib/controller/component/type/upload/index.unit.spec.js
@@ -77,13 +77,13 @@ test('get answered display value', (t) => {
 
   t.equal(uploadController.getAnsweredDisplayValue(componentInstance, userData), 'mock formatted value', 'returns the value')
 
-  t.deepEqual(isMultiLineStub.firstCall.args, [componentInstance, 'mock original name (mock bytes)'], 'gets is multiline')
+  t.same(isMultiLineStub.firstCall.args, [componentInstance, 'mock original name (mock bytes)'], 'gets is multiline')
 
   const { firstCall: { args: [id] } } = bytesStub
   t.equal(id, 'mock size', 'gets the bytes')
 
   const { firstCall: { args } } = formatStub
-  t.deepEqual(args, ['mock original name (mock bytes)', {}, { multiline: false, substitution: true, markdown: true, lang: 'mock content lang' }])
+  t.same(args, ['mock original name (mock bytes)', {}, { multiline: false, substitution: true, markdown: true, lang: 'mock content lang' }])
 
   t.end()
 })

--- a/lib/controller/page/type/page.summary/index.unit.spec.js
+++ b/lib/controller/page/type/page.summary/index.unit.spec.js
@@ -112,7 +112,7 @@ test('When there is no next page', async t => {
   const pageSummaryController = new PageSummaryController()
 
   const expectedInstance = await pageSummaryController.preFlight(pageInstance, userData)
-  t.equals(expectedInstance.redirect, undefined, 'it should not return an unanswered page to redirect to')
+  t.equal(expectedInstance.redirect, undefined, 'it should not return an unanswered page to redirect to')
   t.end()
 })
 
@@ -122,7 +122,7 @@ test('When the next page is not a confirmation page', async t => {
   const pageSummaryController = new PageSummaryController()
 
   const expectedInstance = await pageSummaryController.preFlight(pageInstance, userData)
-  t.equals(expectedInstance.redirect, undefined, 'it should not return an unanswered page to redirect to')
+  t.equal(expectedInstance.redirect, undefined, 'it should not return an unanswered page to redirect to')
   t.end()
 })
 
@@ -134,7 +134,7 @@ test('When all previous required questions have been answered', async t => {
   const pageSummaryController = new PageSummaryController()
 
   const expectedInstance = await pageSummaryController.preFlight(pageInstance, userData)
-  t.equals(expectedInstance.redirect, undefined, 'it should not return an unanswered page to redirect to')
+  t.equal(expectedInstance.redirect, undefined, 'it should not return an unanswered page to redirect to')
   t.end()
 })
 
@@ -146,7 +146,7 @@ test('When any previous required questions have not been answered', async t => {
   const pageSummaryController = new PageSummaryController()
 
   const expectedInstance = await pageSummaryController.preFlight(pageInstance, userData)
-  t.equals(expectedInstance.redirect, '/notAnswered', 'it should return the url of an unanswered page to redirect to')
+  t.equal(expectedInstance.redirect, '/notAnswered', 'it should return the url of an unanswered page to redirect to')
   t.end()
 })
 
@@ -158,7 +158,7 @@ test('When all previous required questions have been answered', async t => {
   const pageSummaryController = new PageSummaryController()
 
   const expectedInstance = await pageSummaryController.preFlight(pageInstance, userData)
-  t.equals(expectedInstance.redirect, undefined, 'it should not return an unanswered page to redirect to')
+  t.equal(expectedInstance.redirect, undefined, 'it should not return an unanswered page to redirect to')
   t.end()
 })
 
@@ -170,7 +170,7 @@ test('When all previous required questions have been answered - and a url is ret
   const pageSummaryController = new PageSummaryController()
 
   const expectedInstance = await pageSummaryController.preFlight(pageInstance, userData)
-  t.equals(expectedInstance.redirect, undefined, 'it should not return an unanswered page to redirect to')
+  t.equal(expectedInstance.redirect, undefined, 'it should not return an unanswered page to redirect to')
   t.end()
 })
 
@@ -198,8 +198,8 @@ test('it attaches a user submission when the property is set to true', async t =
 
   const submissions = submitterClientSpy.getCall(0).args[0].actions
 
-  t.equals(submissions[1].recipientType, 'user')
-  t.equals(submissions[1].attachments.length, 1)
+  t.equal(submissions[1].recipientType, 'user')
+  t.equal(submissions[1].attachments.length, 1)
   submitterClientSpy.resetHistory()
   t.end()
 })
@@ -254,8 +254,8 @@ test('it does not attach a user submission when the property is set to false', a
 
   const actions = submitterClientSpy.getCall(0).args[0].actions
 
-  t.equals(actions[1].recipientType, 'user')
-  t.equals(actions[1].attachments.length, 0)
+  t.equal(actions[1].recipientType, 'user')
+  t.equal(actions[1].attachments.length, 0)
   submitterClientSpy.resetHistory()
   t.end()
 })
@@ -280,10 +280,10 @@ test('it attaches json to submission when env var present', async t => {
   await pageSummaryController.postValidation({}, userData)
 
   const submissions = submitterClientSpy.getCall(0).args[0].actions
-  t.equals(submissions[1].type, 'json')
-  t.equals(submissions[1].url, 'https://example.com/adaptor')
-  t.equals(submissions[1].encryption_key, 'shared_key')
-  t.equals(submissions[1].user_answers.mock_question_1, 'mock_answer_1')
+  t.equal(submissions[1].type, 'json')
+  t.equal(submissions[1].url, 'https://example.com/adaptor')
+  t.equal(submissions[1].encryption_key, 'shared_key')
+  t.equal(submissions[1].user_answers.mock_question_1, 'mock_answer_1')
 
   t.deepEquals(submissions[1].attachments, [])
   submitterClientSpy.resetHistory()
@@ -318,9 +318,9 @@ test('when there are files it attaches them to json submission', async t => {
   await pageSummaryController.postValidation({}, userdata)
 
   const submissions = submitterClientSpy.getCall(0).args[0].actions
-  t.equals(submissions[1].type, 'json')
-  t.equals(submissions[1].url, 'https://example.com/adaptor')
-  t.equals(submissions[1].encryption_key, 'shared_key')
+  t.equal(submissions[1].type, 'json')
+  t.equal(submissions[1].url, 'https://example.com/adaptor')
+  t.equal(submissions[1].encryption_key, 'shared_key')
   t.deepEquals(submissions[1].attachments, userDataWithFiles.uploadedFiles())
   submitterClientSpy.resetHistory()
   t.end()
@@ -410,8 +410,8 @@ test('Dynamic content is rendered in the Team email body', async t => {
   const submissions = submitterClientSpy.getCall(0).args[0].actions
   const emailEntries = submissions.filter(s => s.type === 'email')
 
-  t.equals(emailEntries[0].recipientType, 'team')
-  t.equals(emailEntries[0].email_body, 'user bob submitted!')
+  t.equal(emailEntries[0].recipientType, 'team')
+  t.equal(emailEntries[0].email_body, 'user bob submitted!')
 
   submitterClientSpy.resetHistory()
   t.end()
@@ -445,8 +445,8 @@ test('user email body can be overridden to use a rendered template', async t => 
   const submissions = submitterClientSpy.getCall(0).args[0].actions
   const emailEntries = submissions.filter(s => s.type === 'email')
 
-  t.equals(emailEntries[1].recipientType, 'user')
-  t.equals(emailEntries[1].email_body, 'you (bob) submitted!')
+  t.equal(emailEntries[1].recipientType, 'user')
+  t.equal(emailEntries[1].email_body, 'you (bob) submitted!')
 
   submitterClientSpy.resetHistory()
   t.end()
@@ -482,7 +482,7 @@ test('actions contains email and json actions', async t => {
 
   const submissions = submitterClientSpy.getCall(0).args[0]
 
-  t.equals(submissions.actions.length, 4)
+  t.equal(submissions.actions.length, 4)
 
   // remove deprecated fields
   submissions.actions.map(action => { // eslint-disable-line array-callback-return
@@ -559,7 +559,7 @@ test('split emails from json, csv and normal submissions', async t => {
 
   const submissions = submitterClientSpy.getCall(0).args[0]
 
-  t.equals(submissions.actions.length, 6)
+  t.equal(submissions.actions.length, 6)
 
   // remove deprecated fields
   submissions.actions.map(action => { // eslint-disable-line array-callback-return

--- a/lib/element-size-mappings/element-size-mappings.unit.spec.js
+++ b/lib/element-size-mappings/element-size-mappings.unit.spec.js
@@ -28,7 +28,7 @@ const {
 test('When requesting the size mappings', t => {
   const mappings = getMappings()
 
-  t.deepEqual(mappings, {
+  t.same(mappings, {
     heading: {
       any: 'sizeClass.heading'
     },
@@ -50,20 +50,20 @@ test('When requesting the size mappings', t => {
 
 test('When requesting a size mapping class that has been specified', t => {
   const headingClass = getClass('heading')
-  t.deepEqual(headingClass, 'sizeClass.heading', 'it should return the value')
+  t.same(headingClass, 'sizeClass.heading', 'it should return the value')
   t.end()
 })
 
 test('When requesting a size mapping class for a specific type', t => {
   const labelSingleClass = getClass('label', 'single')
-  t.deepEqual(labelSingleClass, 'sizeClass.label.single', 'it should return the single value')
+  t.same(labelSingleClass, 'sizeClass.label.single', 'it should return the single value')
   const labelMultipleClass = getClass('label', 'multiple')
-  t.deepEqual(labelMultipleClass, 'sizeClass.label.multiple', 'it should return the multiple value')
+  t.same(labelMultipleClass, 'sizeClass.label.multiple', 'it should return the multiple value')
   t.end()
 })
 
 test('When requesting a size mapping class that has not been specified', t => {
   const headingPageStartClass = getClass('heading.page.start')
-  t.deepEqual(headingPageStartClass, '', 'it should return an empty string')
+  t.same(headingPageStartClass, '', 'it should return an empty string')
   t.end()
 })

--- a/lib/format/format.unit.spec.js
+++ b/lib/format/format.unit.spec.js
@@ -157,7 +157,7 @@ test('When formatting a string which contains a nested string', t => {
   getInstanceLangPropertyStub.resetHistory()
   getInstanceLangPropertyStub.callsFake(() => 'bar')
   const formatted = format('[% foo %]')
-  t.deepEqual(getInstanceLangPropertyStub.getCall(0).args, ['foo', 'value', undefined], 'it should use the value property for the string lookup')
+  t.same(getInstanceLangPropertyStub.getCall(0).args, ['foo', 'value', undefined], 'it should use the value property for the string lookup')
   t.equal(formatted, 'bar', 'it should return the nested string')
   getInstanceLangPropertyStub.restore()
   t.end()
@@ -166,7 +166,7 @@ test('When formatting a string which contains a nested string', t => {
 test('When formatting a string for an explicit lang', t => {
   getInstanceLangPropertyStub.resetHistory()
   const formatted = format('[% foo %]', {}, { lang: 'cy' }) // eslint-disable-line no-unused-vars
-  t.deepEqual(getInstanceLangPropertyStub.getCall(0).args, ['foo', 'value', 'cy'], 'it should pass the lang to the instance property lookup')
+  t.same(getInstanceLangPropertyStub.getCall(0).args, ['foo', 'value', 'cy'], 'it should pass the lang to the instance property lookup')
   getInstanceLangPropertyStub.restore()
   t.end()
 })
@@ -174,7 +174,7 @@ test('When formatting a string for an explicit lang', t => {
 test('When formatting a string for an explicit lang that has not been configured', t => {
   getInstanceLangPropertyStub.resetHistory()
   const formatted = format('[% foo %]', {}, { lang: 'fr' }) // eslint-disable-line no-unused-vars
-  t.deepEqual(getInstanceLangPropertyStub.getCall(0).args, ['foo', 'value', 'fr'], 'it should pass the lang to the instance property lookup anyway')
+  t.same(getInstanceLangPropertyStub.getCall(0).args, ['foo', 'value', 'fr'], 'it should pass the lang to the instance property lookup anyway')
   getInstanceLangPropertyStub.restore()
   t.end()
 })
@@ -212,7 +212,7 @@ test('When formatting a string which contains a nested string referencing an exp
   getInstanceLangPropertyStub.callsFake(() => {})
 
   format('[% foo#bar %]')
-  t.deepEqual(getInstanceLangPropertyStub.getCall(0).args, ['foo', 'bar', undefined], 'it should use the explicit property to retrieve the referenced string')
+  t.same(getInstanceLangPropertyStub.getCall(0).args, ['foo', 'bar', undefined], 'it should use the explicit property to retrieve the referenced string')
 
   getInstanceLangPropertyStub.restore()
   t.end()
@@ -255,7 +255,7 @@ test('When formatting a string referencing a url by instance id and passing para
 
   format('[% url:foo bar="baz" %]')
   const callArgs = getUrlStub.getCall(0).args
-  t.deepEqual(callArgs, ['foo', { bar: 'baz' }, undefined], 'it should pass those parameters to getUrl')
+  t.same(callArgs, ['foo', { bar: 'baz' }, undefined], 'it should pass those parameters to getUrl')
 
   getUrlStub.restore()
   t.end()

--- a/lib/format/formatter/get-data.unit.spec.js
+++ b/lib/format/formatter/get-data.unit.spec.js
@@ -45,19 +45,19 @@ test('When asking for a property but no data is passed', t => {
 
 test('When preprocessing an undefined value', t => {
   const value = preprocessMessageFormat(undefined, {})
-  t.deepEqual(value, undefined, 'it should return undefined')
+  t.same(value, undefined, 'it should return undefined')
   t.end()
 })
 
 test('When preprocessing an emptty string', t => {
   const value = preprocessMessageFormat(undefined, {})
-  t.deepEqual(value, undefined, 'it should return undefined')
+  t.same(value, undefined, 'it should return undefined')
   t.end()
 })
 
 test('When preprocessing a string containing an ordinary subsitution', t => {
   const processed = preprocessMessageFormat('{foo}', {})
-  t.deepEqual(processed, {
+  t.same(processed, {
     value: '{foo}',
     args: {}
   }, 'it should return the string and args unchanged')
@@ -74,7 +74,7 @@ test('When preprocessing a string containing a nested subsitution', t => {
   }
 
   const value = preprocessMessageFormat('{foo.bar}', data)
-  t.deepEqual(value, {
+  t.same(value, {
     value: '{__FORMATDATA__IDENTIFIER_foo__dot__bar}',
     args: { __FORMATDATA__IDENTIFIER_foo__dot__bar: 'baz' }
   }, 'it should return the updated value and args')
@@ -85,7 +85,7 @@ test('When preprocessing a string containing a nested subsitution that has no va
   const data = {}
 
   const value = preprocessMessageFormat('{foo.bar}', data)
-  t.deepEqual(value, {
+  t.same(value, {
     value: '{__FORMATDATA__IDENTIFIER_foo__dot__bar}',
     args: { __FORMATDATA__IDENTIFIER_foo__dot__bar: undefined }
   }, 'it should return the updated value and args')
@@ -105,7 +105,7 @@ test('When preprocessing a string containing multiple nested subsitutions', t =>
   }
 
   const value = preprocessMessageFormat('{foo.bar} {x.y}', data)
-  t.deepEqual(value, {
+  t.same(value, {
     value: '{__FORMATDATA__IDENTIFIER_foo__dot__bar} {__FORMATDATA__IDENTIFIER_x__dot__y}',
     args: {
       __FORMATDATA__IDENTIFIER_foo__dot__bar: 'baz',
@@ -125,7 +125,7 @@ test('When preprocessing a string containing a nested subsitution within another
   }
 
   const value = preprocessMessageFormat('{foo, select, undefined{} other{{foo.bar}}}', data)
-  t.deepEqual(value, {
+  t.same(value, {
     value: '{foo, select, undefined{} other{{__FORMATDATA__IDENTIFIER_foo__dot__bar}}}',
     args: { __FORMATDATA__IDENTIFIER_foo__dot__bar: 'baz' }
   }, 'it should return the updated value and args')
@@ -142,7 +142,7 @@ test('When preprocessing a string containing a nested subsitution within another
   }
 
   const value = preprocessMessageFormat('{foo.bar, select, undefined{} other{{foo.bar}}}', data)
-  t.deepEqual(value, {
+  t.same(value, {
     value: '{__FORMATDATA__IDENTIFIER_foo__dot__bar, select, undefined{} other{{__FORMATDATA__IDENTIFIER_foo__dot__bar}}}',
     args: { __FORMATDATA__IDENTIFIER_foo__dot__bar: 'baz' }
   }, 'it should return the updated value and args')
@@ -156,7 +156,7 @@ test('When preprocessing a string containing an array item subsitution', t => {
     }
   }
   const value = preprocessMessageFormat('{foo[2]}', data)
-  t.deepEqual(value, {
+  t.same(value, {
     value: '{__FORMATDATA__IDENTIFIER_foo__leftbracket__2__rightbracket__}',
     args: { __FORMATDATA__IDENTIFIER_foo__leftbracket__2__rightbracket__: 'c' }
   }, 'it should return the updated value and args')
@@ -171,7 +171,7 @@ test('When preprocessing a string containing a scoped subsitution', t => {
   }
 
   const value = preprocessMessageFormat('{foo@bar}', data)
-  t.deepEqual(value, {
+  t.same(value, {
     value: '{__FORMATDATA__SCOPE_foo__IDENTIFIER_bar}',
     args: { __FORMATDATA__SCOPE_foo__IDENTIFIER_bar: 'baz' }
   }, 'it should return the updated value and args')
@@ -193,7 +193,7 @@ test('When preprocessing a string containing an multiple extended substitutions'
     }
   }
   const value = preprocessMessageFormat('{foo@bar} : {bar@foo.bar[0]} : {bar} : {foo[2]}', data)
-  t.deepEqual(value, {
+  t.same(value, {
     value: '{__FORMATDATA__SCOPE_foo__IDENTIFIER_bar} : {__FORMATDATA__SCOPE_bar__IDENTIFIER_foo__dot__bar__leftbracket__0__rightbracket__} : {bar} : {__FORMATDATA__IDENTIFIER_foo__leftbracket__2__rightbracket__}',
     args: {
       __FORMATDATA__SCOPE_foo__IDENTIFIER_bar: 'foo@bar',
@@ -207,7 +207,7 @@ test('When preprocessing a string containing an multiple extended substitutions'
 test('When preprocessing a string containing escaped braces and no extended substitutions', t => {
   const input = "'{'save@foo'}' blah '{'save@bar'}'" // eslint-disable-line quotes
   const value = preprocessMessageFormat(input, {})
-  t.deepEqual(value, {
+  t.same(value, {
     value: "'{'save@foo'}' blah '{'save@bar'}'", // eslint-disable-line quotes
     args: {}
   }, 'it should return undefined')
@@ -217,7 +217,7 @@ test('When preprocessing a string containing escaped braces and no extended subs
 test('When preprocessing a string containing both escaped braces and extended substitutions', t => {
   const input = "{save@foo} blah '{'save@bar'}'" // eslint-disable-line quotes
   const value = preprocessMessageFormat(input, {})
-  t.deepEqual(value, {
+  t.same(value, {
     value: '{__FORMATDATA__SCOPE_save__IDENTIFIER_foo} blah \'{\'save@bar\'}\'',
     args: { __FORMATDATA__SCOPE_save__IDENTIFIER_foo: undefined }
   }, 'it should return the updated value and args but leave the escaped braces intact')
@@ -227,7 +227,7 @@ test('When preprocessing a string containing both escaped braces and extended su
 test('When preprocessing a string with string aliases containing messageformat substitution', t => {
   const input = '[% {foo} %]'
   const value = preprocessMessageFormat(input, {})
-  t.deepEqual(value, {
+  t.same(value, {
     value: '[% {foo} %]',
     args: {}
   }, 'it should return value and args unchanged')
@@ -237,7 +237,7 @@ test('When preprocessing a string with string aliases containing messageformat s
 test('When preprocessing a string with string aliases containing extended messageformat substitution', t => {
   const input = '[% {nested.prop} %]'
   const value = preprocessMessageFormat(input, data)
-  t.deepEqual(value, {
+  t.same(value, {
     value: '[% {__FORMATDATA__IDENTIFIER_nested__dot__prop} %]',
     args: {
       __FORMATDATA__IDENTIFIER_nested__dot__prop: data.input['nested.prop']
@@ -249,7 +249,7 @@ test('When preprocessing a string with string aliases containing extended messag
 test('When preprocessing a string with messageformat substitution containing string alias', t => {
   const input = '{foo, select, bar{[% foo.bar %]} other{}}'
   const value = preprocessMessageFormat(input, {})
-  t.deepEqual(value, {
+  t.same(value, {
     value: '{foo, select, bar{[% foo.bar %]} other{}}',
     args: {}
   }, 'it should return value and args unchanged')
@@ -259,7 +259,7 @@ test('When preprocessing a string with messageformat substitution containing str
 test('When preprocessing a string with extended messageformat substitution containing string alias', t => {
   const input = '{nested.prop, select, bar{[% foo.bar %]} other{{nested.prop}}}'
   const value = preprocessMessageFormat(input, data)
-  t.deepEqual(value, {
+  t.same(value, {
     value: '{__FORMATDATA__IDENTIFIER_nested__dot__prop, select, bar{[% foo.bar %]} other{{__FORMATDATA__IDENTIFIER_nested__dot__prop}}}',
     args: {
       __FORMATDATA__IDENTIFIER_nested__dot__prop: data.input['nested.prop']

--- a/lib/format/parse-args.unit.spec.js
+++ b/lib/format/parse-args.unit.spec.js
@@ -4,66 +4,66 @@ const parseArgs = require('./parse-args')
 
 test('When parsing an undefined value', t => {
   const args = parseArgs()
-  t.deepEqual(args, {}, 'it should return an empty object')
+  t.same(args, {}, 'it should return an empty object')
   t.end()
 })
 
 test('When parsing an empty string', t => {
   const args = parseArgs('')
-  t.deepEqual(args, {}, 'it should return an empty object')
+  t.same(args, {}, 'it should return an empty object')
   t.end()
 })
 
 test('When parsing a property delimited with double quotes', t => {
   const args = parseArgs('foo="bar"')
-  t.deepEqual(args, { foo: 'bar' }, 'it should return the correct property')
+  t.same(args, { foo: 'bar' }, 'it should return the correct property')
   t.end()
 })
 
 test('When parsing a property delimited with single quotes', t => {
   const args = parseArgs('foo=\'bar\'')
-  t.deepEqual(args, { foo: 'bar' }, 'it should return the correct property')
+  t.same(args, { foo: 'bar' }, 'it should return the correct property')
   t.end()
 })
 
 test('When parsing a number property', t => {
   const args = parseArgs('foo=3')
-  t.deepEqual(args, { foo: 3 }, 'it should return the property as a number')
+  t.same(args, { foo: 3 }, 'it should return the property as a number')
   t.end()
 })
 
 test('When parsing a string property which is a number', t => {
   const args = parseArgs('foo="3"')
-  t.deepEqual(args, { foo: '3' }, 'it should return the property as a string')
+  t.same(args, { foo: '3' }, 'it should return the property as a string')
   t.end()
 })
 
 test('When parsing a boolean property', t => {
   const args = parseArgs('foo=true')
-  t.deepEqual(args, { foo: true }, 'it should return the property as true')
+  t.same(args, { foo: true }, 'it should return the property as true')
   t.end()
 })
 
 test('When parsing a negative boolean property', t => {
   const args = parseArgs('foo=false')
-  t.deepEqual(args, { foo: false }, 'it should return the property as false')
+  t.same(args, { foo: false }, 'it should return the property as false')
   t.end()
 })
 
 test('When parsing a string property that looks like a boolean', t => {
   const args = parseArgs('foo="true"')
-  t.deepEqual(args, { foo: 'true' }, 'it should return the property as string')
+  t.same(args, { foo: 'true' }, 'it should return the property as string')
   t.end()
 })
 
 test('When parsing a standalone property', t => {
   const args = parseArgs('foo')
-  t.deepEqual(args, { foo: true }, 'it should return the property as true')
+  t.same(args, { foo: true }, 'it should return the property as true')
   t.end()
 })
 
 test('When parsing an empty property', t => {
   const args = parseArgs('foo=""')
-  t.deepEqual(args, { foo: '' }, 'it should return the property as an empty string and not as true')
+  t.same(args, { foo: '' }, 'it should return the property as an empty string and not as true')
   t.end()
 })

--- a/lib/middleware/auth/auth.unit.spec.js
+++ b/lib/middleware/auth/auth.unit.spec.js
@@ -27,14 +27,14 @@ test('When auth is required ', t => {
 
 test('When auth is initialised with no credentials and no ENV variables', t => {
   const authMiddleware = auth.init()
-  t.equals(authMiddleware.name, '', 'it should return the empty middleware')
+  t.equal(authMiddleware.name, '', 'it should return the empty middleware')
 
   t.end()
 })
 
 test('When auth is initialised with explicit credentials', t => {
   const authMiddleware = defaultAuth()
-  t.equals(authMiddleware.name, 'authorize', 'it should return the authorize middleware')
+  t.equal(authMiddleware.name, 'authorize', 'it should return the authorize middleware')
 
   t.end()
 })
@@ -53,7 +53,7 @@ test('When auth is initialised with credentials', t => {
     }
   })
   authMiddleware(req, res, (msg) => {
-    t.equals(msg, 'basicAuth invoked', 'it should invoke basicAuth')
+    t.equal(msg, 'basicAuth invoked', 'it should invoke basicAuth')
   })
 
   const basicAuthSpy = spy(auth, 'callBasicAuth')

--- a/lib/middleware/error-handler/error-handler.unit.spec.js
+++ b/lib/middleware/error-handler/error-handler.unit.spec.js
@@ -53,14 +53,14 @@ test('When fallback method is called', t => {
   const expectedBody = (code) => `We are currently experiencing difficulties (${code})`
 
   errorHandlerInstance._fallbackError(req, res, 404)
-  t.true(resSendStatusStub.calledWith(), 'should not send a response for status codes below 500')
+  t.ok(resSendStatusStub.calledWith(), 'should not send a response for status codes below 500')
 
   errorHandlerInstance._fallbackError(req, res, 500)
-  t.true(resSendStub.calledWith(expectedBody(500)), 'should send correct repsonse for status code 500')
+  t.ok(resSendStub.calledWith(expectedBody(500)), 'should send correct repsonse for status code 500')
 
   resSendStub.resetHistory()
   errorHandlerInstance._fallbackError(req, res, 700)
-  t.true(resSendStub.calledWith(expectedBody(700)), 'should send correct repsonse for status codes above 500')
+  t.ok(resSendStub.calledWith(expectedBody(700)), 'should send correct repsonse for status codes above 500')
 
   resSendStub.restore()
   resSendStatusStub.restore()
@@ -73,7 +73,7 @@ test('When render method is called but no error instance exists', async t => {
   const fallbackErrorSpy = sinon.spy(errorHandlerInstance, '_fallbackError')
   await errorHandlerInstance.render(req, res, 404)
 
-  t.deepEqual(fallbackErrorSpy.calledWith(req, res, 404), true, 'it should invoke the fallbackError method with same arguments')
+  t.same(fallbackErrorSpy.calledWith(req, res, 404), true, 'it should invoke the fallbackError method with same arguments')
   fallbackErrorSpy.restore()
   t.end()
 })
@@ -103,10 +103,10 @@ test('When render method is called and an error instance exists', async t => {
 
   try {
     await errorHandlerInstance.render(req, res, 404)
-    t.true(nunjucksRenderStub.calledWithExactly(
+    t.ok(nunjucksRenderStub.calledWithExactly(
       errorInstance, { errCode: 404, GA_TRACKING_ID: undefined, GTM_TRACKING_ID: undefined }
     ), 'should invoke the nunjucks render method with the correct arguments')
-    t.true(resSendSpy.calledWith(errorOutput), 'it should send the correct output')
+    t.ok(resSendSpy.calledWith(errorOutput), 'it should send the correct output')
   } catch (e) {
     t.notOk(true, 'it should not throw an error')
     t.notOk(true, 'it should not throw an error')
@@ -145,10 +145,10 @@ test('When render method is called and an error instance  with 500 exists', asyn
   try {
     await errorHandlerInstance.render(req, res, 500)
 
-    t.true(nunjucksRenderStub.calledWithExactly(
+    t.ok(nunjucksRenderStub.calledWithExactly(
       errorInstance, { errCode: 500, GA_TRACKING_ID: undefined, GTM_TRACKING_ID: undefined }
     ), 'should invoke the nunjucks render method with the correct arguments')
-    t.true(resSendSpy.calledWith(errorOutput), 'it should send the correct output')
+    t.ok(resSendSpy.calledWith(errorOutput), 'it should send the correct output')
   } catch (e) {
     t.notOk(true, 'it should not throw an error')
   }
@@ -185,10 +185,10 @@ test('When render method is called and an error instance  with 503 exists', asyn
   try {
     await errorHandlerInstance.render(req, res, 503)
 
-    t.true(nunjucksRenderStub.calledWithExactly(
+    t.ok(nunjucksRenderStub.calledWithExactly(
       errorInstance, { errCode: 503, GA_TRACKING_ID: undefined, GTM_TRACKING_ID: undefined }
     ), 'should invoke the nunjucks render method with the correct arguments')
-    t.true(resSendSpy.calledWith(errorOutput), 'it should send the correct output')
+    t.ok(resSendSpy.calledWith(errorOutput), 'it should send the correct output')
   } catch (e) {
     t.notOk(true, 'it should not throw an error')
   }
@@ -227,10 +227,10 @@ test('When render method is called and an error instance  with 404 exists', asyn
   try {
     await errorHandlerInstance.render(req, res, 404)
 
-    t.true(nunjucksRenderStub.calledWithExactly(
+    t.ok(nunjucksRenderStub.calledWithExactly(
       errorInstance, { errCode: 404, GA_TRACKING_ID: undefined, GTM_TRACKING_ID: undefined }
     ), 'should invoke the nunjucks render method with the correct arguments')
-    t.true(resSendSpy.calledWith(errorOutput), 'it should send the correct output')
+    t.ok(resSendSpy.calledWith(errorOutput), 'it should send the correct output')
   } catch (e) {
     t.notOk(true, 'it should not throw an error')
   }
@@ -277,7 +277,7 @@ test('When notFound handler called', t => {
   const renderSpy = sinon.spy(errorHandlerInstance, 'render')
   errorHandlerInstance.notFound(req, res)
 
-  t.true(renderSpy.calledWith(req, res, 404), 'should render 404')
+  t.ok(renderSpy.calledWith(req, res, 404), 'should render 404')
   t.end()
 })
 
@@ -289,8 +289,8 @@ test('When notFound handler called but the url contains mangled output', t => {
   const testDemangle = (url) => {
     req.url = url
     errorHandlerInstance.notFound(req, res)
-    t.true(renderSpy.calledWith(req, res, 404), 'it should render a 404 page')
-    t.true(redirectStub.notCalled, 'it should not attempt a redirect')
+    t.ok(renderSpy.calledWith(req, res, 404), 'it should render a 404 page')
+    t.ok(redirectStub.notCalled, 'it should not attempt a redirect')
     redirectStub.resetHistory()
   }
   testDemangle('//////////////////////yahoo.com/')
@@ -304,6 +304,6 @@ test('When an unauthorised route is hit', t => {
   const { req, assertStatusCode } = invokeError(errorHandler.init().handle, t, new Error(401))
 
   assertStatusCode(401)
-  t.equals(req.unauthorised, true, 'should set req.unauthorised to true')
+  t.equal(req.unauthorised, true, 'should set req.unauthorised to true')
   t.end()
 })

--- a/lib/middleware/healthcheck/healthcheck.js
+++ b/lib/middleware/healthcheck/healthcheck.js
@@ -1,6 +1,6 @@
 require('@ministryofjustice/module-alias/register-module')(module)
 
-const request = require('request-promise-native')
+const fetch = require('make-fetch-happen')
 const {
   PORT
 } = require('~/fb-runner-node/constants/constants')
@@ -9,7 +9,7 @@ const TEST_URL = `http://localhost:${PORT}`
 
 function init (validate = () => true) {
   return (req, res) => (
-    request(TEST_URL)
+    fetch(TEST_URL)
       .then((response) => ({
         status: validate(response),
         statusCode: 200

--- a/lib/middleware/locals/locals.unit.spec.js
+++ b/lib/middleware/locals/locals.unit.spec.js
@@ -36,7 +36,7 @@ test('When locals is required ', t => {
 test('When locals middleware is called', t => {
   const { req, res } = getLocalInstance()
 
-  t.deepEqual(res.locals, {
+  t.same(res.locals, {
     asset_path: '/assetPath/',
     env: {
       ENVIRONMENT_DISPLAY: 'foo'
@@ -46,10 +46,10 @@ test('When locals middleware is called', t => {
     govuk_frontend_version: '1.4.5'
   }, 'it should set res.locals')
 
-  t.deepEqual(req.env, {
+  t.same(req.env, {
     ENVIRONMENT_DISPLAY: 'foo'
   }, 'it should set req.env')
-  t.deepEqual(req.ENV, {}, 'it should set req.ENV')
+  t.same(req.ENV, {}, 'it should set req.ENV')
 
   t.equal(req.servername, 'http://domain', 'it should set req.servername')
 
@@ -61,7 +61,7 @@ test('When locals middleware is called and x-forwarded-proto header is set', t =
     'x-forwarded-proto': 'https'
   })
 
-  t.equals(req.servername, 'https://domain', 'it should set req.servername')
+  t.equal(req.servername, 'https://domain', 'it should set req.servername')
 
   t.end()
 })

--- a/lib/middleware/logger/logger.unit.spec.js
+++ b/lib/middleware/logger/logger.unit.spec.js
@@ -25,12 +25,12 @@ test('When requesting the logger client', async t => {
   createLoggerStub.resetHistory()
 
   const Logger = logger.getLogger()
-  t.deepEqual(Logger, undefined, 'it should return undefined before the logger is initialised')
+  t.same(Logger, undefined, 'it should return undefined before the logger is initialised')
 
   logger.init({})
 
   const postLogger = logger.getLogger()
-  t.deepEqual(postLogger, 'logger instance', 'it should return a bunyan instance after the logger is initialised')
+  t.same(postLogger, 'logger instance', 'it should return a bunyan instance after the logger is initialised')
 
   t.end()
 })
@@ -106,11 +106,11 @@ test('When invoking the logger middleware', async t => {
   await invokeMiddleware(req, res)
 
   const infoStubArgs = infoStub.getCall(0).args
-  t.deepEqual(infoStubArgs[0], { name: 'http_request', requestId: '123456', req: { method: 'GET', url: '/foo', headers: { cookie: 'sessionId=1234; cookie2=bar' }, logger: 'childLogger' } }, 'it should log the incoming request, adding a request id')
+  t.same(infoStubArgs[0], { name: 'http_request', requestId: '123456', req: { method: 'GET', url: '/foo', headers: { cookie: 'sessionId=1234; cookie2=bar' }, logger: 'childLogger' } }, 'it should log the incoming request, adding a request id')
   t.equal(infoStubArgs[1], 'GET /foo', 'it should set the log message to be a description of the request')
 
   const childStubArgs = childStub.getCall(0).args
-  t.deepEqual(childStubArgs[0], { requestId: '123456', req: { method: 'GET', url: '/foo', headers: { cookie: 'sessionId=1234; cookie2=bar' }, logger: 'childLogger' } }, 'it should create a child logger, adding a request id')
+  t.same(childStubArgs[0], { requestId: '123456', req: { method: 'GET', url: '/foo', headers: { cookie: 'sessionId=1234; cookie2=bar' }, logger: 'childLogger' } }, 'it should create a child logger, adding a request id')
 
   t.equal(req.logger, 'childLogger', 'it should attach the child logger to the request object')
   t.end()

--- a/lib/middleware/metrics/metrics.unit.spec.js
+++ b/lib/middleware/metrics/metrics.unit.spec.js
@@ -66,7 +66,7 @@ test('When initialising metrics', t => {
   } = initMetrics()
 
   t.ok(createMiddlewareStub.calledOnce, 'it should create the promster middleware')
-  t.deepEqual(createMiddlewareStub.getCall(0).args[0], {
+  t.same(createMiddlewareStub.getCall(0).args[0], {
     app,
     options: {
       endpoint: '/metrics',
@@ -75,8 +75,8 @@ test('When initialising metrics', t => {
   }, 'it should invoke the createMiddleware function with the default options')
 
   t.ok(appUseStub.calledTwice, 'it should invoke the app use method twice')
-  t.deepEqual(appUseStub.getCall(0).args, [prometheusStub], 'it should use the returned metrics middleware')
-  t.deepEqual(appUseStub.getCall(1).args, ['/metrics', routeMetrics], 'it should create a route to expose the metrics')
+  t.same(appUseStub.getCall(0).args, [prometheusStub], 'it should use the returned metrics middleware')
+  t.same(appUseStub.getCall(1).args, ['/metrics', routeMetrics], 'it should create a route to expose the metrics')
 
   t.ok(setDefaultLabelsStub.notCalled, 'it should not set the default labels')
 
@@ -95,7 +95,7 @@ test('When custom options are passed to metrics init', t => {
     foo: 'bar'
   })
 
-  t.deepEqual(createMiddlewareStub.getCall(0).args[0], {
+  t.same(createMiddlewareStub.getCall(0).args[0], {
     app,
     options: {
       endpoint: '/custom-metrics',
@@ -106,10 +106,10 @@ test('When custom options are passed to metrics init', t => {
     }
   }, 'it should invoke the createMiddleware function with the custom options')
 
-  t.deepEqual(appUseStub.getCall(1).args, ['/custom-metrics', routeMetrics], 'it should create a route to expose the metrics using the custom value')
+  t.same(appUseStub.getCall(1).args, ['/custom-metrics', routeMetrics], 'it should create a route to expose the metrics using the custom value')
 
   t.ok(setDefaultLabelsStub.calledOnce, 'it should set the default labels')
-  t.deepEqual(setDefaultLabelsStub.getCall(0).args[0], {
+  t.same(setDefaultLabelsStub.getCall(0).args[0], {
     foo: 'bar'
   }, 'it should pass the requested default labels')
 

--- a/lib/middleware/metrics/route-metrics.unit.spec.js
+++ b/lib/middleware/metrics/route-metrics.unit.spec.js
@@ -35,10 +35,10 @@ test('When metrics endpoint is called', t => {
   t.ok(resEndStub.calledOnce, 'it should call res.end once')
   t.ok(promsterGetContentTypeStub.calledOnce, 'it should call promster.getContentType once')
   t.ok(promsterGetSummaryStub.calledOnce, 'it should call promster.getSummaryStub once')
-  t.deepEqual(resSetHeaderStub.getCall(0).args, [
+  t.same(resSetHeaderStub.getCall(0).args, [
     'Content-Type', 'metrics-content-type'
   ], 'it should set the correct content-type')
-  t.deepEqual(resEndStub.getCall(0).args, ['metrics-summary'], 'it should send the metrics output')
+  t.same(resEndStub.getCall(0).args, ['metrics-summary'], 'it should send the metrics output')
 
   promsterGetContentTypeStub.restore()
   promsterGetSummaryStub.restore()

--- a/lib/middleware/middleware.unit.spec.js
+++ b/lib/middleware/middleware.unit.spec.js
@@ -23,7 +23,7 @@ const expected = [
 ]
 
 test('When the middleware module is loaded', (t) => {
-  t.deepEqual(Object.keys(middleware).sort(), expected.sort(),
+  t.same(Object.keys(middleware).sort(), expected.sort(),
     'it should export the expected functions')
 
   t.end()

--- a/lib/middleware/routes-cached/routes-cached.unit.spec.js
+++ b/lib/middleware/routes-cached/routes-cached.unit.spec.js
@@ -27,15 +27,15 @@ test('When a cached file is requested', t => {
   request(app)
     .get('/foo')
     .end((err, res) => {
-      t.equals(err, null, 'it should not invoke an error')
-      t.equals(res.text, 'static-a foo', 'it should serve the file')
+      t.equal(err, null, 'it should not invoke an error')
+      t.equal(res.text, 'static-a foo', 'it should serve the file')
     })
 
   request(app)
     .get('/foo.html')
     .end((err, res) => {
-      t.equals(err, null, 'it should invoke an error if requested with an .html extension')
-      t.equals(res.text, 'static-a foo', 'it should serve the file')
+      t.equal(err, null, 'it should invoke an error if requested with an .html extension')
+      t.equal(res.text, 'static-a foo', 'it should serve the file')
     })
 })
 
@@ -47,16 +47,16 @@ test('When a cached file is requested which does not have an .html extension', t
   request(app)
     .get('/bar')
     .end((err, res) => {
-      t.equals(err, null, 'it should not invoke an error when called without extension')
-      t.equals(res.status, 200, 'it should send a 200 (without extension)')
-      t.equals(res.text, undefined, 'it should serve no content (without extension)') // this is what's observed, but is it an express-static bug?
+      t.equal(err, null, 'it should not invoke an error when called without extension')
+      t.equal(res.status, 200, 'it should send a 200 (without extension)')
+      t.equal(res.text, undefined, 'it should serve no content (without extension)') // this is what's observed, but is it an express-static bug?
     })
 
   request(app)
     .get('/bar.html')
     .end((err, res) => {
-      t.equals(err, null, 'it should not invoke an error when called with extension')
-      t.equals(res.status, 404, 'it should send a 404 (with extension)')
+      t.equal(err, null, 'it should not invoke an error when called with extension')
+      t.equal(res.status, 404, 'it should send a 404 (with extension)')
     })
 })
 
@@ -68,22 +68,22 @@ test('When a cached index file is requested', t => {
   request(app)
     .get('/index.html')
     .end((err, res) => {
-      t.equals(err, null, 'it should not invoke an error if requested with the .html extension')
-      t.equals(res.text, 'static-a index.html', 'it should serve the file (with extension)')
+      t.equal(err, null, 'it should not invoke an error if requested with the .html extension')
+      t.equal(res.text, 'static-a index.html', 'it should serve the file (with extension)')
     })
 
   request(app)
     .get('/index')
     .end((err, res) => {
-      t.equals(err, null, 'it should not invoke an error if requested without the .html extension')
-      t.equals(res.text, 'static-a index.html', 'it should serve the file (without extension')
+      t.equal(err, null, 'it should not invoke an error if requested without the .html extension')
+      t.equal(res.text, 'static-a index.html', 'it should serve the file (without extension')
     })
 
   request(app)
     .get('/')
     .end((err, res) => {
-      t.equals(err, null, 'it should not invoke an error if requested as an implicit directory index')
-      t.equals(res.text, 'static-a index.html', 'it should serve the file (index)')
+      t.equal(err, null, 'it should not invoke an error if requested as an implicit directory index')
+      t.equal(res.text, 'static-a index.html', 'it should serve the file (index)')
     })
 })
 
@@ -93,8 +93,8 @@ test('When a cached index file is requested', t => {
 //   request(app)
 //     .get('/url/prefix/static.txt')
 //     .end((err, res) => {
-//       t.equals(err, null, 'it should not invoke an error')
-//       t.equals(res.text, 'static-a static.txt', 'it should use that prefix and serve the correct file')
+//       t.equal(err, null, 'it should not invoke an error')
+//       t.equal(res.text, 'static-a static.txt', 'it should use that prefix and serve the correct file')
 //       t.end()
 //     })
 // })

--- a/lib/middleware/routes-static/routes-static.test.multiple-paths.unit.spec.js
+++ b/lib/middleware/routes-static/routes-static.test.multiple-paths.unit.spec.js
@@ -24,7 +24,7 @@ test('When a file that exists within more than one static route is requested', a
   })
 
   const { error, text } = await request(app).get('/static.txt')
-  t.equals(error, false, 'it should not invoke an error')
-  t.equals(text, 'static-b static.txt', 'it should serve the correct file')
+  t.equal(error, false, 'it should not invoke an error')
+  t.equal(text, 'static-b static.txt', 'it should serve the correct file')
   t.end()
 })

--- a/lib/middleware/routes-static/routes-static.test.no-paths.unit.spec.js
+++ b/lib/middleware/routes-static/routes-static.test.no-paths.unit.spec.js
@@ -17,6 +17,6 @@ test('When a file that does not exist within a static route is requested', async
   const app = callRoutesStatic()
   const { error, status } = await request(app).get('/static.txt')
   t.ok(error, null, 'it should invoke an error')
-  t.equals(status, 404, 'it should return 404')
+  t.equal(status, 404, 'it should return 404')
   t.end()
 })

--- a/lib/middleware/routes-static/routes-static.test.node-module-asset-serving.unit.spec.js
+++ b/lib/middleware/routes-static/routes-static.test.node-module-asset-serving.unit.spec.js
@@ -21,9 +21,9 @@ test('When a file from an assets folder is requested', async t => {
   const app = callRoutesStatic({ serviceSources })
 
   const { error, status, headers } = await request(app).get('/image-resource.png')
-  t.equals(error, false, 'it should not invoke an error')
-  t.equals(status, 200, 'it should return 200')
-  t.equals(headers['content-type'], 'image/png', 'it should return the correct mime type')
+  t.equal(error, false, 'it should not invoke an error')
+  t.equal(status, 200, 'it should return 200')
+  t.equal(headers['content-type'], 'image/png', 'it should return the correct mime type')
   t.end()
 })
 
@@ -35,10 +35,10 @@ test('When a specified node module does not have an assets folder', async t => {
   const app = callRoutesStatic({ serviceSources })
 
   const { status: status1 } = await request(app).get('/static.txt')
-  t.equals(status1, 404, 'it should not serve assets at the root level')
+  t.equal(status1, 404, 'it should not serve assets at the root level')
 
   const { status: status2 } = await request(app).get('/assets/static.txt')
-  t.equals(status2, 404, 'it should not serve assets at any URL')
+  t.equal(status2, 404, 'it should not serve assets at any URL')
   t.end()
 })
 
@@ -50,9 +50,9 @@ test('When an asset folder is present within another asset folder', async t => {
   const app = callRoutesStatic({ serviceSources })
 
   const { status: statusNotFound } = await request(app).get('/image-resource-2.png')
-  t.equals(statusNotFound, 404, 'it should not be found at the top level')
+  t.equal(statusNotFound, 404, 'it should not be found at the top level')
 
   const { status: statusFound } = await request(app).get('/assets/image-resource-2.png')
-  t.equals(statusFound, 200, 'it should be found by specifying the nested asset folder')
+  t.equal(statusFound, 200, 'it should be found by specifying the nested asset folder')
   t.end()
 })

--- a/lib/middleware/routes-static/routes-static.unit.spec.js
+++ b/lib/middleware/routes-static/routes-static.unit.spec.js
@@ -19,9 +19,9 @@ test('When a file that exists within a static route is requested', async t => {
     paths: [staticPath]
   })
   const { error, text, status } = await request(app).get('/static.txt')
-  t.equals(error, false, 'it should not invoke an error')
-  t.equals(text, 'static-a static.txt', 'it should serve the file')
-  t.equals(status, 200, 'it should return a successful status')
+  t.equal(error, false, 'it should not invoke an error')
+  t.equal(text, 'static-a static.txt', 'it should serve the file')
+  t.equal(status, 200, 'it should return a successful status')
   t.end()
 })
 
@@ -31,7 +31,7 @@ test('When a url prefix is passed to routes-static', async t => {
     paths: [staticPath]
   })
   const { error, text } = await request(app).get('/url/prefix/static.txt')
-  t.equals(error, false, 'it should not invoke an error')
-  t.equals(text, 'static-a static.txt', 'it should use that prefix and serve the correct file')
+  t.equal(error, false, 'it should not invoke an error')
+  t.equal(text, 'static-a static.txt', 'it should use that prefix and serve the correct file')
   t.end()
 })

--- a/lib/middleware/serializers/serializers.unit.spec.js
+++ b/lib/middleware/serializers/serializers.unit.spec.js
@@ -43,7 +43,7 @@ test('When serializing a request object', t => {
     another_prop: 'should also be discarded'
   }
   const serializedReq = serializeRequest(req)
-  t.deepEqual(serializedReq, {
+  t.same(serializedReq, {
     method: 'METHOD',
     url: '/url',
     headers: {
@@ -75,7 +75,7 @@ test('When serializing a request object with cookies', t => {
     }
   }
   const serializedReq = serializeRequest(req)
-  t.deepEqual(serializedReq, {
+  t.same(serializedReq, {
     headers: {
       cookie: 'foo=cookieShortHashValue; bar=cookieShortHashValue'
     },
@@ -115,7 +115,7 @@ test('When calling the logger serializers', async t => {
     another_prop: 'should also be discarded'
   }
   const serializedError = serializeError(error)
-  t.deepEqual(serializedError, {
+  t.same(serializedError, {
     name: 'error.name',
     code: 'error.code',
     message: 'error.message',

--- a/lib/middleware/user-data/user-data.unit.spec.js
+++ b/lib/middleware/user-data/user-data.unit.spec.js
@@ -58,8 +58,8 @@ test('When getting user data', async t => {
   await loadUserData(req, res)
   const { getUserDataProperty, getUserData, getAllData } = req.user
   t.equal(getUserDataProperty('a[b]'), true, 'it should get specific values')
-  t.deepEqual(getUserData(), { a: { b: true } }, 'it should add getUserData method')
-  t.deepEqual(getAllData(), { input: { a: { b: true } }, count: {}, flash: [] }, 'it should add getUserData method')
+  t.same(getUserData(), { a: { b: true } }, 'it should add getUserData method')
+  t.same(getAllData(), { input: { a: { b: true } }, count: {}, flash: [] }, 'it should add getUserData method')
   t.end()
 })
 
@@ -78,7 +78,7 @@ test('When setting user data', async t => {
   const { setUserDataProperty, setUserData } = req.user
   t.equal(setUserDataProperty('a[b]', 'value'), 'value', 'it should be able to set specific values')
   t.equal(setUserDataProperty('z[y]', 'value'), 'value', 'it should be able to set specific values')
-  t.deepEqual(setUserData({ a: { b: true } }), { a: { b: true }, z: { y: 'value' } }, 'it should be able to replace all the user data')
+  t.same(setUserData({ a: { b: true } }), { a: { b: true }, z: { y: 'value' } }, 'it should be able to replace all the user data')
   t.end()
 })
 
@@ -151,7 +151,7 @@ test('When getting count values', t => {
   getInstanceByPropertyValueStub.restore()
   getInstancePropertyStub.restore()
 
-  t.deepEqual(userData.getUserCount(), {
+  t.same(userData.getUserCount(), {
     foo: 1,
     'foo[1]bar': 2,
     'foo[1]bar[2]baz': 5
@@ -178,7 +178,7 @@ test('when there are no uploaded files', async t => {
   await loadUserData(req, res)
   const { uploadedFiles } = req.user
 
-  t.deepEqual(uploadedFiles(), [], 'it returns empty array')
+  t.same(uploadedFiles(), [], 'it returns empty array')
   t.end()
 })
 
@@ -226,6 +226,6 @@ test('when there are uploaded files', async t => {
     type: 'filestore'
   }]
 
-  t.deepEqual(uploadedFiles(), expected, 'it returns array of file objects')
+  t.same(uploadedFiles(), expected, 'it returns array of file objects')
   t.end()
 })

--- a/lib/module/savereturn/client/savereturn/client.unit.spec.js
+++ b/lib/module/savereturn/client/savereturn/client.unit.spec.js
@@ -111,9 +111,9 @@ test('When calling the save and return sendPost method', async t => {
 
   const basicArgs = FBJWTClientSendPostStub.getCall(0).args
 
-  t.deepEqual(basicArgs[1], logger, 'it should pass any supplied logger to the super method in FBJWTClient')
+  t.same(basicArgs[1], logger, 'it should pass any supplied logger to the super method in FBJWTClient')
 
-  t.deepEqual(basicArgs[0], {
+  t.same(basicArgs[0], {
     url: '/service/:serviceSlug/savereturn/foo',
     payload: {
       a: 'a'
@@ -121,7 +121,7 @@ test('When calling the save and return sendPost method', async t => {
     context: { serviceSlug: 'testServiceSlug' }
   }, 'it should invoke the super method in FBJWTClient with the correct args')
 
-  t.deepEqual(responseBody, '', 'it should return the response body from the super method in FBJWTClient')
+  t.same(responseBody, '', 'it should return the response body from the super method in FBJWTClient')
 
   await saveReturnClient.sendPost({
     url: '/foo',
@@ -131,7 +131,7 @@ test('When calling the save and return sendPost method', async t => {
   })
 
   const encryptedArgs = FBJWTClientSendPostStub.getCall(1).args
-  t.deepEqual(encryptedArgs[0].payload, {
+  t.same(encryptedArgs[0].payload, {
     encrypted_a: 'a/encryptedPayload'
   }, 'it should encrypt any payload properties beginning with encrypted_')
 
@@ -153,7 +153,7 @@ test('When calling the save and return sendPost method', async t => {
     }
   })
 
-  t.deepEqual(response, { a: 'a', encrypted_b: 'b', b: 'b/decryptedPayload' }, 'it should decrypt any properties beginning with encrypted_')
+  t.same(response, { a: 'a', encrypted_b: 'b', b: 'b/decryptedPayload' }, 'it should decrypt any properties beginning with encrypted_')
 
   t.end()
 })
@@ -167,7 +167,7 @@ test('When requesting an email token to set up save and return', async t => {
   const sendPostArgs = args[0]
 
   t.equal(sendPostArgs.url, '/setup/email/add', 'it should use the expected url stub')
-  t.deepEqual(sendPostArgs.payload, {
+  t.same(sendPostArgs.payload, {
     encrypted_email: 'email',
     encrypted_details: {
       userId: 'userId',
@@ -193,7 +193,7 @@ test('When requesting a mobile code to set up save and return', async t => {
   const sendPostArgs = args[0]
 
   t.equal(sendPostArgs.url, '/setup/mobile/add', 'it should use the expected url stub')
-  t.deepEqual(sendPostArgs.payload, {
+  t.same(sendPostArgs.payload, {
     encrypted_email: 'email',
     encrypted_details: {
       userId: 'userId',
@@ -220,7 +220,7 @@ test('When validating an email token to set up save and return', async t => {
   const sendPostArgs = args[0]
 
   t.equal(sendPostArgs.url, '/setup/email/validate', 'it should use the expected url stub')
-  t.deepEqual(sendPostArgs.payload, {
+  t.same(sendPostArgs.payload, {
     email_token: 'emailToken'
   }, 'it should create the expected payload')
   t.equal(args[1], 'logger', 'it should pass through any logger instance')
@@ -230,7 +230,7 @@ test('When validating an email token to set up save and return', async t => {
   await saveReturnClient.validateSetupEmailToken('emailToken', 'passphrase', 'logger')
   const argsWithPassphrase = sendPostStub.getCall(1).args[0]
 
-  t.deepEqual(argsWithPassphrase.payload, {
+  t.same(argsWithPassphrase.payload, {
     email_token: 'emailToken',
     encrypted_passphrase: 'passphrase'
   }, 'it should encrypt and add any passphrase provided in the payload')
@@ -248,7 +248,7 @@ test('When validating a mobile code to set up save and return', async t => {
   const sendPostArgs = args[0]
 
   t.equal(sendPostArgs.url, '/setup/mobile/validate', 'it should use the expected url stub')
-  t.deepEqual(sendPostArgs.payload, {
+  t.same(sendPostArgs.payload, {
     code: 'code',
     encrypted_email: 'email'
   }, 'it should create the expected payload')
@@ -269,7 +269,7 @@ test('When creating a save and return record', async t => {
   const sendPostArgs = args[0]
 
   t.equal(sendPostArgs.url, '/record/create', 'it should use the expected url stub')
-  t.deepEqual(sendPostArgs.payload, {
+  t.same(sendPostArgs.payload, {
     encrypted_email: 'email',
     encrypted_details: {
       userId: 'userId',
@@ -285,7 +285,7 @@ test('When creating a save and return record', async t => {
   await saveReturnClient.createRecord('userId', 'userToken', 'email', undefined, 'logger')
   const argsWithoutMobile = sendPostStub.getCall(1).args[0]
 
-  t.deepEqual(argsWithoutMobile.payload, {
+  t.same(argsWithoutMobile.payload, {
     encrypted_email: 'email',
     encrypted_details: {
       userId: 'userId',
@@ -307,7 +307,7 @@ test('When requesting an magic link to sign in', async t => {
   const sendPostArgs = args[0]
 
   t.equal(sendPostArgs.url, '/signin/email/add', 'it should use the expected url stub')
-  t.deepEqual(sendPostArgs.payload, {
+  t.same(sendPostArgs.payload, {
     encrypted_email: 'email',
     duration: 'duration'
   }, 'it should create the expected payload')
@@ -328,7 +328,7 @@ test('When validating a magic link', async t => {
   const sendPostArgs = args[0]
 
   t.equal(sendPostArgs.url, '/signin/email/validate', 'it should use the expected url stub')
-  t.deepEqual(sendPostArgs.payload, {
+  t.same(sendPostArgs.payload, {
     magiclink: 'magicLink'
   }, 'it should create the expected payload')
   t.equal(args[1], 'logger', 'it should pass through any logger instance')
@@ -348,7 +348,7 @@ test('When requesting a mobile code to confirm sign in', async t => {
   const sendPostArgs = args[0]
 
   t.equal(sendPostArgs.url, '/signin/mobile/add', 'it should use the expected url stub')
-  t.deepEqual(sendPostArgs.payload, {
+  t.same(sendPostArgs.payload, {
     encrypted_email: 'email',
     duration: 'duration'
   }, 'it should create the expected payload')
@@ -369,7 +369,7 @@ test('When validating a mobile code to confirm sign in', async t => {
   const sendPostArgs = args[0]
 
   t.equal(sendPostArgs.url, '/signin/mobile/validate', 'it should use the expected url stub')
-  t.deepEqual(sendPostArgs.payload, {
+  t.same(sendPostArgs.payload, {
     code: 'code',
     encrypted_email: 'email'
   }, 'it should create the expected payload')

--- a/lib/module/savereturn/controller/page/type/return.setup.email.token/return.setup.email.token.controller.unit.spec.js
+++ b/lib/module/savereturn/controller/page/type/return.setup.email.token/return.setup.email.token.controller.unit.spec.js
@@ -80,19 +80,19 @@ test('When a user verifies their email token', async t => {
   const pageInstance = await setupEmailTokenController.preUpdateContents({}, userData)
 
   t.ok(validateSetupEmailTokenStub.calledOnce, 'it should validate the email token')
-  t.deepEqual(validateSetupEmailTokenStub.getCall(0).args, ['token', 'passphrase', loggerStub], 'it should call validateSetupEmailToken with the expected args')
+  t.same(validateSetupEmailTokenStub.getCall(0).args, ['token', 'passphrase', loggerStub], 'it should call validateSetupEmailToken with the expected args')
 
   t.ok(resetUserStub.calledOnce, 'it should reset the user')
-  t.deepEqual(resetUserStub.getCall(0).args, [userData, userDetails], 'it should call resetUser with the expected args')
+  t.same(resetUserStub.getCall(0).args, [userData, userDetails], 'it should call resetUser with the expected args')
 
   t.ok(createRecordStub.calledOnce, 'it should create a save and return record for the user')
-  t.deepEqual(createRecordStub.getCall(0).args, ['userId', 'userToken', 'email', undefined, loggerStub], 'it should call createRecord with the expected args')
+  t.same(createRecordStub.getCall(0).args, ['userId', 'userToken', 'email', undefined, loggerStub], 'it should call createRecord with the expected args')
 
   t.ok(authenticateStub.calledOnce, 'it should authenticate the user')
-  t.deepEqual(authenticateStub.getCall(0).args, [userData, 'setup-email'], 'it should call authenticate with the expected args')
+  t.same(authenticateStub.getCall(0).args, [userData, 'setup-email'], 'it should call authenticate with the expected args')
 
   t.ok(sendEmailStub.calledOnce, 'it should send an email stating that the user has set up save and return successfully')
-  t.deepEqual(sendEmailStub.getCall(0).args, ['email.return.setup.email.verified', userData], 'it should call sendEmail with the expected args')
+  t.same(sendEmailStub.getCall(0).args, ['email.return.setup.email.verified', userData], 'it should call sendEmail with the expected args')
 
   t.equal(pageInstance.redirect, 'return.setup.success', 'it should update the page instance redirect property with the expected value')
 
@@ -112,7 +112,7 @@ test('When a user tries to verify an email token that is not valid', async t => 
 
   await setupEmailTokenController.preUpdateContents({}, userData)
   t.ok(handleValidationErrorStub.calledOnce, 'it should yield to the error handler')
-  t.deepEqual(handleValidationErrorStub.getCall(0).args, [error, 'return.setup.email'], 'it should call handleValidationError with the expected args')
+  t.same(handleValidationErrorStub.getCall(0).args, [error, 'return.setup.email'], 'it should call handleValidationError with the expected args')
 
   t.end()
 })

--- a/lib/module/savereturn/controller/page/type/return.setup.email/return.setup.email.controller.unit.spec.js
+++ b/lib/module/savereturn/controller/page/type/return.setup.email/return.setup.email.controller.unit.spec.js
@@ -61,10 +61,10 @@ test('When a user provides an email to set up save and return with', async t => 
   await setupEmailController.postValidation({}, userData)
 
   t.ok(createSetupEmailTokenStub.calledOnce, 'it should request the creation of an email token')
-  t.deepEqual(createSetupEmailTokenStub.getCall(0).args, ['userId', 'userToken', 'email@example.com', 100, loggerStub], 'it should call createMagiclink with the expected args')
+  t.same(createSetupEmailTokenStub.getCall(0).args, ['userId', 'userToken', 'email@example.com', 100, loggerStub], 'it should call createMagiclink with the expected args')
 
   t.ok(sendEmailStub.calledOnce, 'it should send an email containing the email token')
-  t.deepEqual(sendEmailStub.getCall(0).args, ['email.return.setup.email.token', userData, { token: 'token' }], 'it should call sendEmail with the expected args')
+  t.same(sendEmailStub.getCall(0).args, ['email.return.setup.email.token', userData, { token: 'token' }], 'it should call sendEmail with the expected args')
 
   t.end()
 })

--- a/lib/module/savereturn/controller/page/type/return.setup.mobile.validate/return.setup.mobile.validate.controller.unit.spec.js
+++ b/lib/module/savereturn/controller/page/type/return.setup.mobile.validate/return.setup.mobile.validate.controller.unit.spec.js
@@ -100,19 +100,19 @@ test('When a user verifies their email token', async t => {
   const pageInstance = await setupMobileValidateController.postValidation({}, userData)
 
   t.ok(validateSetupMobileCodeStub.calledOnce, 'it should validate the mobile code')
-  t.deepEqual(validateSetupMobileCodeStub.getCall(0).args, ['code', 'email', loggerStub], 'it should call validateSetupMobileCode with the expected args')
+  t.same(validateSetupMobileCodeStub.getCall(0).args, ['code', 'email', loggerStub], 'it should call validateSetupMobileCode with the expected args')
 
   t.ok(resetUserStub.calledOnce, 'it should reset the user')
-  t.deepEqual(resetUserStub.getCall(0).args, [userData, userDetails], 'it should call resetUser with the expected args')
+  t.same(resetUserStub.getCall(0).args, [userData, userDetails], 'it should call resetUser with the expected args')
 
   t.ok(createRecordStub.calledOnce, 'it should create a save and return record for the user')
-  t.deepEqual(createRecordStub.getCall(0).args, ['userId', 'userToken', 'email', 'mobile', loggerStub], 'it should call createRecord with the expected args')
+  t.same(createRecordStub.getCall(0).args, ['userId', 'userToken', 'email', 'mobile', loggerStub], 'it should call createRecord with the expected args')
 
   t.ok(authenticateStub.calledOnce, 'it should authenticate the user')
-  t.deepEqual(authenticateStub.getCall(0).args, [userData, 'setup-mobile'], 'it should call authenticate with the expected args')
+  t.same(authenticateStub.getCall(0).args, [userData, 'setup-mobile'], 'it should call authenticate with the expected args')
 
   t.ok(sendEmailStub.calledOnce, 'it should send an email stating that the user has set up save and return successfully')
-  t.deepEqual(sendEmailStub.getCall(0).args, ['email.return.setup.mobile.verified', userData], 'it should call sendEmail with the expected args')
+  t.same(sendEmailStub.getCall(0).args, ['email.return.setup.mobile.verified', userData], 'it should call sendEmail with the expected args')
 
   t.equal(pageInstance.redirect, 'return.setup.success', 'it should update the page instance redirect property with the expected value')
 
@@ -132,7 +132,7 @@ test('When a user tries to verify a mobile token that is not valid (expired, use
   await setupMobileValidateController.postValidation({}, userData)
 
   t.ok(handleValidationErrorStub.calledOnce, 'it should yield to the error handler')
-  t.deepEqual(handleValidationErrorStub.getCall(0).args, [error, 'return.setup.mobile'], 'it should call handleValidationError with the expected args')
+  t.same(handleValidationErrorStub.getCall(0).args, [error, 'return.setup.mobile'], 'it should call handleValidationError with the expected args')
 
   t.end()
 })

--- a/lib/module/savereturn/controller/page/type/return.setup.mobile/return.setup.mobile.controller.unit.spec.js
+++ b/lib/module/savereturn/controller/page/type/return.setup.mobile/return.setup.mobile.controller.unit.spec.js
@@ -64,10 +64,10 @@ test('When a user provides an email to set up save and return with', async t => 
   await setupMobileController.postValidation({}, userData)
 
   t.ok(createSetupMobileCodeStub.calledOnce, 'it should request the creation of a mobile code')
-  t.deepEqual(createSetupMobileCodeStub.getCall(0).args, ['userId', 'userToken', 'email@example.com', '07290654321', 100, loggerStub], 'it should call createSetupMobileCode with the expected args')
+  t.same(createSetupMobileCodeStub.getCall(0).args, ['userId', 'userToken', 'email@example.com', '07290654321', 100, loggerStub], 'it should call createSetupMobileCode with the expected args')
 
   t.ok(sendSMSStub.calledOnce, 'it should send an sms containing the mobile code')
-  t.deepEqual(sendSMSStub.getCall(0).args, ['sms.return.setup.mobile', userData, { code: 'code' }], 'it should call sendSMS with the expected args')
+  t.same(sendSMSStub.getCall(0).args, ['sms.return.setup.mobile', userData, { code: 'code' }], 'it should call sendSMS with the expected args')
 
   t.end()
 })

--- a/lib/module/savereturn/controller/page/type/return.signin.magiclink/return.signin.magiclink.controller.unit.spec.js
+++ b/lib/module/savereturn/controller/page/type/return.signin.magiclink/return.signin.magiclink.controller.unit.spec.js
@@ -90,13 +90,13 @@ test('When a user with 2fa enabled visits a valid magic link', async t => {
   const pageInstance = await signinMagiclinkController.preUpdateContents({}, userData)
 
   t.ok(validateAuthenticationMagiclinkStub.calledOnce, 'it should validate the magic link')
-  t.deepEqual(validateAuthenticationMagiclinkStub.getCall(0).args, ['magiclink', loggerStub], 'it should call validateAuthenticationMagiclink with the expected args')
+  t.same(validateAuthenticationMagiclinkStub.getCall(0).args, ['magiclink', loggerStub], 'it should call validateAuthenticationMagiclink with the expected args')
 
   t.ok(resetUserStub.calledOnce, 'it should reset the user')
-  t.deepEqual(resetUserStub.getCall(0).args, [userData, userDetailsWith2fa], 'it should call resetUser with the expected args')
+  t.same(resetUserStub.getCall(0).args, [userData, userDetailsWith2fa], 'it should call resetUser with the expected args')
 
   t.ok(createSigninMobileCodeStub.calledOnce, 'it should send an sms containing the confirmation code')
-  t.deepEqual(createSigninMobileCodeStub.getCall(0).args, ['email', 45, loggerStub], 'it should call createSigninMobileCode with the expected args')
+  t.same(createSigninMobileCodeStub.getCall(0).args, ['email', 45, loggerStub], 'it should call createSigninMobileCode with the expected args')
 
   t.ok(sendEmailStub.notCalled, 'it should not send an email stating that the user has signed in')
 
@@ -115,15 +115,15 @@ test('When a user without 2fa enabled visits a valid magic link', async t => {
   const pageInstance = await signinMagiclinkController.preUpdateContents({}, userData)
 
   t.ok(validateAuthenticationMagiclinkStub.calledOnce, 'it should validate the magic link')
-  t.deepEqual(validateAuthenticationMagiclinkStub.getCall(0).args, ['magiclink', loggerStub], 'it should call validateAuthenticationMagiclink with the expected args')
+  t.same(validateAuthenticationMagiclinkStub.getCall(0).args, ['magiclink', loggerStub], 'it should call validateAuthenticationMagiclink with the expected args')
 
   t.ok(resetUserStub.calledOnce, 'it should reset the user')
-  t.deepEqual(resetUserStub.getCall(0).args, [userData, userDetailsWithout2fa], 'it should call resetUser with the expected args')
+  t.same(resetUserStub.getCall(0).args, [userData, userDetailsWithout2fa], 'it should call resetUser with the expected args')
 
   t.ok(createSigninMobileCodeStub.notCalled, 'it should not send an sms containing a confirmation code')
 
   t.ok(sendEmailStub.calledOnce, 'it should send an email stating that the user has signed in')
-  t.deepEqual(sendEmailStub.getCall(0).args, ['email.return.signin.success', userData], 'it should call sendEmail with the expected args')
+  t.same(sendEmailStub.getCall(0).args, ['email.return.signin.success', userData], 'it should call sendEmail with the expected args')
 
   t.equal(pageInstance.redirect, 'return.authenticated', 'it should update the page instance redirect property with the expected value')
 
@@ -143,7 +143,7 @@ test('When a user visits a valid magic link that is not valid', async t => {
   await signinMagiclinkController.preUpdateContents({}, userData)
 
   t.ok(handleValidationErrorStub.calledOnce, 'it should yield to the error handler')
-  t.deepEqual(handleValidationErrorStub.getCall(0).args, [error, 'return.signin.magiclink'], 'it should call handleValidationError with the expected args')
+  t.same(handleValidationErrorStub.getCall(0).args, [error, 'return.signin.magiclink'], 'it should call handleValidationError with the expected args')
 
   t.end()
 })

--- a/lib/module/savereturn/controller/page/type/return.signin.mobile.validate/return.signin.mobile.validate.controller.unit.spec.js
+++ b/lib/module/savereturn/controller/page/type/return.signin.mobile.validate/return.signin.mobile.validate.controller.unit.spec.js
@@ -132,18 +132,18 @@ test('When a user verifies their mobile sign in code', async t => {
   const instance = await signinMobileValidateController.postValidation({}, userData)
 
   t.ok(validateSigninMobileCodeStub.calledOnce, 'it should validate the mobile code')
-  t.deepEqual(validateSigninMobileCodeStub.getCall(0).args, ['signin_code', 'email', loggerStub], 'it should call validateSigninMobileCode with the expected args')
+  t.same(validateSigninMobileCodeStub.getCall(0).args, ['signin_code', 'email', loggerStub], 'it should call validateSigninMobileCode with the expected args')
 
-  t.deepEqual(unsetUserDataPropertyStub.getCall(0).args, ['signin_code'], 'it should unset the signin_code value')
+  t.same(unsetUserDataPropertyStub.getCall(0).args, ['signin_code'], 'it should unset the signin_code value')
 
   t.ok(resetUserStub.calledOnce, 'it should reset the user')
-  t.deepEqual(resetUserStub.getCall(0).args, [userData, userDetails], 'it should call resetUser with the expected args')
+  t.same(resetUserStub.getCall(0).args, [userData, userDetails], 'it should call resetUser with the expected args')
 
   t.ok(authenticateStub.calledOnce, 'it should authenticate the user')
-  t.deepEqual(authenticateStub.getCall(0).args, [userData, 'signin-code'], 'it should call authenticate with the expected args')
+  t.same(authenticateStub.getCall(0).args, [userData, 'signin-code'], 'it should call authenticate with the expected args')
 
   t.ok(sendEmailStub.calledOnce, 'it should send an email stating that the user has set up save and return successfully')
-  t.deepEqual(sendEmailStub.getCall(0).args, ['email.return.signin.success', userData], 'it should call sendEmail with the expected args')
+  t.same(sendEmailStub.getCall(0).args, ['email.return.signin.success', userData], 'it should call sendEmail with the expected args')
 
   t.equal(instance.redirect, 'return.authenticated', 'it should update the page instance redirect property with the expected value')
 
@@ -163,7 +163,7 @@ test('When a user tries to verify a mobile sign in code is not valid (expired, u
   await signinMobileValidateController.postValidation({}, userData)
 
   t.ok(handleValidationErrorStub.calledOnce, 'it should yield to the error handler')
-  t.deepEqual(handleValidationErrorStub.getCall(0).args, [error, 'return.signin.mobile'], 'it should call handleValidationError with the expected args')
+  t.same(handleValidationErrorStub.getCall(0).args, [error, 'return.signin.mobile'], 'it should call handleValidationError with the expected args')
 
   t.end()
 })

--- a/lib/module/savereturn/controller/page/type/return.signout/return.signout.controller.unit.spec.js
+++ b/lib/module/savereturn/controller/page/type/return.signout/return.signout.controller.unit.spec.js
@@ -36,8 +36,8 @@ test('When a user provides an email to sign in with', async t => {
   t.ok(clearSessionStub.calledOnce, 'it should clear the user session')
 
   t.ok(unsetUserDataPropertyStub.calledTwice, 'it should unset the required values')
-  t.deepEqual(unsetUserDataPropertyStub.getCall(0).args, ['authenticated'], 'it should unset the authenticated value')
-  t.deepEqual(unsetUserDataPropertyStub.getCall(1).args, ['email'], 'it should unset the email value')
+  t.same(unsetUserDataPropertyStub.getCall(0).args, ['authenticated'], 'it should unset the authenticated value')
+  t.same(unsetUserDataPropertyStub.getCall(1).args, ['email'], 'it should unset the email value')
 
   t.end()
 })

--- a/lib/module/savereturn/controller/page/type/return.start/return.start.controller.unit.spec.js
+++ b/lib/module/savereturn/controller/page/type/return.start/return.start.controller.unit.spec.js
@@ -62,10 +62,10 @@ test('When a user provides an email to sign in with', async t => {
   await signinStartController.postValidation({}, userData)
 
   t.ok(createMagiclinkStub.calledOnce, 'it should request the creation of a magic link')
-  t.deepEqual(createMagiclinkStub.getCall(0).args, ['email@example.com', 100, loggerStub], 'it should call createMagiclink with the expected args')
+  t.same(createMagiclinkStub.getCall(0).args, ['email@example.com', 100, loggerStub], 'it should call createMagiclink with the expected args')
 
   t.ok(sendEmailStub.calledOnce, 'it should send an email containing the magiclink')
-  t.deepEqual(sendEmailStub.getCall(0).args, ['email.return.signin.email', userData, { token: 'token' }], 'it should call sendEmail with the expected args')
+  t.same(sendEmailStub.getCall(0).args, ['email.return.signin.email', userData, { token: 'token' }], 'it should call sendEmail with the expected args')
 
   t.end()
 })
@@ -100,7 +100,7 @@ test('When a request to create a magic link is for an unrecognised email address
 
   const pageInstance = await signinStartController.postValidation({}, userData)
 
-  t.deepEqual(pageInstance, {}, 'it should return the page instance as normal')
+  t.same(pageInstance, {}, 'it should return the page instance as normal')
   t.ok(sendEmailStub.notCalled, 'it should not send an email containing the magiclink')
 
   t.end()

--- a/lib/module/savereturn/controller/savereturn.unit.spec.js
+++ b/lib/module/savereturn/controller/savereturn.unit.spec.js
@@ -93,7 +93,7 @@ test('When handling an error that is a 401 and has a message that can be mapped 
   getInstanceStub.returns(errorInstance)
 
   const instance = handleValidationError({ code: 401, message: 'boom' }, 'instance')
-  t.deepEqual(instance, errorInstance, 'it should return the error instance in place of the original page instance')
+  t.same(instance, errorInstance, 'it should return the error instance in place of the original page instance')
   t.end()
 })
 
@@ -103,7 +103,7 @@ test('When handling an error that is a 401 and has a message that cannot be mapp
   try {
     t.throws(handleValidationError({ code: 401, message: 'boom' }, 'instance'))
   } catch (e) {
-    t.deepEqual(e, { code: 401, message: 'boom' }, 'it should throw the error')
+    t.same(e, { code: 401, message: 'boom' }, 'it should throw the error')
   }
   t.end()
 })
@@ -116,7 +116,7 @@ test('When handling an error that is not a 401', t => {
   try {
     t.throws(handleValidationError({ code: 402, message: 'boom' }, 'instance'))
   } catch (e) {
-    t.deepEqual(e, { code: 402, message: 'boom' }, 'it should throw the error')
+    t.same(e, { code: 402, message: 'boom' }, 'it should throw the error')
   }
   t.end()
 })
@@ -129,7 +129,7 @@ test('When handling an error that has no message', t => {
   try {
     t.throws(handleValidationError({ code: 401 }, 'instance'))
   } catch (e) {
-    t.deepEqual(e, { code: 401 }, 'it should throw the error')
+    t.same(e, { code: 401 }, 'it should throw the error')
   }
   t.end()
 })
@@ -140,11 +140,11 @@ test('When resetting a user that has provided a mobile number', async t => {
   await resetUser(userData, userDetails)
 
   t.ok(resetUserDataStub.calledOnce)
-  t.deepEqual(resetUserDataStub.getCall(0).args, ['userId', 'userToken'], 'it should reset the user’s data')
+  t.same(resetUserDataStub.getCall(0).args, ['userId', 'userToken'], 'it should reset the user’s data')
 
   t.ok(setUserDataPropertyStub.calledTwice)
-  t.deepEqual(setUserDataPropertyStub.getCall(0).args, ['email', 'user@example.com'], 'it should set the user’s email address')
-  t.deepEqual(setUserDataPropertyStub.getCall(1).args, ['mobile', '01234654321'], 'it should set the user’s mobile number')
+  t.same(setUserDataPropertyStub.getCall(0).args, ['email', 'user@example.com'], 'it should set the user’s email address')
+  t.same(setUserDataPropertyStub.getCall(1).args, ['mobile', '01234654321'], 'it should set the user’s mobile number')
   t.end()
 })
 
@@ -154,10 +154,10 @@ test('When resetting a user that has not provided a mobile number', async t => {
   await resetUser(userData, userDetailsWithoutMobile)
 
   t.ok(resetUserDataStub.calledOnce)
-  t.deepEqual(resetUserDataStub.getCall(0).args, ['userId2', 'userToken2'], 'it should reset the user’s data')
+  t.same(resetUserDataStub.getCall(0).args, ['userId2', 'userToken2'], 'it should reset the user’s data')
 
   t.ok(setUserDataPropertyStub.calledOnce)
-  t.deepEqual(setUserDataPropertyStub.getCall(0).args, ['email', 'user2@example.com'], 'it should set the user’s email address')
+  t.same(setUserDataPropertyStub.getCall(0).args, ['email', 'user2@example.com'], 'it should set the user’s email address')
   t.end()
 })
 
@@ -171,9 +171,9 @@ test('When authenticating a user', async t => {
   await authenticate(userData, 'inward-bound')
 
   t.ok(setUserDataPropertyStub.calledThrice, 'it should set the expected number of user properties')
-  t.deepEqual(setUserDataPropertyStub.getCall(0).args, ['authenticated', true], 'it should set the user’s authenticated status')
-  t.deepEqual(setUserDataPropertyStub.getCall(1).args, ['loginTime', 1483228800000], 'it should set the user’s login time')
-  t.deepEqual(setUserDataPropertyStub.getCall(2).args, ['history', [{ phase: 'inward-bound', date: 1483228800000 }]], 'it should update the user’s login history')
+  t.same(setUserDataPropertyStub.getCall(0).args, ['authenticated', true], 'it should set the user’s authenticated status')
+  t.same(setUserDataPropertyStub.getCall(1).args, ['loginTime', 1483228800000], 'it should set the user’s login time')
+  t.same(setUserDataPropertyStub.getCall(2).args, ['history', [{ phase: 'inward-bound', date: 1483228800000 }]], 'it should update the user’s login history')
 
   clock.restore()
 
@@ -190,10 +190,10 @@ test('When deauthenticating a user', async t => {
   await deauthenticate(userData)
 
   t.ok(unsetUserDataPropertyStub.calledOnce, 'it should unset the expected number of user properties')
-  t.deepEqual(unsetUserDataPropertyStub.getCall(0).args, ['authenticated'], 'it should unset the user’s authenticated status')
+  t.same(unsetUserDataPropertyStub.getCall(0).args, ['authenticated'], 'it should unset the user’s authenticated status')
 
   t.ok(setUserDataPropertyStub.calledOnce, 'it should set the expected number of user properties')
-  t.deepEqual(setUserDataPropertyStub.getCall(0).args, ['history', [{ phase: 'deauthenticate', date: 1483228800000 }]], 'it should update the user’s login history')
+  t.same(setUserDataPropertyStub.getCall(0).args, ['history', [{ phase: 'deauthenticate', date: 1483228800000 }]], 'it should update the user’s login history')
 
   clock.restore()
 
@@ -238,10 +238,10 @@ test('When getting messages', async t => {
 
   const expectedProperties = ['body', 'from', 'subject', 'to']
   expectedProperties.forEach((prop, index) => {
-    t.deepEqual(formatStub.getCall(index).args, [prop, formatData, formatOptions], `it should format the ${prop} property`)
+    t.same(formatStub.getCall(index).args, [prop, formatData, formatOptions], `it should format the ${prop} property`)
   })
 
-  t.deepEqual(message, {
+  t.same(message, {
     _id: 'email.test',
     _type: 'emailMessage',
     body: 'body:formatted',
@@ -265,7 +265,7 @@ test('When sending emails', async t => {
   await sendEmail('email.test', userData, { data_foo: 'dbar' }, { personalisation_foo: 'pbar' })
 
   t.ok(getEmailMessageStub.calledOnce, 'it should get the email message instance')
-  t.deepEqual(getEmailMessageStub.getCall(0).args, [
+  t.same(getEmailMessageStub.getCall(0).args, [
     'email.test',
     userData,
     { data_foo: 'dbar' },
@@ -273,7 +273,7 @@ test('When sending emails', async t => {
   ], 'it should call getMessage with the expected args')
 
   t.ok(emailClientStub.calledOnce, 'it should send the email message')
-  t.deepEqual(emailClientStub.getCall(0).args, [{ _id: 'email.test' }, {}, userData.logger], 'it should call emailClient.send with the expected args')
+  t.same(emailClientStub.getCall(0).args, [{ _id: 'email.test' }, {}, userData.logger], 'it should call emailClient.send with the expected args')
 
   getEmailMessageStub.restore()
   t.end()
@@ -286,7 +286,7 @@ test('When sending sms messages', async t => {
   await sendSMS('sms.test', userData, { data_foo: 'dbar' }, { personalisation_foo: 'pbar' })
 
   t.ok(getSMSMessageStub.calledOnce, 'it should get the sms message instance')
-  t.deepEqual(getSMSMessageStub.getCall(0).args, [
+  t.same(getSMSMessageStub.getCall(0).args, [
     'sms.test',
     userData,
     { data_foo: 'dbar' },
@@ -294,7 +294,7 @@ test('When sending sms messages', async t => {
   ], 'it should call getMessage with the expected args')
 
   t.ok(smsClientStub.calledOnce, 'it should send the sms message')
-  t.deepEqual(smsClientStub.getCall(0).args, [{ _id: 'sms.test' }, {}, userData.logger], 'it should call smsClient.send with the expected args')
+  t.same(smsClientStub.getCall(0).args, [{ _id: 'sms.test' }, {}, userData.logger], 'it should call smsClient.send with the expected args')
 
   getSMSMessageStub.restore()
   t.end()

--- a/lib/page/format-properties/format-properties.unit.spec.js
+++ b/lib/page/format-properties/format-properties.unit.spec.js
@@ -41,7 +41,7 @@ test('When formatProperties is required ', t => {
 
 test('When given no properties to update', t => {
   const emptyPageInstance = {}
-  t.deepEqual(formatProperties(emptyPageInstance, userData({})), {}, 'it should do nothing')
+  t.same(formatProperties(emptyPageInstance, userData({})), {}, 'it should do nothing')
   t.end()
 })
 
@@ -102,19 +102,19 @@ test('When updating a page', t => {
 
   const userDataStubs = userData({})
   const emptyPageInstanceProps = formatProperties({}, userDataStubs)
-  t.deepEqual(emptyPageInstanceProps, {}, 'it should do nothing')
+  t.same(emptyPageInstanceProps, {}, 'it should do nothing')
   t.ok(getScopedUserDataStub.calledOnce, 'it should get the scoped user data')
-  t.deepEqual(getScopedUserDataStub.getCall(0).args, [{
+  t.same(getScopedUserDataStub.getCall(0).args, [{
     param: {},
     page: {},
     instance: {}
   }, 'scope'], 'it should call getScopedUserDataStub with the expected args')
 
   const noContentProps = formatProperties({ nocontent: '{x}' }, userData({ x: 'value' }))
-  t.deepEqual(noContentProps, { nocontent: '{x}' }, 'it should leave non-content properties intact')
+  t.same(noContentProps, { nocontent: '{x}' }, 'it should leave non-content properties intact')
 
   const unprocessedProps = formatProperties({ unprocessed: '{x}' }, userData({ x: 'value' }))
-  t.deepEqual(unprocessedProps, { unprocessed: '{x}' }, 'it should leave properties marked as surplus intact')
+  t.same(unprocessedProps, { unprocessed: '{x}' }, 'it should leave properties marked as surplus intact')
 
   const componentsProps = formatProperties({
     components: [{
@@ -125,7 +125,7 @@ test('When updating a page', t => {
       body: '{x}'
     }]
   }, userData({ x: 'value' }))
-  t.deepEqual(componentsProps, {
+  t.same(componentsProps, {
     components: [{
       _type: 'foo',
       heading: 'value'
@@ -146,22 +146,22 @@ test('When updating a page', t => {
   contentProps.forEach(prop => {
     const pageInstance = { [prop]: '{x}' }
     const instanceProps = formatProperties(pageInstance, userData({ x: 'value' }))
-    t.deepEqual(instanceProps, { [prop]: 'value' }, `it should update ${prop} properties`)
+    t.same(instanceProps, { [prop]: 'value' }, `it should update ${prop} properties`)
     const pageInstanceWithParamProps = formatProperties({ [prop]: '[#x]' }, userData())
-    t.deepEqual(pageInstanceWithParamProps, { [prop]: 'param_value' }, `it should update ${prop} properties containing param syntax`)
+    t.same(pageInstanceWithParamProps, { [prop]: 'param_value' }, `it should update ${prop} properties containing param syntax`)
   })
 
   const pageInstanceBodyProps = formatProperties({ body: '{x}' }, userData({ x: 'value' }))
-  t.deepEqual(pageInstanceBodyProps, { body: '<p>value</p>' }, 'it should update body properties')
+  t.same(pageInstanceBodyProps, { body: '<p>value</p>' }, 'it should update body properties')
 
   const pageInstanceWithHtmlProps = formatProperties({ label: { html: '{x}' } }, userData({ x: 'value' }))
-  t.deepEqual(pageInstanceWithHtmlProps, { label: { html: 'value' } }, 'it should update nested html properties')
+  t.same(pageInstanceWithHtmlProps, { label: { html: 'value' } }, 'it should update nested html properties')
 
   const pageInstanceWithHtmlAndParamProps = formatProperties({ label: { html: '[#x]' } }, userData())
-  t.deepEqual(pageInstanceWithHtmlAndParamProps, { label: { html: 'param_value' } }, 'it should update nested html properties containing param')
+  t.same(pageInstanceWithHtmlAndParamProps, { label: { html: 'param_value' } }, 'it should update nested html properties containing param')
 
   const pageInstanceWithParamProps = formatProperties({ heading: '[#z]' }, userData(), { z: 'passed_param_value' })
-  t.deepEqual(pageInstanceWithParamProps, { heading: 'passed_param_value' }, 'it should update properties containing param syntax when params are passed explicitly')
+  t.same(pageInstanceWithParamProps, { heading: 'passed_param_value' }, 'it should update properties containing param syntax when params are passed explicitly')
 
   getUrlStub.resetHistory()
   formatProperties({ href: '/foo' }, userData())
@@ -185,7 +185,7 @@ test('When updating a page', t => {
 
   getUrlStub.resetHistory()
   formatProperties({ href: 'foo' }, userData())
-  t.deepEqual(getUrlStub.getCall(0).args, ['foo', {}, undefined], 'it should attempt to look up urls that could be ids')
+  t.same(getUrlStub.getCall(0).args, ['foo', {}, undefined], 'it should attempt to look up urls that could be ids')
 
   getServiceSchemaStub.restore()
   getUrlStub.restore()
@@ -197,7 +197,7 @@ test('When updating a page with multiline properties', t => {
   getServiceSchemaStub.callsFake(schemaStubFn)
 
   const emptyPageInstanceProps = formatProperties({}, userData({}))
-  t.deepEqual(emptyPageInstanceProps, {}, 'it should do nothing')
+  t.same(emptyPageInstanceProps, {}, 'it should do nothing')
 
   const contentProps = [
     'body',
@@ -205,14 +205,14 @@ test('When updating a page with multiline properties', t => {
   ]
   contentProps.forEach(prop => {
     const pageInstanceProps = formatProperties({ [prop]: '{x}' }, userData({ x: 'value' }))
-    t.deepEqual(pageInstanceProps, { [prop]: '<p>value</p>' }, `it should update ${prop} properties`)
+    t.same(pageInstanceProps, { [prop]: '<p>value</p>' }, `it should update ${prop} properties`)
   })
 
   const pageInstanceBodyProps = formatProperties({ body: '{x}' }, userData({ x: 'value' }))
-  t.deepEqual(pageInstanceBodyProps, { body: '<p>value</p>' }, 'it should update body properties')
+  t.same(pageInstanceBodyProps, { body: '<p>value</p>' }, 'it should update body properties')
 
   const pageInstanceWithHtmlProps = formatProperties({ label: { html: '{x}' } }, userData({ x: 'value' }))
-  t.deepEqual(pageInstanceWithHtmlProps, { label: { html: 'value' } }, 'it should update nested html properties')
+  t.same(pageInstanceWithHtmlProps, { label: { html: 'value' } }, 'it should update nested html properties')
 
   getServiceSchemaStub.restore()
   t.end()
@@ -228,7 +228,7 @@ test('When updating a page and a lang is specified', t => {
     heading: 'default lang heading'
   }
   const pageInstanceProps = formatProperties(pageInstance, userData(), {})
-  t.deepEqual(pageInstanceProps, pageInstance, 'it should leave properties untouched if no lang specified')
+  t.same(pageInstanceProps, pageInstance, 'it should leave properties untouched if no lang specified')
 
   const langInstance = formatProperties(pageInstance, userData(), {}, 'foo')
   t.equal(langInstance.title, pageInstance['title:foo'], 'it should update property with lang value if it exists')
@@ -264,7 +264,7 @@ test('When updating a page in edit mode', t => {
 
   const data = userData()
   const emptyPageInstanceProps = formatProperties(emptyPageInstance, data, {})
-  t.deepEqual(emptyPageInstanceProps, emptyPageInstance, 'it should leave properties untouched if no edit mode passed')
+  t.same(emptyPageInstanceProps, emptyPageInstance, 'it should leave properties untouched if no edit mode passed')
 
   data.EDITMODE = 'edit'
   const editmodePageInstance = formatProperties(emptyPageInstance, data, {})

--- a/lib/page/get-display-value/get-display-value.unit.spec.js
+++ b/lib/page/get-display-value/get-display-value.unit.spec.js
@@ -25,7 +25,7 @@ test('get display value', (t) => {
 
   t.ok(getDisplayValueStub.calledWith(nameInstance, userData), 'calls `getDisplayValue`')
 
-  t.equals(displayValue, 'display value', 'returns the display value')
+  t.equal(displayValue, 'display value', 'returns the display value')
 
   t.end()
 })

--- a/lib/page/process-input/process-control-composite.unit.spec.js
+++ b/lib/page/process-input/process-control-composite.unit.spec.js
@@ -71,7 +71,7 @@ test('When all composite values for a composite control exist', t => {
   t.ok(setUserDataPropertyStub.calledTwice, 'it should set all the composite values')
   t.ok(unsetUserDataPropertyStub.notCalled, 'it should not unset the composite values')
 
-  t.deepEqual(setUserDataPropertyStub.args, [['foo-a', 'x'], ['foo-b', 'y']], 'it should set the composite values to the expected values')
+  t.same(setUserDataPropertyStub.args, [['foo-a', 'x'], ['foo-b', 'y']], 'it should set the composite values to the expected values')
 
   t.equal(value, 'composite value', 'it should return value provided by getCompositeValue method')
 
@@ -91,7 +91,7 @@ test('When a composite value for a composite control is missing', t => {
   t.ok(setUserDataPropertyStub.calledOnce, 'it should set the valid composite values')
   t.ok(unsetUserDataPropertyStub.called, 'it should unset the invalid composite values')
 
-  t.deepEqual(setUserDataPropertyStub.args, [['foo-b', 'y']], 'it should set the composite values to the expected values')
+  t.same(setUserDataPropertyStub.args, [['foo-b', 'y']], 'it should set the composite values to the expected values')
 
   t.equal(value, 'composite value', 'it should return value provided by getCompositeValue method')
 

--- a/lib/page/process-input/process-control-standard.unit.spec.js
+++ b/lib/page/process-input/process-control-standard.unit.spec.js
@@ -135,11 +135,11 @@ test('When processing a control for which the value provided is an array', t => 
     t.throw(processControlStandard(pageInstance, userData, nameInstance, options), 'it should throw an error')
   } catch (e) {
     t.ok(errorLoggerStub.calledOnce, 'it should log the error')
-    t.deepEqual(errorLoggerStub.args[0], [{ name: 'foo' }, 'Input name is not unique for the request'], 'it should call the logger emthod with the expected args')
+    t.same(errorLoggerStub.args[0], [{ name: 'foo' }, 'Input name is not unique for the request'], 'it should call the logger emthod with the expected args')
     t.equal(e.name, 'InputError', 'it should throw an InputError')
     t.equal(e.code, 'EDUPLICATEINPUTNAME', 'it should add the expected code')
     t.equal(e.message, 'Input name foo is not unique', 'it should throw an InputError')
-    t.deepEqual(e.renderError, {
+    t.same(e.renderError, {
       heading: 'Input name foo is not unique',
       lede: 'The form will not work correctly unless you fix this problem'
     }, 'it should add a renderError object to the error')

--- a/lib/page/process-input/process-control.unit.spec.js
+++ b/lib/page/process-input/process-control.unit.spec.js
@@ -47,10 +47,10 @@ test('When processing a standard control', t => {
   processControl(pageInstance, userData, nameInstance)
 
   t.ok(skipControlValidationStub.calledOnce, 'it should check whether to skip validating the control')
-  t.deepEqual(skipControlValidationStub.args[0], [pageInstance, userData, nameInstance], 'it should call skipControlValidation with the expected args')
+  t.same(skipControlValidationStub.args[0], [pageInstance, userData, nameInstance], 'it should call skipControlValidation with the expected args')
 
   t.ok(skipControlProcessingStub.calledOnce, 'it should check whether to skip processing the control')
-  t.deepEqual(skipControlProcessingStub.args[0], [pageInstance, userData, nameInstance], 'it should call skipControlProcessing with the expected args')
+  t.same(skipControlProcessingStub.args[0], [pageInstance, userData, nameInstance], 'it should call skipControlProcessing with the expected args')
 
   const options = {
     controlName: 'foo',
@@ -59,15 +59,15 @@ test('When processing a standard control', t => {
 
   t.ok(processControlCompositeStub.notCalled, 'it should not use the composite method to process the control')
   t.ok(processControlStandardStub.calledOnce, 'it should process the control with the standard method')
-  t.deepEqual(processControlStandardStub.args[0], [pageInstance, userData, nameInstance, options], 'it should call processControlStandard with the expected args')
+  t.same(processControlStandardStub.args[0], [pageInstance, userData, nameInstance, options], 'it should call processControlStandard with the expected args')
 
   const optionsWithNameValue = Object.assign({ nameValue: 'bar' }, options)
 
   t.ok(updateControlValueStub.calledOnce, 'it should update the control’s value')
-  t.deepEqual(updateControlValueStub.args[0], [pageInstance, userData, nameInstance, optionsWithNameValue], 'it should call updateControlValue with the expected args')
+  t.same(updateControlValueStub.args[0], [pageInstance, userData, nameInstance, optionsWithNameValue], 'it should call updateControlValue with the expected args')
 
   t.ok(updateControlDisplayValueStub.calledOnce, 'it should update the control’s display value')
-  t.deepEqual(updateControlDisplayValueStub.args[0], [pageInstance, userData, nameInstance, optionsWithNameValue], 'it should call updateControlDisplayValue with the expected args')
+  t.same(updateControlDisplayValueStub.args[0], [pageInstance, userData, nameInstance, optionsWithNameValue], 'it should call updateControlDisplayValue with the expected args')
 
   t.end()
 })
@@ -80,10 +80,10 @@ test('When processing a composite control', t => {
   processControl(pageInstance, userData, nameInstance)
 
   t.ok(skipControlValidationStub.calledOnce, 'it should check whether to skip validating the control')
-  t.deepEqual(skipControlValidationStub.args[0], [pageInstance, userData, nameInstance], 'it should call skipControlValidation with the expected args')
+  t.same(skipControlValidationStub.args[0], [pageInstance, userData, nameInstance], 'it should call skipControlValidation with the expected args')
 
   t.ok(skipControlProcessingStub.calledOnce, 'it should check whether to skip processing the control')
-  t.deepEqual(skipControlProcessingStub.args[0], [pageInstance, userData, nameInstance], 'it should call skipControlProcessing with the expected args')
+  t.same(skipControlProcessingStub.args[0], [pageInstance, userData, nameInstance], 'it should call skipControlProcessing with the expected args')
 
   const options = {
     controlName: 'foo',
@@ -92,15 +92,15 @@ test('When processing a composite control', t => {
 
   t.ok(processControlStandardStub.notCalled, 'it should not use the composite method to process the control')
   t.ok(processControlCompositeStub.calledOnce, 'it should process the control with the standard method')
-  t.deepEqual(processControlCompositeStub.args[0], [pageInstance, userData, nameInstance, options], 'it should call processControlStandard with the expected args')
+  t.same(processControlCompositeStub.args[0], [pageInstance, userData, nameInstance, options], 'it should call processControlStandard with the expected args')
 
   const optionsWithNameValue = Object.assign({ nameValue: 'bar' }, options)
 
   t.ok(updateControlValueStub.calledOnce, 'it should update the control’s value')
-  t.deepEqual(updateControlValueStub.args[0], [pageInstance, userData, nameInstance, optionsWithNameValue], 'it should call updateControlValue with the expected args')
+  t.same(updateControlValueStub.args[0], [pageInstance, userData, nameInstance, optionsWithNameValue], 'it should call updateControlValue with the expected args')
 
   t.ok(updateControlDisplayValueStub.calledOnce, 'it should update the control’s display value')
-  t.deepEqual(updateControlDisplayValueStub.args[0], [pageInstance, userData, nameInstance, optionsWithNameValue], 'it should call updateControlDisplayValue with the expected args')
+  t.same(updateControlDisplayValueStub.args[0], [pageInstance, userData, nameInstance, optionsWithNameValue], 'it should call updateControlDisplayValue with the expected args')
 
   t.end()
 })

--- a/lib/page/process-input/process-input.unit.spec.js
+++ b/lib/page/process-input/process-input.unit.spec.js
@@ -34,7 +34,7 @@ test('When processing the input for a page instance', t => {
 
   t.equal(processControlStub.callCount, 3, 'it should process the expected component instances')
 
-  t.deepEqual(processControlStub.args, [
+  t.same(processControlStub.args, [
     [pageInstance, userData, namedInstance1],
     [pageInstance, userData, namedInstance2],
     [pageInstance, userData, namedInstance3]

--- a/lib/page/process-input/skip-control-validation.unit.spec.js
+++ b/lib/page/process-input/skip-control-validation.unit.spec.js
@@ -36,7 +36,7 @@ test('When an instance is shown conditionally', t => {
 
   skipControlValidation(pageInstance, userData, nameInstance)
   t.ok(evaluateStub.calledOnce, 'it should evaluate the condition for showing the component')
-  t.deepEqual(evaluateStub.args[0], [
+  t.same(evaluateStub.args[0], [
     nameInstance.$conditionalShow,
     {
       page: pageInstance,

--- a/lib/page/process-input/update-control-display-value.unit.spec.js
+++ b/lib/page/process-input/update-control-display-value.unit.spec.js
@@ -44,7 +44,7 @@ test('When updating the display value for a control with an undefined value', t 
   })
   t.ok(setUserDataPropertyStub.notCalled, 'it should not attempt to set the control’s display value')
   t.ok(unsetUserDataPropertyStub.calledOnce, 'it should unset the control’s display value')
-  t.deepEqual(unsetUserDataPropertyStub.args[0], ['foo', 'display'], 'it should pass the expected args to the unset method')
+  t.same(unsetUserDataPropertyStub.args[0], ['foo', 'display'], 'it should pass the expected args to the unset method')
 
   t.end()
 })
@@ -58,7 +58,7 @@ test('When updating the display value for a control with a value', t => {
   })
   t.ok(unsetUserDataPropertyStub.notCalled, 'it should not attempt to unset the control’s display value')
   t.ok(setUserDataPropertyStub.calledOnce, 'it should set the control’s display value')
-  t.deepEqual(setUserDataPropertyStub.args[0], ['foo', 'display value', 'display'], 'it should pass the expected args to the set method')
+  t.same(setUserDataPropertyStub.args[0], ['foo', 'display value', 'display'], 'it should pass the expected args to the set method')
 
   t.end()
 })

--- a/lib/page/process-input/update-control-value.unit.spec.js
+++ b/lib/page/process-input/update-control-value.unit.spec.js
@@ -49,7 +49,7 @@ test('When updating a control with an undefined value', t => {
   })
   t.ok(setUserDataPropertyStub.notCalled, 'it should not attempt to set the control’s value')
   t.ok(unsetUserDataPropertyStub.calledOnce, 'it should unset the control’s value')
-  t.deepEqual(unsetUserDataPropertyStub.args[0], ['foo'], 'it should pass the expected args to the unset method')
+  t.same(unsetUserDataPropertyStub.args[0], ['foo'], 'it should pass the expected args to the unset method')
 
   t.end()
 })
@@ -62,7 +62,7 @@ test('When updating a composite control with an undefined value', t => {
     composite: ['a', 'b']
   })
   t.equal(unsetUserDataPropertyStub.callCount, 3, 'it should unset the control’s value')
-  t.deepEqual(unsetUserDataPropertyStub.args, [['foo'], ['foo-a'], ['foo-b']], 'it should pass the expected args to the unset method')
+  t.same(unsetUserDataPropertyStub.args, [['foo'], ['foo-a'], ['foo-b']], 'it should pass the expected args to the unset method')
 
   t.end()
 })
@@ -76,7 +76,7 @@ test('When updating a control with a defined value', t => {
   })
   t.ok(unsetUserDataPropertyStub.notCalled, 'it should not attempt to unset the control’s value')
   t.ok(setUserDataPropertyStub.calledOnce, 'it should set the control’s value')
-  t.deepEqual(setUserDataPropertyStub.args[0], ['foo', 'bar'], 'it should pass the expected args to the set method')
+  t.same(setUserDataPropertyStub.args[0], ['foo', 'bar'], 'it should pass the expected args to the set method')
 
   t.end()
 })
@@ -89,7 +89,7 @@ test('When updating a control with a falsy value', t => {
     nameValue: 0
   })
   t.ok(setUserDataPropertyStub.calledOnce, 'it should set the control’s value')
-  t.deepEqual(setUserDataPropertyStub.args[0], ['foo', 0], 'it should pass the expected args to the set method')
+  t.same(setUserDataPropertyStub.args[0], ['foo', 0], 'it should pass the expected args to the set method')
 
   t.end()
 })
@@ -105,7 +105,7 @@ test('When updating a control that should be redacted with a new value', t => {
   })
 
   t.ok(redactStub.calledOnce, 'it should compare the value to be updated with the previous value')
-  t.deepEqual(redactStub.args[0], ['previous', '.#1234'], 'it should call the redact method with the expected args')
+  t.same(redactStub.args[0], ['previous', '.#1234'], 'it should call the redact method with the expected args')
   t.ok(setUserDataPropertyStub.calledOnce, 'it should set the control’s value')
 
   t.end()

--- a/lib/page/process-uploads/get-allowed-upload-controls.unit.spec.js
+++ b/lib/page/process-uploads/get-allowed-upload-controls.unit.spec.js
@@ -21,7 +21,7 @@ const componentsMultiple = [{
 test('Without `maxFiles`', t => {
   const allowedComponents = getAllowedComponents(componentsNoMaxFiles)
 
-  t.deepEqual(allowedComponents, [{
+  t.same(allowedComponents, [{
     name: 'test[1]',
     maxCount: 1
   }], 'returns one of one')
@@ -32,7 +32,7 @@ test('Without `maxFiles`', t => {
 test('With `maxFiles`', t => {
   const allowedComponents = getAllowedComponents(componentsMaxFiles)
 
-  t.deepEqual(allowedComponents, [{
+  t.same(allowedComponents, [{
     name: 'test[1]',
     maxCount: 1
   }, {
@@ -46,7 +46,7 @@ test('With `maxFiles`', t => {
 test('With and without `maxFiles` for multiple controls', t => {
   const allowedComponents = getAllowedComponents(componentsMultiple)
 
-  t.deepEqual(allowedComponents, [{
+  t.same(allowedComponents, [{
     name: 'test[1]',
     maxCount: 1
   }, {

--- a/lib/page/process-uploads/process-upload-controls.unit.spec.js
+++ b/lib/page/process-uploads/process-upload-controls.unit.spec.js
@@ -51,11 +51,11 @@ test('`processComponents` is called', async t => {
   const { files, fileErrors } = await processComponents(userData, components, allowedComponents)
 
   t.plan(4)
-  t.deepEqual(files, ['a', 'b'], 'it should return the files parsed by multer')
-  t.deepEqual(fileErrors, ['x', 'y'], 'it should return the errors determined by multer')
+  t.same(files, ['a', 'b'], 'it should return the files parsed by multer')
+  t.same(fileErrors, ['x', 'y'], 'it should return the errors determined by multer')
 
   t.equal(setBodyInputStub.called, true, 'it should call userData.setBodyInput')
-  t.deepEqual(setBodyInputStub.getCall(0).args[0], { field: 'value' }, 'it should call userData.setBodyInput')
+  t.same(setBodyInputStub.getCall(0).args[0], { field: 'value' }, 'it should call userData.setBodyInput')
 
   t.end()
 })
@@ -85,12 +85,12 @@ test('Removing an upload', async t => {
   await processComponents(userData, components, allowedComponents)
 
   t.plan(4)
-  t.deepEqual(getUserDataPropertyStub.getCall(0).args, ['foo'], 'it should retrieve the correct user data property')
-  t.deepEqual(unsetUserDataPropertyStub.getCall(0).args, ['foo'], 'it should unset the correct user data property')
+  t.same(getUserDataPropertyStub.getCall(0).args, ['foo'], 'it should retrieve the correct user data property')
+  t.same(unsetUserDataPropertyStub.getCall(0).args, ['foo'], 'it should unset the correct user data property')
   t.ok(setUserDataPropertyStub.notCalled, 'it should not set the user data property')
 
   const setFlashMessageStubArgs = setFlashMessageStub.getCall(0).args
-  t.deepEqual(setFlashMessageStubArgs[0], {
+  t.same(setFlashMessageStubArgs[0], {
     type: 'file.removed',
     html: 'Successfully removed originalname'
   }, 'it should set a flash message for the upload')
@@ -123,8 +123,8 @@ test('Removing an upload when a property has multiple uploads', async t => {
   await processComponents(userData, components, allowedComponents)
 
   t.plan(3)
-  t.deepEqual(getUserDataPropertyStub.getCall(0).args, ['foo'], 'it should retrieve the correct user data property')
-  t.deepEqual(setUserDataPropertyStub.getCall(0).args, ['foo', [{ uuid: 'baz' }]], 'it should set the user data property')
+  t.same(getUserDataPropertyStub.getCall(0).args, ['foo'], 'it should retrieve the correct user data property')
+  t.same(setUserDataPropertyStub.getCall(0).args, ['foo', [{ uuid: 'baz' }]], 'it should set the user data property')
   t.ok(unsetUserDataPropertyStub.notCalled, 'it should not unset the user data property')
 
   t.end()
@@ -150,7 +150,7 @@ test('Trying to remove an upload which does not exist', async t => {
   await processComponents(userData, components, allowedComponents)
 
   t.plan(3)
-  t.deepEqual(getUserDataPropertyStub.getCall(0).args, ['foo'], 'it should retrieve the correct user data property')
+  t.same(getUserDataPropertyStub.getCall(0).args, ['foo'], 'it should retrieve the correct user data property')
   t.ok(unsetUserDataPropertyStub.notCalled, 'it should not unset the user data property')
   t.ok(setUserDataPropertyStub.notCalled, 'it should not set the user data property')
 

--- a/lib/page/process-uploads/process-uploaded-files.unit.spec.js
+++ b/lib/page/process-uploads/process-uploaded-files.unit.spec.js
@@ -32,7 +32,7 @@ test('The `accept` property is not present', async t => {
     files
   } = await processComponentFiles(pageInstance, userData, uploadedFiles, uploadControl)
 
-  t.deepEqual(files.allowed_types, undefined, '`allowed_types` is undefined')
+  t.same(files.allowed_types, undefined, '`allowed_types` is undefined')
 
   t.end()
 })
@@ -53,7 +53,7 @@ test('The `accept` property is an array', async t => {
     files
   } = await processComponentFiles(pageInstance, userData, uploadedFiles, uploadControlWithoutAccept)
 
-  t.deepEqual(files.allowed_types, undefined, '`allowed_types` is undefined')
+  t.same(files.allowed_types, undefined, '`allowed_types` is undefined')
 
   t.end()
 })
@@ -78,7 +78,7 @@ test('The `accept` property is an array of mimetypes', async t => {
     }
   } = await processComponentFiles(pageInstance, userData, uploadedFiles, uploadControlWithAccept)
 
-  t.deepEqual(file.allowed_types, ['application/pdf', 'image/png'], '`allowed_types` is an array of mimetypes')
+  t.same(file.allowed_types, ['application/pdf', 'image/png'], '`allowed_types` is an array of mimetypes')
 
   t.end()
 })
@@ -132,8 +132,8 @@ test('When an uploaded file is valid', async t => {
       fileErrors
     } = await processComponentFiles(pageInstance, userData, uploadedFilesWithoutFileErrors, uploadControl)
 
-    t.deepEqual(files, uploadedFilesWithoutFileErrors.files, 'returns the `files` property of the uploaded files object')
-    t.deepEqual(fileErrors, {}, 'returns an object when the `fileErrors` property of the uploaded files object does not exist')
+    t.same(files, uploadedFilesWithoutFileErrors.files, 'returns the `files` property of the uploaded files object')
+    t.same(fileErrors, {}, 'returns an object when the `fileErrors` property of the uploaded files object does not exist')
   }
 
   {
@@ -142,8 +142,8 @@ test('When an uploaded file is valid', async t => {
       fileErrors
     } = await processComponentFiles(pageInstance, userData, uploadedFilesWithErrors, uploadControl)
 
-    t.deepEqual(files, uploadedFilesWithErrors.files, 'returns the `files` property of the uploaded files object')
-    t.deepEqual(fileErrors, uploadedFilesWithErrors.fileErrors, 'returns the `fileErrors` property of the uploaded files object')
+    t.same(files, uploadedFilesWithErrors.files, 'returns the `files` property of the uploaded files object')
+    t.same(fileErrors, uploadedFilesWithErrors.fileErrors, 'returns the `fileErrors` property of the uploaded files object')
   }
 
   t.end()
@@ -167,8 +167,8 @@ test('When an uploaded file is not valid', async t => {
     fileErrors
   } = await processComponentFiles(pageInstance, userData, uploadedFiles, uploadControl)
 
-  t.deepEqual(files, {}, 'removes the invalid file from the `files` object')
-  t.deepEqual(fileErrors, {
+  t.same(files, {}, 'removes the invalid file from the `files` object')
+  t.same(fileErrors, {
     maxSize: [
       {
         fieldname: 'test[1]',

--- a/lib/page/process-uploads/register-upload-errors.unit.spec.js
+++ b/lib/page/process-uploads/register-upload-errors.unit.spec.js
@@ -54,11 +54,11 @@ test('When registering upload errors with an error message', t => {
 
   t.equal(firstArg, pageInstance, 'invokes `setErrors` with `pageInstance` as the first argument')
 
-  t.deepEqual(Object.keys(error), ['instance', 'errorType', 'error'], 'the error object has the expected properties')
+  t.same(Object.keys(error), ['instance', 'errorType', 'error'], 'the error object has the expected properties')
 
   t.equal(error.instance, 'test', 'normalises the upload control name')
   t.equal(error.errorType, 'This error has an error message', 'uses the error message as the error type')
-  t.deepEqual(error.error, {
+  t.same(error.error, {
     values: {
       filename: 'originalname.txt',
       maxFiles: 1,

--- a/lib/page/process-uploads/store-uploaded-files.unit.spec.js
+++ b/lib/page/process-uploads/store-uploaded-files.unit.spec.js
@@ -75,7 +75,7 @@ test('When storeUploadedFiles is passed a list of uploaded files to store', asyn
 
   t.equal(FBUserFileStoreClientStubArgs[0], '/tmp/uploadedfilehash', 'it should call the storeFromPath method with the correct filepath')
 
-  t.deepEqual(FBUserFileStoreClientStubArgs[1], {
+  t.same(FBUserFileStoreClientStubArgs[1], {
     userId: 'userid',
     userToken: 'usertoken',
     policy: {}
@@ -85,9 +85,9 @@ test('When storeUploadedFiles is passed a list of uploaded files to store', asyn
 
   const setUserDataPropertyStubArgs = setUserDataPropertyStub.getCall(0).args
 
-  t.deepEqual(setUserDataPropertyStubArgs[0], 'mock component name', 'it should update the correct user data property')
+  t.same(setUserDataPropertyStubArgs[0], 'mock component name', 'it should update the correct user data property')
 
-  t.deepEqual(setUserDataPropertyStubArgs[1], [
+  t.same(setUserDataPropertyStubArgs[1], [
     {
       fieldname: 'test[1]',
       originalname: 'originalname',
@@ -102,9 +102,9 @@ test('When storeUploadedFiles is passed a list of uploaded files to store', asyn
 
   const setSuccessfulUploadStubArgs = setSuccessfulUploadStub.getCall(0).args
 
-  t.deepEqual(setSuccessfulUploadStubArgs[0], 'mock component name', 'it should increment the field’s successful file upload count')
+  t.same(setSuccessfulUploadStubArgs[0], 'mock component name', 'it should increment the field’s successful file upload count')
 
-  t.deepEqual(fsUnlinkStub.getCall(0).args[0], '/tmp/uploadedfilehash', 'it should delete the file after it has been uploaded')
+  t.same(fsUnlinkStub.getCall(0).args[0], '/tmp/uploadedfilehash', 'it should delete the file after it has been uploaded')
 
   t.end()
 
@@ -139,9 +139,9 @@ test('When storeUploadedFiles is passed a files with policy properties', async t
 
   const policyArgs = FBUserFileStoreClientStub.getCall(0).args[1].policy
 
-  t.deepEqual(policyArgs.max_size, 10000, 'it should set the max_size policy property')
-  t.deepEqual(policyArgs.expires, 7, 'it should set the expires policy property')
-  t.deepEqual(policyArgs.allowed_types, ['image/*'], 'it should set the allowed_types policy property')
+  t.same(policyArgs.max_size, 10000, 'it should set the max_size policy property')
+  t.same(policyArgs.expires, 7, 'it should set the expires policy property')
+  t.same(policyArgs.allowed_types, ['image/*'], 'it should set the allowed_types policy property')
   t.end()
   FBUserFileStoreClientStub.resetHistory()
 })
@@ -172,7 +172,7 @@ test('When storeUploadedFiles encounters an error uploading a file', async t => 
   setUserDataPropertyStub.resetHistory()
   const fileErrors = await storeUploadedFiles(pageInstance, userData, uploadedResults)
 
-  t.deepEqual(fileErrors, {
+  t.same(fileErrors, {
     UPLOAD_FAILED: [{
       fieldname: 'test[1]',
       originalname: 'originalname',
@@ -185,9 +185,9 @@ test('When storeUploadedFiles encounters an error uploading a file', async t => 
     }]
   }, 'it should set an error noting that the attempt to file store failed')
 
-  t.deepEqual(setUserDataPropertyStub.notCalled, true, 'it should not update the user data property')
+  t.same(setUserDataPropertyStub.notCalled, true, 'it should not update the user data property')
 
-  t.deepEqual(fsUnlinkStub.getCall(0).args[0], '/tmp/uploadedfilehash', 'it should delete the file even though it has not been uploaded')
+  t.same(fsUnlinkStub.getCall(0).args[0], '/tmp/uploadedfilehash', 'it should delete the file even though it has not been uploaded')
 
   t.end()
   setUserDataPropertyStub.resetHistory()

--- a/lib/page/set-default-values/set-default-values.unit.spec.js
+++ b/lib/page/set-default-values/set-default-values.unit.spec.js
@@ -35,7 +35,7 @@ test('When updating a page that contains a property that has a default value in 
     _type: 'defaultTypeSchema',
     defaultTest: undefined
   }, userData)
-  t.deepEqual(pageInstanceWithDefaultValueProps.defaultTest, 'defaultTest default value', 'it should use the default value')
+  t.same(pageInstanceWithDefaultValueProps.defaultTest, 'defaultTest default value', 'it should use the default value')
 
   getServiceSchemaStub.restore()
   t.end()
@@ -49,7 +49,7 @@ test('When updating a page that contains a property that has a default value in 
     _type: 'defaultTypeSchema',
     defaultTest: 'specified value'
   }, userData)
-  t.deepEqual(pageInstanceWithSpecifiedValueProps.defaultTest, pageInstanceWithSpecifiedValueProps.defaultTest, 'it should not overwrite the specified value')
+  t.same(pageInstanceWithSpecifiedValueProps.defaultTest, pageInstanceWithSpecifiedValueProps.defaultTest, 'it should not overwrite the specified value')
 
   getServiceSchemaStub.restore()
   t.end()
@@ -63,7 +63,7 @@ test('When updating a page that contains a property that has no default value in
     _type: 'anotherSchema',
     defaultTest: 'specified value'
   }, userData)
-  t.deepEqual(pageInstanceWithNoDefaultForProp.defaultTest, pageInstanceWithNoDefaultForProp.defaultTest, 'it should leave the value unspecified')
+  t.same(pageInstanceWithNoDefaultForProp.defaultTest, pageInstanceWithNoDefaultForProp.defaultTest, 'it should leave the value unspecified')
 
   getServiceSchemaStub.restore()
   t.end()
@@ -75,7 +75,7 @@ test('When updating a page that contains an instance that has a const value in i
   const pageInstanceWithConstValueProps = setDefaultValues({
     _type: 'constTypeSchema'
   }, userData)
-  t.deepEqual(pageInstanceWithConstValueProps.constTest, 'constTest const value', 'it should use the const value')
+  t.same(pageInstanceWithConstValueProps.constTest, 'constTest const value', 'it should use the const value')
 
   getServiceSchemaStub.restore()
   t.end()
@@ -88,7 +88,7 @@ test('When updating a page that contains a property with a value that has a cons
     _type: 'constTypeSchema',
     constTest: 'Overridden value'
   }, userData)
-  t.deepEqual(pageInstanceWithConstValueProps.constTest, 'constTest const value', 'it should use the const value')
+  t.same(pageInstanceWithConstValueProps.constTest, 'constTest const value', 'it should use the const value')
 
   getServiceSchemaStub.restore()
   t.end()

--- a/lib/page/set-errors/set-errors.unit.spec.js
+++ b/lib/page/set-errors/set-errors.unit.spec.js
@@ -45,12 +45,12 @@ test('The module', t => {
 })
 
 test('When adjusting error objects', t => {
-  t.deepEqual(adjustErrorObjs({}), undefined, 'returns undefined if errors are undefined')
+  t.same(adjustErrorObjs({}), undefined, 'returns undefined if errors are undefined')
 
   {
     const errors = [{ instance: { name: 'test' }, errorType: 'boom' }]
 
-    t.deepEqual(adjustErrorObjs({}, errors), errors, 'returns errors if errors are defined')
+    t.same(adjustErrorObjs({}, errors), errors, 'returns errors if errors are defined')
   }
 
   {
@@ -59,7 +59,7 @@ test('When adjusting error objects', t => {
     const errors = [{ instance: 'test', errorType: 'boom' }]
     const adjusted = [{ instance: {}, errorType: 'boom' }]
 
-    t.deepEqual(adjustErrorObjs(pageInstance, errors), adjusted, 'removes errors which cannot be mapped to a component in the page instance')
+    t.same(adjustErrorObjs(pageInstance, errors), adjusted, 'removes errors which cannot be mapped to a component in the page instance')
   }
 
   {
@@ -75,7 +75,7 @@ test('When adjusting error objects', t => {
       },
       errorType: 'boom'
     }]
-    t.deepEqual(adjustErrorObjs(pageInstance, errors), adjusted, 'adjusts errors which can be mapped to a component in the page instance')
+    t.same(adjustErrorObjs(pageInstance, errors), adjusted, 'adjusts errors which can be mapped to a component in the page instance')
   }
 
   t.end()
@@ -214,7 +214,7 @@ test('When preparing parameters for formatting', t => {
       }
     }
 
-    t.deepEqual(getFormatParameters(controlInstance, error), {
+    t.same(getFormatParameters(controlInstance, error), {
       control: 'MOCK CONTROL LABEL',
       mockRule: 'MOCK CONTROL VALIDATION RULE VALUE',
       value: {},
@@ -247,7 +247,7 @@ test('When preparing parameters for formatting', t => {
       }
     }
 
-    t.deepEqual(getFormatParameters(controlInstance, error, 'mock-lang'), {
+    t.same(getFormatParameters(controlInstance, error, 'mock-lang'), {
       control: 'MOCK LANG CONTROL LABEL',
       mockRule: 'MOCK CONTROL VALIDATION RULE VALUE',
       value: {},
@@ -279,7 +279,7 @@ test('When preparing parameters for formatting', t => {
       }
     }
 
-    t.deepEqual(getFormatParameters(controlInstance, error), {
+    t.same(getFormatParameters(controlInstance, error), {
       control: 'MOCK CONTROL LEGEND',
       mockRule: 'MOCK CONTROL VALIDATION RULE VALUE',
       value: {},
@@ -311,7 +311,7 @@ test('When preparing parameters for formatting', t => {
       }
     }
 
-    t.deepEqual(getFormatParameters(controlInstance, error, 'mock-lang'), {
+    t.same(getFormatParameters(controlInstance, error, 'mock-lang'), {
       control: 'MOCK LANG CONTROL LEGEND',
       mockRule: 'MOCK CONTROL VALIDATION RULE VALUE',
       value: {},
@@ -340,7 +340,7 @@ test('When preparing parameters for formatting', t => {
       }
     }
 
-    t.deepEqual(getFormatParameters(controlInstance, error), {
+    t.same(getFormatParameters(controlInstance, error), {
       control: 'MOCK CONTROL LABEL',
       mockRule: 'MOCK CONTROL VALIDATION RULE VALUE',
       value: {},
@@ -377,14 +377,14 @@ test('When getting the localised legend', t => {
 test('When getting the error strings from the control', t => {
   const mockErrors = {}
 
-  t.deepEqual(getInstanceErrorStringsFromControl(), {}, 'always returns an object')
+  t.same(getInstanceErrorStringsFromControl(), {}, 'always returns an object')
   t.equal(getInstanceErrorStringsFromControl({ errors: { mockErrors } }, 'mockErrors'), mockErrors, 'returns the error object for the error type')
 
   t.end()
 })
 
 test('When getting the error lookups array', t => {
-  t.deepEqual(getErrorLookupsArray('MOCK ERROR TYPE', 'MOCK CONTROL TYPE', 'MOCK POSITION'), [
+  t.same(getErrorLookupsArray('MOCK ERROR TYPE', 'MOCK CONTROL TYPE', 'MOCK POSITION'), [
     'error.MOCK ERROR TYPE.MOCK CONTROL TYPE.MOCK POSITION',
     'error.MOCK CONTROL TYPE.MOCK ERROR TYPE.MOCK POSITION',
     'error.MOCK ERROR TYPE.MOCK CONTROL TYPE',
@@ -424,7 +424,7 @@ test('When testing the error strings for a field', t => {
     hasInstanceErrorString(errorStrings, position)
 
     t.equal(spy.callCount, 1, 'calls `Reflect.has()` once')
-    t.deepEqual(spy.getCall(0).args, [errorStrings, 'MOCK POSITION'], 'calls `Reflect.has()` with the error string object and position string')
+    t.same(spy.getCall(0).args, [errorStrings, 'MOCK POSITION'], 'calls `Reflect.has()` with the error string object and position string')
 
     spy.restore()
   }
@@ -437,7 +437,7 @@ test('When testing the error strings for a field', t => {
     hasInstanceErrorString(errorStrings, position, lang)
 
     t.equal(stub.callCount, 1, 'calls `Reflect.has()` once')
-    t.deepEqual(stub.getCall(0).args, [errorStrings, 'MOCK POSITION:MOCK LANG'], 'calls `Reflect.has()` with the error string object and concatenated position and lang strings')
+    t.same(stub.getCall(0).args, [errorStrings, 'MOCK POSITION:MOCK LANG'], 'calls `Reflect.has()` with the error string object and concatenated position and lang strings')
 
     stub.restore()
   }
@@ -450,8 +450,8 @@ test('When testing the error strings for a field', t => {
     hasInstanceErrorString(errorStrings, position, lang)
 
     t.equal(stub.callCount, 2, 'calls `Reflect.has()` twice')
-    t.deepEqual(stub.getCall(0).args, [errorStrings, 'MOCK POSITION:MOCK LANG'], 'calls `Reflect.has()` with the error string object and concatenated position and lang strings')
-    t.deepEqual(stub.getCall(1).args, [errorStrings, 'MOCK POSITION'], 'calls `Reflect.has()` with the error string object and position string')
+    t.same(stub.getCall(0).args, [errorStrings, 'MOCK POSITION:MOCK LANG'], 'calls `Reflect.has()` with the error string object and concatenated position and lang strings')
+    t.same(stub.getCall(1).args, [errorStrings, 'MOCK POSITION'], 'calls `Reflect.has()` with the error string object and position string')
 
     stub.restore()
   }
@@ -470,7 +470,7 @@ test('When getting the error strings for a field', t => {
     getInstanceErrorString(errorStrings, position)
 
     t.equal(spy.callCount, 1, 'calls `Reflect.get()` once')
-    t.deepEqual(spy.getCall(0).args, [errorStrings, 'MOCK POSITION'], 'calls `Reflect.get()` with the error string object and position string')
+    t.same(spy.getCall(0).args, [errorStrings, 'MOCK POSITION'], 'calls `Reflect.get()` with the error string object and position string')
 
     spy.restore()
   }
@@ -483,7 +483,7 @@ test('When getting the error strings for a field', t => {
     getInstanceErrorString(errorStrings, position, lang)
 
     t.equal(stub.callCount, 1, 'calls `Reflect.get()` once')
-    t.deepEqual(stub.getCall(0).args, [errorStrings, 'MOCK POSITION:MOCK LANG'], 'calls `Reflect.get()` with the error string object and concatenated position and lang strings')
+    t.same(stub.getCall(0).args, [errorStrings, 'MOCK POSITION:MOCK LANG'], 'calls `Reflect.get()` with the error string object and concatenated position and lang strings')
 
     stub.restore()
   }
@@ -496,8 +496,8 @@ test('When getting the error strings for a field', t => {
     getInstanceErrorString(errorStrings, position, lang)
 
     t.equal(stub.callCount, 2, 'calls `Reflect.get()` twice')
-    t.deepEqual(stub.getCall(0).args, [errorStrings, 'MOCK POSITION:MOCK LANG'], 'calls `Reflect.get()` with the error string object and concatenated position and lang strings')
-    t.deepEqual(stub.getCall(1).args, [errorStrings, 'MOCK POSITION'], 'calls `Reflect.get()` with the error string object and position string')
+    t.same(stub.getCall(0).args, [errorStrings, 'MOCK POSITION:MOCK LANG'], 'calls `Reflect.get()` with the error string object and concatenated position and lang strings')
+    t.same(stub.getCall(1).args, [errorStrings, 'MOCK POSITION'], 'calls `Reflect.get()` with the error string object and position string')
 
     stub.restore()
   }
@@ -573,8 +573,8 @@ test('When setting control errors', t => {
       ]
     } = setControlErrors(pageInstance, errors)
 
-    t.deepEqual(componentOne, { _id: 'controlA', _type: 'text', label: 'Your name', error: 'boom' }, 'adds an error to the first component')
-    t.deepEqual(componentTwo, { _id: 'controlB', _type: 'number', label: 'Your age', error: 'minimum' }, 'adds an error to the second component')
+    t.same(componentOne, { _id: 'controlA', _type: 'text', label: 'Your name', error: 'boom' }, 'adds an error to the first component')
+    t.same(componentTwo, { _id: 'controlB', _type: 'number', label: 'Your age', error: 'minimum' }, 'adds an error to the second component')
   }
 
   {
@@ -603,8 +603,8 @@ test('When setting control errors', t => {
       ]
     } = setControlErrors(pageInstance)
 
-    t.deepEqual(componentOne, { _id: 'controlA', _type: 'text', label: 'Your name' }, 'does not add an error')
-    t.deepEqual(componentTwo, { _id: 'controlB', _type: 'number', label: 'Your age' }, 'does not add an error')
+    t.same(componentOne, { _id: 'controlA', _type: 'text', label: 'Your name' }, 'does not add an error')
+    t.same(componentTwo, { _id: 'controlB', _type: 'number', label: 'Your age' }, 'does not add an error')
   }
 
   t.end()
@@ -627,7 +627,7 @@ test('When setting a summary error', t => {
 
   setSummaryError(pageInstance, controlInstance, errorType)
 
-  t.deepEqual(pageInstance.errorList, [{
+  t.same(pageInstance.errorList, [{
     html: 'boom',
     href: '#control'
   }], 'it should add the error to the page instance’s error list')
@@ -652,7 +652,7 @@ test('When setting a summary error for a composite field', t => {
 
   setSummaryError(pageInstance, controlInstance, errorType, { compositeInput: 'rose' })
 
-  t.deepEqual(pageInstance.errorList, [{
+  t.same(pageInstance.errorList, [{
     html: 'boom',
     href: '#controlname-rose'
   }], 'it should add the anchor for the correct composite input field')
@@ -677,7 +677,7 @@ test('When setting a summary error for a radios field ', t => {
 
   setSummaryError(pageInstance, controlInstance, errorType)
 
-  t.deepEqual(pageInstance.errorList, [{
+  t.same(pageInstance.errorList, [{
     html: 'boom',
     href: '#controlname-0'
   }], 'it should add the anchor for the first radio option element based on the radios instance name')
@@ -704,7 +704,7 @@ test('When setting a summary error for a field with items with no name', t => {
 
   setSummaryError(pageInstance, controlInstance, errorType)
 
-  t.deepEqual(pageInstance.errorList, [{
+  t.same(pageInstance.errorList, [{
     html: 'boom',
     href: '#checkbox-name'
   }], 'it should add the anchor for the first checkbox option element')
@@ -714,7 +714,7 @@ test('When setting a summary error for a field with items with no name', t => {
 test('When adding a delimited summary error', t => {
   const xInst = {}
   setSummaryError(xInst, 'fakeinstance', 'boom==/url')
-  t.deepEqual(xInst.errorList, [{
+  t.same(xInst.errorList, [{
     html: 'boom',
     href: '/url'
   }], 'it should split the parts into html and text params')
@@ -759,7 +759,7 @@ test('When setting summary errors', t => {
     const returnValue = setSummaryErrors(pageInstance, errors)
 
     t.equal(returnValue, pageInstance, 'returns the page instance')
-    t.deepEqual(returnValue, {
+    t.same(returnValue, {
       errorsSeen: {
         summary: {
           control1: 'boom',
@@ -795,7 +795,7 @@ test('When setting summary errors', t => {
     const returnValue = setSummaryErrors(pageInstance, errors)
 
     t.equal(returnValue, pageInstance, 'returns the page instance')
-    t.deepEqual(returnValue, {}, 'does not mutate the page instance by adding an `errorsSeen` field, an `errorList` field, and an `errorTitle` field')
+    t.same(returnValue, {}, 'does not mutate the page instance by adding an `errorsSeen` field, an `errorList` field, and an `errorTitle` field')
   }
 
   t.end()
@@ -855,11 +855,11 @@ test('When setting duplicate summary errors', t => {
     errorTwo
   ] = pageInstance.errorList
 
-  t.deepEqual(errorOne, {
+  t.same(errorOne, {
     html: 'required', href: '#control1'
   }, 'it should not add other errors if a required error has already been registered for the component')
 
-  t.deepEqual(errorTwo, {
+  t.same(errorTwo, {
     html: 'minimum', href: '#control2'
   }, 'it should not add required errors if any error has already been registered for the component')
 
@@ -891,7 +891,7 @@ test('When errors have been registered out of source order', t => {
   pageInstance = setErrors(pageInstance, errors)
   const errorList = pageInstance.errorList
 
-  t.deepEqual(errorList, [{
+  t.same(errorList, [{
     html: 'invalid', href: '#control1'
   }, {
     html: 'required', href: '#control2'
@@ -910,9 +910,9 @@ test('When setting summary heading', t => {
     }
   })
 
-  t.deepEqual(setSummaryErrorsHeading({ errorList: [1, 2, 3] }).errorTitle, 'There were 3 problems', 'it should return the correct heading for multiple errors')
-  t.deepEqual(setSummaryErrorsHeading({ errorList: [1] }).errorTitle, 'There was one problem', 'it should return the correct heading for a single error')
-  t.deepEqual(setSummaryErrorsHeading({ errorList: [] }).errorTitle, 'There were no problems', 'it should return the correct heading for no errors')
+  t.same(setSummaryErrorsHeading({ errorList: [1, 2, 3] }).errorTitle, 'There were 3 problems', 'it should return the correct heading for multiple errors')
+  t.same(setSummaryErrorsHeading({ errorList: [1] }).errorTitle, 'There was one problem', 'it should return the correct heading for a single error')
+  t.same(setSummaryErrorsHeading({ errorList: [] }).errorTitle, 'There were no problems', 'it should return the correct heading for no errors')
 
   t.end()
 })
@@ -923,7 +923,7 @@ test('When setting errors', t => {
   const returnValue = setErrors(pageInstance)
 
   t.equal(returnValue, pageInstance, 'returns the page instance')
-  t.deepEqual(returnValue, { errorsSeen: { summary: {}, control: {} } }, 'mutates the page instance by adding an `errorsSeen` field')
+  t.same(returnValue, { errorsSeen: { summary: {}, control: {} } }, 'mutates the page instance by adding an `errorsSeen` field')
 
   t.end()
 })

--- a/lib/page/set-multipart-form/set-multipart-form.unit.spec.js
+++ b/lib/page/set-multipart-form/set-multipart-form.unit.spec.js
@@ -68,7 +68,7 @@ test('The method is POST and the content-type is not multipart/form-data', async
       }
     }))
   } catch (e) {
-    t.equals(e.message, '400', 'it should throw a bad request')
+    t.equal(e.message, '400', 'it should throw a bad request')
   }
 
   t.end()
@@ -109,7 +109,7 @@ test('The method is POST and the content-type is not multipart/form-data', async
       }
     }))
   } catch (e) {
-    t.equals(e.message, '400', 'it should throw a bad request')
+    t.equal(e.message, '400', 'it should throw a bad request')
   }
 
   t.end()
@@ -131,7 +131,7 @@ test('The method is POST and there is no content-type', async t => {
       }
     }))
   } catch (e) {
-    t.equals(e.message, '400', 'it should throw a bad request')
+    t.equal(e.message, '400', 'it should throw a bad request')
   }
 
   t.end()

--- a/lib/page/skip-components/skip-components.unit.spec.js
+++ b/lib/page/skip-components/skip-components.unit.spec.js
@@ -19,7 +19,7 @@ test('When skipComponents is required ', t => {
 
 test('When given a page that has no components to remove', t => {
   const pageInstanceEmpty = {}
-  t.deepEqual(skipComponentsClone(pageInstanceEmpty, {}), {}, 'it should do nothing')
+  t.same(skipComponentsClone(pageInstanceEmpty, {}), {}, 'it should do nothing')
   t.end()
 })
 
@@ -34,7 +34,7 @@ test('When given a page has components to remove', t => {
   }
   const pageExpected = cloneDeep(pageInstance)
   pageExpected.items.splice(0, 1)
-  t.deepEqual(skipComponentsClone(pageInstance, {}), pageExpected, 'it should remove the components that are array items')
+  t.same(skipComponentsClone(pageInstance, {}), pageExpected, 'it should remove the components that are array items')
 
   const pageInstanceProp = {
     x: {
@@ -44,7 +44,7 @@ test('When given a page has components to remove', t => {
   }
   const pageExpectedProp = cloneDeep(pageInstanceProp)
   delete pageExpectedProp.x
-  t.deepEqual(skipComponentsClone(pageInstanceProp, {}), pageExpectedProp, 'it should remove the components that are object properties')
+  t.same(skipComponentsClone(pageInstanceProp, {}), pageExpectedProp, 'it should remove the components that are object properties')
 
   const pageInstanceNested = {
     items: [{
@@ -60,7 +60,7 @@ test('When given a page has components to remove', t => {
   }
   const pageExpectedNested = cloneDeep(pageInstanceNested)
   pageExpectedNested.items.splice(0, 1)
-  t.deepEqual(skipComponentsClone(pageInstanceNested, {}), pageExpectedNested, 'it should remove components that have subcomponents that should also be removed')
+  t.same(skipComponentsClone(pageInstanceNested, {}), pageExpectedNested, 'it should remove components that have subcomponents that should also be removed')
 
   const pageInstanceInput = {
     items: [{
@@ -76,8 +76,8 @@ test('When given a page has components to remove', t => {
   }
   const pageExpectedInput = cloneDeep(pageInstanceInput)
   pageExpectedInput.items.splice(0, 1)
-  t.deepEqual(skipComponentsClone(pageInstanceInput, {}), pageExpectedInput, 'it should remove a component when its condition evaluates to true')
-  t.deepEqual(skipComponentsClone(pageInstanceInput, { x: 'y' }), pageInstanceInput, 'it should not remove a component when its condition evaluates to true')
+  t.same(skipComponentsClone(pageInstanceInput, {}), pageExpectedInput, 'it should remove a component when its condition evaluates to true')
+  t.same(skipComponentsClone(pageInstanceInput, { x: 'y' }), pageInstanceInput, 'it should not remove a component when its condition evaluates to true')
 
   t.end()
 })

--- a/lib/page/update-control-names/update-control-names.unit.spec.js
+++ b/lib/page/update-control-names/update-control-names.unit.spec.js
@@ -30,7 +30,7 @@ test('When updateControlNames is required ', t => {
 
 test('When given a page that has no properties to update', t => {
   const pageInstanceEmpty = {}
-  t.deepEqual(updateControlNames(pageInstanceEmpty, userDataPropertyEmpty), {}, 'it should do nothing')
+  t.same(updateControlNames(pageInstanceEmpty, userDataPropertyEmpty), {}, 'it should do nothing')
   t.end()
 })
 
@@ -41,12 +41,12 @@ test('When given a page to update that has controls', t => {
     }]
   }
 
-  t.deepEqual(updateControlNames(cloneDeep(pageInstance), userDataPropertyEmpty), pageInstance, 'it should not update name controls if no data passed')
+  t.same(updateControlNames(cloneDeep(pageInstance), userDataPropertyEmpty), pageInstance, 'it should not update name controls if no data passed')
 
   const pageExpected = cloneDeep(pageInstance)
   pageExpected.items[0].value = 'world'
 
-  t.deepEqual(updateControlNames(cloneDeep(pageInstance), userDataPropertyHelloWorld), pageExpected, 'it should update name controls if passed data that matches')
+  t.same(updateControlNames(cloneDeep(pageInstance), userDataPropertyHelloWorld), pageExpected, 'it should update name controls if passed data that matches')
 
   const pageInstanceCheckbox = {
     items: [{
@@ -58,14 +58,14 @@ test('When given a page to update that has controls', t => {
     }]
   }
 
-  t.deepEqual(updateControlNames(cloneDeep(pageInstanceCheckbox), userDataPropertyEmpty), pageInstanceCheckbox, 'it should not update checkbox check value if no data passed')
+  t.same(updateControlNames(cloneDeep(pageInstanceCheckbox), userDataPropertyEmpty), pageInstanceCheckbox, 'it should not update checkbox check value if no data passed')
 
   const pageExpectedCheckbox = cloneDeep(pageInstanceCheckbox)
   pageExpectedCheckbox.items[0].checked = true
 
-  t.deepEqual(updateControlNames(cloneDeep(pageInstanceCheckbox), userDataPropertyHelloWorld), pageExpectedCheckbox, 'it should update checkbox check value if passed data that matches')
+  t.same(updateControlNames(cloneDeep(pageInstanceCheckbox), userDataPropertyHelloWorld), pageExpectedCheckbox, 'it should update checkbox check value if passed data that matches')
 
-  t.deepEqual(updateControlNames(cloneDeep(pageInstanceCheckbox), userDataPropertySpace), pageInstanceCheckbox, 'it should not update checkbox check value if data does not match')
+  t.same(updateControlNames(cloneDeep(pageInstanceCheckbox), userDataPropertySpace), pageInstanceCheckbox, 'it should not update checkbox check value if data does not match')
 
   t.end()
 })
@@ -83,15 +83,15 @@ test('When given a page to update that has controls that contain items', t => {
       }]
     }
   }
-  t.deepEqual(updateControlNames(cloneDeep(pageInstanceRadios), userDataPropertyEmpty), pageInstanceRadios, 'it should not update radio checked values if no data passed')
+  t.same(updateControlNames(cloneDeep(pageInstanceRadios), userDataPropertyEmpty), pageInstanceRadios, 'it should not update radio checked values if no data passed')
 
   const pageExpectedRadios = cloneDeep(pageInstanceRadios)
   pageExpectedRadios.x.items[0].checked = true
-  t.deepEqual(updateControlNames(cloneDeep(pageInstanceRadios), userDataPropertyHelloWorld), pageExpectedRadios, 'it should update radio checked values if passed data that matches')
+  t.same(updateControlNames(cloneDeep(pageInstanceRadios), userDataPropertyHelloWorld), pageExpectedRadios, 'it should update radio checked values if passed data that matches')
 
   const pageExpectedRadiosB = cloneDeep(pageInstanceRadios)
   pageExpectedRadiosB.x.items[1].checked = true
-  t.deepEqual(updateControlNames(cloneDeep(pageInstanceRadios), userDataPropertySpace), pageExpectedRadiosB, 'it should update radio checked values if passed data that matches - part 2')
+  t.same(updateControlNames(cloneDeep(pageInstanceRadios), userDataPropertySpace), pageExpectedRadiosB, 'it should update radio checked values if passed data that matches - part 2')
 
   const pageInstanceSelect = {
     x: {
@@ -105,14 +105,14 @@ test('When given a page to update that has controls that contain items', t => {
       }]
     }
   }
-  t.deepEqual(updateControlNames(cloneDeep(pageInstanceSelect), userDataPropertyEmpty), pageInstanceSelect, 'it should not update options selected values if no data passed')
+  t.same(updateControlNames(cloneDeep(pageInstanceSelect), userDataPropertyEmpty), pageInstanceSelect, 'it should not update options selected values if no data passed')
   const pageExpectedSelect = cloneDeep(pageInstanceSelect)
   pageExpectedSelect.x.items[0].selected = true
-  t.deepEqual(updateControlNames(cloneDeep(pageInstanceSelect), userDataPropertyHelloWorld), pageExpectedSelect, 'it should update option selected values if passed data that matches')
+  t.same(updateControlNames(cloneDeep(pageInstanceSelect), userDataPropertyHelloWorld), pageExpectedSelect, 'it should update option selected values if passed data that matches')
 
   const pageExpectedSelectB = cloneDeep(pageInstanceSelect)
   pageExpectedSelectB.x.items[1].selected = true
-  t.deepEqual(updateControlNames(cloneDeep(pageInstanceSelect), userDataPropertySpace), pageExpectedSelectB, 'it should update option selected values if passed data that matches - part 2')
+  t.same(updateControlNames(cloneDeep(pageInstanceSelect), userDataPropertySpace), pageExpectedSelectB, 'it should update option selected values if passed data that matches - part 2')
 
   t.end()
 })
@@ -136,7 +136,7 @@ test('When given a page to update that contains checkboxes without names', t => 
   }
   const expected = cloneDeep(pageInstanceCheckboxes)
   expected.x.name = 'foo'
-  t.deepEqual(updateControlNames(cloneDeep(pageInstanceCheckboxes), userDataPropertyEmpty), expected, 'it should set their name properties to their _id')
+  t.same(updateControlNames(cloneDeep(pageInstanceCheckboxes), userDataPropertyEmpty), expected, 'it should set their name properties to their _id')
 
   t.end()
 })
@@ -159,7 +159,7 @@ test('When given a page to update that contains checkboxes with names', t => {
     }
   }
   const expected = cloneDeep(pageInstanceCheckboxes)
-  t.deepEqual(updateControlNames(cloneDeep(pageInstanceCheckboxes), userDataPropertyEmpty), expected, 'it should leave hem alone')
+  t.same(updateControlNames(cloneDeep(pageInstanceCheckboxes), userDataPropertyEmpty), expected, 'it should leave hem alone')
 
   t.end()
 })

--- a/lib/page/validate-input/validate-input.unit.spec.js
+++ b/lib/page/validate-input/validate-input.unit.spec.js
@@ -130,12 +130,12 @@ test('When validating a page instance that has no errors', t => {
   validateInput(pageInstance, userData)
 
   const validateRequiredArgs = validateRequiredStub.validateRequired.getCall(0).args
-  t.deepEqual(validateRequiredArgs[0], pageInstance, 'it should pass the pageInstance to validateRequired method')
-  t.deepEqual(validateRequiredArgs[1], userData, 'it should pass the userData methods to validateRequired method')
+  t.same(validateRequiredArgs[0], pageInstance, 'it should pass the pageInstance to validateRequired method')
+  t.same(validateRequiredArgs[1], userData, 'it should pass the userData methods to validateRequired method')
 
   const validateValueArgs = validateValueStub.validateValue.getCall(0).args
-  t.deepEqual(validateValueArgs[0], pageInstance, 'it should pass the pageInstance to validateValue method')
-  t.deepEqual(validateValueArgs[1], userData, 'it should pass the userData methods to validateValue method')
+  t.same(validateValueArgs[0], pageInstance, 'it should pass the pageInstance to validateValue method')
+  t.same(validateValueArgs[1], userData, 'it should pass the userData methods to validateValue method')
 
   t.ok(setErrorsStub.setErrors.notCalled, 'it should not call setErrors method')
   t.end()
@@ -184,14 +184,14 @@ test('When validating a page instance that has no errors', t => {
   const validatedPage = validateInput(cloneDeep(pageInstance), userData)
   const setErrorsArgs = setErrorsStub.setErrors.getCall(0).args
 
-  t.deepEqual(setErrorsArgs[0], pageInstance, 'it should pass the pageInstance to the setErrors method')
+  t.same(setErrorsArgs[0], pageInstance, 'it should pass the pageInstance to the setErrors method')
 
-  t.deepEqual(setErrorsArgs[1], errorExample, 'it should pass the errors to the setErrors method')
+  t.same(setErrorsArgs[1], errorExample, 'it should pass the errors to the setErrors method')
 
-  t.deepEqual(validatedPage.someErrors, errorExample, 'it apply setErrors onto the page instance')
-  t.deepEqual(validatedPage.$hasErrors, true, 'it should set the $hasErrors property on the page instance')
+  t.same(validatedPage.someErrors, errorExample, 'it apply setErrors onto the page instance')
+  t.same(validatedPage.$hasErrors, true, 'it should set the $hasErrors property on the page instance')
 
-  t.deepEqual(getPageControllerStub.callCount, 2, 'getPageController should be invoked the correct number of times')
+  t.same(getPageControllerStub.callCount, 2, 'getPageController should be invoked the correct number of times')
 
   t.end()
 })
@@ -209,7 +209,7 @@ test('When getting the errors for an instance that is required', t => {
 
   const noErrors = validateInput.getInstanceError({}, {})
 
-  t.deepEqual(noErrors, undefined, 'it should return no errors')
+  t.same(noErrors, undefined, 'it should return no errors')
 
   t.end()
 })
@@ -240,8 +240,8 @@ test('When getting the errors for an instance that has an invalid value', t => {
 
   const componentInstance = validateInput(pageInstance, {})
 
-  t.deepEqual(setErrorsStub.setErrors.getCall(0).args, [{ components: [{ name: 'foo' }], $hasErrors: true, $validated: false }, [{ errorType: 'component', instance: 'foo' }]], 'it should invoke setErrors with the correct args')
-  t.deepEqual(componentInstance, { components: [{ name: 'foo' }], $hasErrors: true, $validated: false }, 'it should annotate the page instance with $hasErrors')
+  t.same(setErrorsStub.setErrors.getCall(0).args, [{ components: [{ name: 'foo' }], $hasErrors: true, $validated: false }, [{ errorType: 'component', instance: 'foo' }]], 'it should invoke setErrors with the correct args')
+  t.same(componentInstance, { components: [{ name: 'foo' }], $hasErrors: true, $validated: false }, 'it should annotate the page instance with $hasErrors')
 
   t.end()
 })
@@ -274,7 +274,7 @@ test('When getting the errors for a compoiste instance that has an invalid value
 
   const compositeInstance = validateInput(pageInstance, {})
 
-  t.deepEqual(compositeInstance.components[0].classes, 'baz govuk-input--error', 'it should add the error class without overriding any explicit value set for classes')
+  t.same(compositeInstance.components[0].classes, 'baz govuk-input--error', 'it should add the error class without overriding any explicit value set for classes')
 
   t.end()
 })
@@ -292,7 +292,7 @@ test('When getting the errors for an instance that is required', t => {
 
   const requiredErrors = validateInput.getInstanceError({ _id: 'required' }, {})
 
-  t.deepEqual(requiredErrors, [{ errorType: 'required' }], 'it should return required errors')
+  t.same(requiredErrors, [{ errorType: 'required' }], 'it should return required errors')
 
   t.end()
 })
@@ -310,7 +310,7 @@ test('When getting the errors for an instance that has an invalid value', t => {
 
   const valueErrors = validateInput.getInstanceError({}, {})
 
-  t.deepEqual(valueErrors, [{ errorType: 'value' }], 'it should return value errors')
+  t.same(valueErrors, [{ errorType: 'value' }], 'it should return value errors')
 
   t.end()
 })

--- a/lib/page/validate-input/validate-required/validate-required.unit.spec.js
+++ b/lib/page/validate-input/validate-required/validate-required.unit.spec.js
@@ -56,11 +56,11 @@ test('When validating a page instance which has a required control', t => {
       }
     }
   })
-  t.deepEqual(validateRequired(pageInstance, valueUserData).length, 0, 'it should not return an error if it has a value')
+  t.same(validateRequired(pageInstance, valueUserData).length, 0, 'it should not return an error if it has a value')
 
-  t.deepEqual(validateRequired(pageInstance, undefinedValueUserData).length, 1, 'it should return an error if it has no value')
+  t.same(validateRequired(pageInstance, undefinedValueUserData).length, 1, 'it should return an error if it has no value')
 
-  t.deepEqual(validateRequired(pageInstance, emptyValueUserData).length, 1, 'it should return an error if it has a value but that value is only white space')
+  t.same(validateRequired(pageInstance, emptyValueUserData).length, 1, 'it should return an error if it has a value but that value is only white space')
   getServiceSchemaStub.restore()
   t.end()
 })
@@ -88,7 +88,7 @@ test('When validating an instance which has no required controls', t => {
     }]
   }
 
-  t.deepEqual(validateRequired(notRequiredPageInstance, undefinedValueUserData).length, 0, 'it should not return an error if it has no value')
+  t.same(validateRequired(notRequiredPageInstance, undefinedValueUserData).length, 0, 'it should not return an error if it has no value')
   getServiceSchemaStub.restore()
   t.end()
 })
@@ -112,7 +112,7 @@ test('When validating a page instance containing a checkbox instance', t => {
   }]
   const pageInstance = {}
 
-  t.deepEqual(validateRequired(checkboxNameInstances, pageInstance, undefinedValueUserData).length, 0, 'it should not return an error')
+  t.same(validateRequired(checkboxNameInstances, pageInstance, undefinedValueUserData).length, 0, 'it should not return an error')
 
   getServiceSchemaStub.restore()
 
@@ -153,28 +153,28 @@ test('When validating a page containing a checkboxes instance', t => {
     }]
   }
 
-  t.deepEqual(validateRequired(pageInstance, undefinedValueUserData).length, 0, 'it should not return an error if the checkboxes instance is not required')
+  t.same(validateRequired(pageInstance, undefinedValueUserData).length, 0, 'it should not return an error if the checkboxes instance is not required')
 
   const requiredCheckboxPageInstance = cloneDeep(pageInstance)
   requiredCheckboxPageInstance.components[0].validation = { required: true }
 
-  t.deepEqual(validateRequired(requiredCheckboxPageInstance, undefinedValueUserData).length, 1, 'it should return an error if the checkboxes instance is required and none of its items have a value')
+  t.same(validateRequired(requiredCheckboxPageInstance, undefinedValueUserData).length, 1, 'it should return an error if the checkboxes instance is required and none of its items have a value')
 
   const valueUserData = getUserData({
     'test-b': 'yes-b'
   })
-  t.deepEqual(validateRequired(requiredCheckboxPageInstance, valueUserData).length, 0, 'it should return an error if the checkboxes instance is required and any of its items have a value')
+  t.same(validateRequired(requiredCheckboxPageInstance, valueUserData).length, 0, 'it should return an error if the checkboxes instance is required and any of its items have a value')
 
   const wrongValueUserData = getUserData({
     'test-b': 'yes-c'
   })
-  t.deepEqual(validateRequired(requiredCheckboxPageInstance, wrongValueUserData).length, 1, 'it should return an error if the checkboxes instance is required and any of its items have a value ')
+  t.same(validateRequired(requiredCheckboxPageInstance, wrongValueUserData).length, 1, 'it should return an error if the checkboxes instance is required and any of its items have a value ')
 
   const testUserData = getUserData({
     'test-d': 'default-checkbox-val'
   })
 
-  t.deepEqual(validateRequired(requiredCheckboxPageInstance, testUserData).length, 0, 'it should not throw an error and it should use schema-provided default values when no checkbox value is provided')
+  t.same(validateRequired(requiredCheckboxPageInstance, testUserData).length, 0, 'it should not throw an error and it should use schema-provided default values when no checkbox value is provided')
 
   getServiceSchemaStub.restore()
   t.end()
@@ -204,7 +204,7 @@ test('When validating instances that have hard-coded required values from their 
     }
   })
   const expected = []
-  t.deepEqual(validateRequired(nameInstances, userData), expected, 'it should return no errors when validating a valid instance')
+  t.same(validateRequired(nameInstances, userData), expected, 'it should return no errors when validating a valid instance')
 
   getServiceSchemaStub.restore()
   t.end()
@@ -264,7 +264,7 @@ test('When checking whether a valid instance has an error', t => {
 
   const expected = []
 
-  t.deepEqual(validatedInstance, expected, 'it should return an empty array')
+  t.same(validatedInstance, expected, 'it should return an empty array')
   getServiceSchemaStub.restore()
   t.end()
 })
@@ -315,7 +315,7 @@ test('When checking whether an instance is required', t => {
     name: 'test-a'
   }
   const buttonRequired = isRequired(buttonInstance, userData)
-  t.deepEqual(buttonRequired, false, 'it should always return false for buttons')
+  t.same(buttonRequired, false, 'it should always return false for buttons')
 
   t.end()
 })

--- a/lib/page/validate-input/validate-value/validate-value.unit.spec.js
+++ b/lib/page/validate-input/validate-value/validate-value.unit.spec.js
@@ -25,7 +25,7 @@ test('When validating instances which are valid', t => {
     'test-a': 'ok'
   })
   const expected = []
-  t.deepEqual(validateValue(nameInstances, userData), expected, 'it should return no errors')
+  t.same(validateValue(nameInstances, userData), expected, 'it should return no errors')
   t.end()
 })
 
@@ -38,8 +38,8 @@ test('When validating instances that have no value', t => {
   const undefinedUserData = getUserData({})
   const emptyUserData = getUserData({ 'test-a': '' })
   const expected = []
-  t.deepEqual(validateValue(nameInstances, undefinedUserData), expected, 'it should return no errors if the value is undefined')
-  t.deepEqual(validateValue(nameInstances, emptyUserData), expected, 'it should return no errors if the value is an empty string')
+  t.same(validateValue(nameInstances, undefinedUserData), expected, 'it should return no errors if the value is undefined')
+  t.same(validateValue(nameInstances, emptyUserData), expected, 'it should return no errors if the value is an empty string')
   t.end()
 })
 
@@ -55,7 +55,7 @@ test('When validating instances which are not valid', t => {
   const errors = validateValue(nameInstances, userData)
   const expected = [{ instance: nameInstances[0], errorType: 'type', error: { property: 'instance', message: 'is not of a type(s) string', schema: { type: 'string' }, instance: 10, name: 'type', argument: ['string'], stack: 'instance is not of a type(s) string' } }]
 
-  t.deepEqual(JSON.stringify(errors), JSON.stringify(expected), 'it should return expected errors')
+  t.same(JSON.stringify(errors), JSON.stringify(expected), 'it should return expected errors')
   t.end()
 })
 
@@ -70,7 +70,7 @@ test('When validating instances which are numbers', t => {
   })
   const errors = validateValue(nameInstances, userData)
 
-  t.deepEqual(errors.length, 1, 'it should return expected errors')
+  t.same(errors.length, 1, 'it should return expected errors')
   t.end()
 })
 
@@ -85,7 +85,7 @@ test('When validating instances which already have error set', t => {
     'test-a': 'ok'
   })
   const expected = []
-  t.deepEqual(validateValue(nameInstances, userData), expected, 'it should return no errors')
+  t.same(validateValue(nameInstances, userData), expected, 'it should return no errors')
   t.end()
 })
 
@@ -98,7 +98,7 @@ test('When validating instances which have no validation', t => {
   }]
   const userData = getUserData({})
   const expected = []
-  t.deepEqual(validateValue(nameInstances, userData), expected, 'it should return no errors')
+  t.same(validateValue(nameInstances, userData), expected, 'it should return no errors')
   t.end()
 })
 
@@ -113,7 +113,7 @@ test('When validating instances which only have required validation', t => {
   }]
   const userData = getUserData({})
   const expected = []
-  t.deepEqual(validateValue(nameInstances, userData), expected, 'it should return no errors')
+  t.same(validateValue(nameInstances, userData), expected, 'it should return no errors')
   t.end()
 })
 
@@ -138,7 +138,7 @@ test('When validating instances that have hard-coded validation values from thei
     }
   })
   const expected = []
-  t.deepEqual(validateValue(nameInstances, userData), expected, 'it should return no errors when validating a valid instance')
+  t.same(validateValue(nameInstances, userData), expected, 'it should return no errors when validating a valid instance')
   t.notDeepEqual(validateValue(nameInstances, failingUserData), expected, 'it should return errors when validating an ivalid instance')
 
   getServiceSchemaStub.restore()
@@ -154,7 +154,7 @@ test('When validating instances which have a $originalName property', t => {
   }]
   const userData = getUserData({})
   const expected = []
-  t.deepEqual(validateValue(nameInstances, userData), expected, 'it should return no errors')
+  t.same(validateValue(nameInstances, userData), expected, 'it should return no errors')
   t.end()
 })
 
@@ -166,7 +166,7 @@ test('When validating upload instances', t => {
   }]
   const userData = getUserData({})
   const expected = []
-  t.deepEqual(validateValue(nameInstances, userData), expected, 'it should return no errors')
+  t.same(validateValue(nameInstances, userData), expected, 'it should return no errors')
   t.end()
 })
 
@@ -181,7 +181,7 @@ test('When validating instances that only need required validation', t => {
   }]
   const userData = getUserData({})
   const expected = []
-  t.deepEqual(validateValue(nameInstances, userData), expected, 'it should return no errors')
+  t.same(validateValue(nameInstances, userData), expected, 'it should return no errors')
   t.end()
 })
 
@@ -198,7 +198,7 @@ test('When checking whether an invalid instance has an error', t => {
 
   const expected = [{ instance: { _id: 'a', _type: 'text', name: 'test-a', validation: { type: 'string' } }, errorType: 'type', error: { property: 'instance', message: 'is not of a type(s) string', schema: { type: 'string' }, instance: 10, name: 'type', argument: ['string'], stack: 'instance is not of a type(s) string' } }]
 
-  t.deepEqual(JSON.stringify(validatedInstance), JSON.stringify(expected), 'it should return an array containing the errors relating to the instance')
+  t.same(JSON.stringify(validatedInstance), JSON.stringify(expected), 'it should return an array containing the errors relating to the instance')
   t.end()
 })
 
@@ -215,6 +215,6 @@ test('When checking whether a valid instance has an error', t => {
 
   const expected = []
 
-  t.deepEqual(validatedInstance, expected, 'it should return an empty array')
+  t.same(validatedInstance, expected, 'it should return an empty array')
   t.end()
 })

--- a/lib/presenter/pdf-payload.transformers.unit.spec.js
+++ b/lib/presenter/pdf-payload.transformers.unit.spec.js
@@ -13,31 +13,31 @@ const {
 } = require('./pdf-payload.transformers')
 
 test('An answer is an object', (t) => {
-  t.equals(isObject({}), true, 'returns true when the argument is an object')
+  t.equal(isObject({}), true, 'returns true when the argument is an object')
 
   t.end()
 })
 
 test('An answer is not an object', (t) => {
-  t.equals(isObject(), false, 'returns false when the argument is undefined (or no argument is supplied)')
+  t.equal(isObject(), false, 'returns false when the argument is undefined (or no argument is supplied)')
 
-  t.equals(isObject(null), false, 'returns false when the argument is null')
+  t.equal(isObject(null), false, 'returns false when the argument is null')
 
-  t.equals(isObject(true), false, 'returns false when the argument is a boolean')
+  t.equal(isObject(true), false, 'returns false when the argument is a boolean')
 
-  t.equals(isObject(1), false, 'returns false when the argument is a number')
+  t.equal(isObject(1), false, 'returns false when the argument is a number')
 
-  t.equals(isObject('A'), false, 'returns false when the argument is a string')
+  t.equal(isObject('A'), false, 'returns false when the argument is a string')
 
   t.end()
 })
 
 test('A collection contains an answer with the `groupBy` field', (t) => {
-  t.equals([{ groupBy: 'group-id' }].some(hasGroup('group-id')), true, 'returns true when the group is found')
+  t.equal([{ groupBy: 'group-id' }].some(hasGroup('group-id')), true, 'returns true when the group is found')
 
-  t.equals([{ groupBy: 'not-group-id' }].some(hasGroup('group-id')), false, 'returns false when the group is not found')
+  t.equal([{ groupBy: 'not-group-id' }].some(hasGroup('group-id')), false, 'returns false when the group is not found')
 
-  t.equals([].some(hasGroup('group-id')), false, 'returns false when the group is not found because the collection is empty')
+  t.equal([].some(hasGroup('group-id')), false, 'returns false when the group is not found because the collection is empty')
 
   t.end()
 })
@@ -67,7 +67,7 @@ test('Aggregating the group', (t) => {
     }
   }
 
-  t.deepEqual(aggregateGroup(accumulator, current), expected, 'returns the aggregated group (with appended values)')
+  t.same(aggregateGroup(accumulator, current), expected, 'returns the aggregated group (with appended values)')
 
   t.end()
 })
@@ -119,7 +119,7 @@ test('Aggregating the group when it has not been encountered before', (t) => {
 
   t.type(accumulatorStub.concat.firstCall.args[0], Object, 'calls `concat` on the collection (to append an object)')
 
-  t.equals(result, array, 'returns from `accumulator.concat()`')
+  t.equal(result, array, 'returns from `accumulator.concat()`')
 
   t.end()
 })
@@ -157,7 +157,7 @@ test('Transforming the group when it contains one answer', (t) => {
     }
   }
 
-  t.deepEqual(transformGroup(answer, groupStub), expected, 'returns the one answer untransformed')
+  t.same(transformGroup(answer, groupStub), expected, 'returns the one answer untransformed')
 
   t.end()
 })
@@ -190,7 +190,7 @@ test('Transforming the group when it contains more than one answer', (t) => {
     }
   }
 
-  t.deepEqual(transformGroup(answer, groupStub), expected, 'returns the transformed group')
+  t.same(transformGroup(answer, groupStub), expected, 'returns the transformed group')
 
   t.end()
 })

--- a/lib/presenter/pdf-payload.unit.spec.js
+++ b/lib/presenter/pdf-payload.unit.spec.js
@@ -220,6 +220,6 @@ const payload = {
 }
 
 test('creates a presentable payload', function (t) {
-  t.deepEqual(pdfPayload(payload), expectedPayload, 'it should present the formbuilder payload')
+  t.same(pdfPayload(payload), expectedPayload, 'it should present the formbuilder payload')
   t.end()
 })

--- a/lib/route/route.unit.spec.js
+++ b/lib/route/route.unit.spec.js
@@ -310,7 +310,7 @@ test('When matching a url against registered page instances', t => {
 
   checkUrls.forEach(url => {
     if (!url.skipGetData) {
-      t.deepEqual(JSON.stringify(routeMethods.getData(url.url)), JSON.stringify(url.data), url.description)
+      t.same(JSON.stringify(routeMethods.getData(url.url)), JSON.stringify(url.data), url.description)
     }
   })
 
@@ -323,7 +323,7 @@ test('When creating a url for a page instance', t => {
   checkUrls.forEach(url => {
     const data = url.input || url.data
     if (data !== NOTFOUND && !url.skipGetUrl) {
-      t.deepEqual(routeMethods.getUrl(data.route, data.params, data.lang), url.url, url.description)
+      t.same(routeMethods.getUrl(data.route, data.params, data.lang), url.url, url.description)
     }
   })
 
@@ -336,7 +336,7 @@ test('When creating a url for a page instance', t => {
 test('When matching routes with a baseUrl', t => {
   const routeMethods = route.init(urlInstances, '/prefix')
 
-  t.deepEqual(routeMethods.getData('/a'), { route: 'a' }, 'it should return the correct data')
+  t.same(routeMethods.getData('/a'), { route: 'a' }, 'it should return the correct data')
   t.equal(routeMethods.getUrl('a', {}), '/prefix/a', 'it should return correctly prefixed urls')
   t.equal(routeMethods.getUrl('z', {}), undefined, 'it should return undefined if the page instance does not exist')
 
@@ -453,7 +453,7 @@ tests.forEach(nextTest => {
         testMessage = `it should not go forward from ${input._id}`
       }
 
-      t.deepEqual(actualOutput, output, testMessage)
+      t.same(actualOutput, output, testMessage)
     }
     if (output && !noReverse) {
       let testMessage
@@ -468,7 +468,7 @@ tests.forEach(nextTest => {
         testMessage = `it should go back from ${output._id} to ${input._id}${skipMessage}`
       }
 
-      t.deepEqual(actualOutput, input, testMessage)
+      t.same(actualOutput, input, testMessage)
     }
     t.end()
   })

--- a/lib/server/server-init.unit.spec.js
+++ b/lib/server/server-init.unit.spec.js
@@ -43,10 +43,10 @@ test('When setting up the runner', async t => {
   const nunjucksConfigurationInitStubArgs = nunjucksConfigurationInitStub.getCall(0).args
   const getRouterStubArgs = getRouterStub.getCall(0).args
 
-  t.deepEqual(configureSourcesStubArgs, [options], 'it should pass the correct args to configureSources')
-  t.deepEqual(loadSourcesStubArgs, [serviceSources, options], 'it should pass the correct args to loadSources')
-  t.deepEqual(nunjucksConfigurationInitStubArgs, [app, serviceSources, options], 'it should pass the correct args to nunjucksConfiguration.init')
-  t.deepEqual(getRouterStubArgs, [{
+  t.same(configureSourcesStubArgs, [options], 'it should pass the correct args to configureSources')
+  t.same(loadSourcesStubArgs, [serviceSources, options], 'it should pass the correct args to loadSources')
+  t.same(nunjucksConfigurationInitStubArgs, [app, serviceSources, options], 'it should pass the correct args to nunjucksConfiguration.init')
+  t.same(getRouterStubArgs, [{
     foo: 'bar',
     schemas,
     serviceData,

--- a/lib/server/server-listen.unit.spec.js
+++ b/lib/server/server-listen.unit.spec.js
@@ -57,7 +57,7 @@ test('Starting the server', async (t) => {
 test('Resolving the promise', async (t) => {
   listenStub.resetHistory()
 
-  t.deepEqual(await listenServer(app, { PORT: 3000 }), {
+  t.same(await listenServer(app, { PORT: 3000 }), {
     server: 'server',
     app
   }, 'resolves with an object containing the server and the app instance')
@@ -71,7 +71,7 @@ test('Rejecting the promise', async (t) => {
   try {
     await listenServer(errorApp, { PORT: 3000 })
   } catch (error) {
-    t.deepEqual(error, 'error', 'rejects with an object containing the error')
+    t.same(error, 'error', 'rejects with an object containing the error')
   }
 
   t.end()
@@ -85,7 +85,7 @@ test('Starting the server with a callback function', async (t) => {
     callback: (e, result) => {
       t.notOk(e, 'does not call the callback with an error')
 
-      t.deepEqual(result, {
+      t.same(result, {
         server: 'server',
         app
       }, 'calls the callback with an object containing the server and the app instance')
@@ -102,13 +102,13 @@ test('Starting the server with a callback function and an error is thrown', asyn
     await listenServer(errorApp, {
       PORT: 3000,
       callback: (e, result) => {
-        t.deepEqual(e, 'error', 'calls the callback with an error')
+        t.same(e, 'error', 'calls the callback with an error')
 
         t.ok(result, 'calls the callback with a result')
       }
     })
   } catch (error) {
-    t.deepEqual(error, 'error', 'rejects with an object containing the error')
+    t.same(error, 'error', 'rejects with an object containing the error')
   }
 
   t.end()

--- a/lib/server/server-monitoring.unit.spec.js
+++ b/lib/server/server-monitoring.unit.spec.js
@@ -71,8 +71,8 @@ test('When configuring the server monitoring and a sentry DSN is passed (excepti
   const eventWithRequest = beforeSend({ request: {} })
 
   t.equal(typeof beforeSend, 'function', 'it should pass a beforeSend method to sanitise request data')
-  t.deepEqual(eventWithoutRequest, {}, 'it should leave events without request objects alone')
-  t.deepEqual(eventWithRequest, { request: 'XXXX' }, 'it should sanitise request objects')
+  t.same(eventWithoutRequest, {}, 'it should leave events without request objects alone')
+  t.same(eventWithRequest, { request: 'XXXX' }, 'it should sanitise request objects')
 
   const sentryConfigureScopeFn = sentryConfigureScopeStub.getCall(0).args[0]
   const scope = {
@@ -81,9 +81,9 @@ test('When configuring the server monitoring and a sentry DSN is passed (excepti
   const scopeSetExtraStub = stub(scope, 'setExtra')
   sentryConfigureScopeFn(scope)
 
-  t.deepEqual(scopeSetExtraStub.getCall(0).args, ['PLATFORM_ENV', 'platformEnv'], 'it should set the PLATFORM_ENV scope')
-  t.deepEqual(scopeSetExtraStub.getCall(1).args, ['DEPLOYMENT_ENV', 'deploymentEnv'], 'it should set the DEPLOYMENT_ENV scope')
-  t.deepEqual(scopeSetExtraStub.getCall(2).args, ['SERVICE_SLUG', 'serviceSlug'], 'it should set the SERVICE_SLUG scope')
+  t.same(scopeSetExtraStub.getCall(0).args, ['PLATFORM_ENV', 'platformEnv'], 'it should set the PLATFORM_ENV scope')
+  t.same(scopeSetExtraStub.getCall(1).args, ['DEPLOYMENT_ENV', 'deploymentEnv'], 'it should set the DEPLOYMENT_ENV scope')
+  t.same(scopeSetExtraStub.getCall(2).args, ['SERVICE_SLUG', 'serviceSlug'], 'it should set the SERVICE_SLUG scope')
 
   t.end()
 })
@@ -97,7 +97,7 @@ test('When configuring the server monitoring (metrics)', t => {
 
   t.ok(metricsInitStub.called, 'it should initialise the metrics client')
   t.equal(metricsInitStubArgs[0], app, 'it should pass the app to the metrics init method')
-  t.deepEqual(metricsInitStubArgs[1], {
+  t.same(metricsInitStubArgs[1], {
     defaultLabels: {
       PLATFORM_ENV: 'platformEnv',
       DEPLOYMENT_ENV: 'deploymentEnv',
@@ -116,7 +116,7 @@ test('When configuring the server monitoring (logger)', t => {
   const loggerInitStubArgs = loggerInitStub.getCall(0).args
 
   t.ok(loggerInitStub.called, 'it should initialise the logger client')
-  t.deepEqual(loggerInitStubArgs[0], {
+  t.same(loggerInitStubArgs[0], {
     LOG_LEVEL: 'feverish',
     PLATFORM_ENV: 'platformEnv',
     DEPLOYMENT_ENV: 'deploymentEnv',

--- a/lib/server/server-router.unit.spec.js
+++ b/lib/server/server-router.unit.spec.js
@@ -32,12 +32,12 @@ test('When getting the server router', t => {
   const router = getRouter(options)
 
   t.ok(configureMiddlewareStub.calledOnce, 'it should initialise the runner middleware once')
-  t.deepEqual(configureMiddlewareStub.getCall(0).args, [options], 'it should call configureMiddleware with the expected args')
+  t.same(configureMiddlewareStub.getCall(0).args, [options], 'it should call configureMiddleware with the expected args')
 
   const useCalls = useStub.getCalls()
   t.equal(useCalls.length, 2, 'it should use the expected number of middleware functions')
-  t.deepEqual(useCalls[0].args, ['middleware_a'], 'it should call use with the expected args if passed a function')
-  t.deepEqual(useCalls[1].args, ['/route-b', 'middleware_b'], 'it should call use with the expected args if passed a route and a function')
+  t.same(useCalls[0].args, ['middleware_a'], 'it should call use with the expected args if passed a function')
+  t.same(useCalls[1].args, ['/route-b', 'middleware_b'], 'it should call use with the expected args if passed a route and a function')
 
   t.equal(router, routerInstance, 'it should return the expected router instance')
 

--- a/lib/server/server.unit.spec.js
+++ b/lib/server/server.unit.spec.js
@@ -56,22 +56,22 @@ test('When starting the server', async t => {
 
   t.ok(configureMonitoringStub.calledOnce, 'it should set up monitoring')
   const monitorArgs = configureMonitoringStub.getCall(0).args
-  t.deepEqual(monitorArgs[0], app, 'it should pass the app to the monitoring setup method')
-  t.deepEqual(monitorArgs[1].APP_DIR, '/appdir/constants', 'it should pass through constants to the monitoring setup method')
+  t.same(monitorArgs[0], app, 'it should pass the app to the monitoring setup method')
+  t.same(monitorArgs[1].APP_DIR, '/appdir/constants', 'it should pass through constants to the monitoring setup method')
 
   t.ok(initRunnerStub.calledOnce, 'it should create the runner instance')
   const initRunnerArgs = initRunnerStub.getCall(0).args
-  t.deepEqual(initRunnerArgs[0], app, 'it should pass the app to the initRunner method')
-  t.deepEqual(initRunnerArgs[1].APP_DIR, '/appdir/constants', 'it should pass through constants to the initRunner method')
+  t.same(initRunnerArgs[0], app, 'it should pass the app to the initRunner method')
+  t.same(initRunnerArgs[1].APP_DIR, '/appdir/constants', 'it should pass through constants to the initRunner method')
 
   t.ok(appUseStub.calledOnce, 'it should mount the runner instance')
   const useArgs = appUseStub.getCall(0).args
-  t.deepEqual(useArgs[0], runnerInstance, 'it should pass runner instance to express use method')
+  t.same(useArgs[0], runnerInstance, 'it should pass runner instance to express use method')
 
   t.ok(listenServerStub.calledOnce, 'it should start the runner server')
   const listenServerArgs = listenServerStub.getCall(0).args
-  t.deepEqual(listenServerArgs[0], app, 'it should pass the app to the listenServer method')
-  t.deepEqual(listenServerArgs[1].APP_DIR, '/appdir/constants', 'it should pass through constants to the listenServer method')
+  t.same(listenServerArgs[0], app, 'it should pass the app to the listenServer method')
+  t.same(listenServerArgs[1].APP_DIR, '/appdir/constants', 'it should pass through constants to the listenServer method')
 
   t.end()
 })
@@ -82,13 +82,13 @@ test('When starting the server with custom options', async t => {
   await server.start({ APP_DIR: '/appdir/options' })
 
   const monitorArgs = configureMonitoringStub.getCall(0).args
-  t.deepEqual(monitorArgs[1].APP_DIR, '/appdir/options', 'it should override default constants values passed to monitoring setup method with those defined in custom options')
+  t.same(monitorArgs[1].APP_DIR, '/appdir/options', 'it should override default constants values passed to monitoring setup method with those defined in custom options')
 
   const initRunnerArgs = initRunnerStub.getCall(0).args
-  t.deepEqual(initRunnerArgs[1].APP_DIR, '/appdir/options', 'it should override default constants values passed to initRunner method with those defined in custom options')
+  t.same(initRunnerArgs[1].APP_DIR, '/appdir/options', 'it should override default constants values passed to initRunner method with those defined in custom options')
 
   const listenServerArgs = listenServerStub.getCall(0).args
-  t.deepEqual(listenServerArgs[1].APP_DIR, '/appdir/options', 'it should override default constants values passed to listenServer method with those defined in custom options')
+  t.same(listenServerArgs[1].APP_DIR, '/appdir/options', 'it should override default constants values passed to listenServer method with those defined in custom options')
 
   t.end()
 })

--- a/lib/server/sources/configure/sources-configure-dependencies.unit.spec.js
+++ b/lib/server/sources/configure/sources-configure-dependencies.unit.spec.js
@@ -70,7 +70,7 @@ test('When determining the sources for a form with a single dependency', t => {
 
   const serviceSources = configureDependencies('service_package_path', 'service_node_modules_path')
 
-  t.deepEqual(serviceSources, [{ source: 'base_components', sourcePath: 'service_node_modules_path/base_components' }], 'it should return the dependency for the service')
+  t.same(serviceSources, [{ source: 'base_components', sourcePath: 'service_node_modules_path/base_components' }], 'it should return the dependency for the service')
 
   t.end()
 })
@@ -96,7 +96,7 @@ test('When determining the sources for a form with nested dependencies', t => {
 
   const serviceSources = configureDependencies('service_package_path', 'service_node_modules_path')
 
-  t.deepEqual(serviceSources, [{ source: 'nested_components', sourcePath: 'service_node_modules_path/nested_components' }, { source: 'base_components', sourcePath: 'service_node_modules_path/base_components' }], 'it should return the dependencies for the service in the correct order')
+  t.same(serviceSources, [{ source: 'nested_components', sourcePath: 'service_node_modules_path/nested_components' }, { source: 'base_components', sourcePath: 'service_node_modules_path/base_components' }], 'it should return the dependencies for the service in the correct order')
 
   t.end()
 })
@@ -119,7 +119,7 @@ test('When determining the sources for a form with multiple dependencies', t => 
 
   const serviceSources = configureDependencies('service_package_path', 'service_node_modules_path')
 
-  t.deepEqual(serviceSources, [{ source: 'other_components', sourcePath: 'service_node_modules_path/other_components' }, { source: 'base_components', sourcePath: 'service_node_modules_path/base_components' }], 'it should return the dependencies for the service in the correct order')
+  t.same(serviceSources, [{ source: 'other_components', sourcePath: 'service_node_modules_path/other_components' }, { source: 'base_components', sourcePath: 'service_node_modules_path/base_components' }], 'it should return the dependencies for the service in the correct order')
 
   t.end()
 })
@@ -150,7 +150,7 @@ test('When determining the sources for a form containing a dependency specified 
 
   const serviceSources = configureDependencies('service_package_path', 'service_node_modules_path')
 
-  t.deepEqual(serviceSources, [{ source: 'nested_components_a', sourcePath: 'service_node_modules_path/nested_components_a' }, { source: 'other_components', sourcePath: 'service_node_modules_path/other_components' }, { source: 'base_components', sourcePath: 'service_node_modules_path/base_components' }], 'it should return the dependencies for the service in the correct order and with any duplicated sources filtered out')
+  t.same(serviceSources, [{ source: 'nested_components_a', sourcePath: 'service_node_modules_path/nested_components_a' }, { source: 'other_components', sourcePath: 'service_node_modules_path/other_components' }, { source: 'base_components', sourcePath: 'service_node_modules_path/base_components' }], 'it should return the dependencies for the service in the correct order and with any duplicated sources filtered out')
 
   t.end()
 })
@@ -209,7 +209,7 @@ test('When overriding the path for a dependency source', t => {
   const serviceSources = configureDependencies('service_package_path', 'service_node_modules_path')
   process.env.MODULE__scope_base_components = ''
 
-  t.deepEqual(serviceSources, [{ source: '@scope/other-components', sourcePath: 'service_node_modules_path/@scope/other-components' }, { source: '@scope/base-components', sourcePath: 'overridden_path' }], 'it should return the dependencies for the service with the dependency path overridden')
+  t.same(serviceSources, [{ source: '@scope/other-components', sourcePath: 'service_node_modules_path/@scope/other-components' }, { source: '@scope/base-components', sourcePath: 'overridden_path' }], 'it should return the dependencies for the service with the dependency path overridden')
 
   t.end()
 })

--- a/lib/server/sources/configure/sources-configure-modules.unit.spec.js
+++ b/lib/server/sources/configure/sources-configure-modules.unit.spec.js
@@ -120,10 +120,10 @@ test('The service has no config.modules.json and no modules are enabled', t => {
 
   const serviceSources = configureModules('missing/service_config_path', 'runner_dir')
 
-  t.deepEqual(serviceSources, [], 'it should return no service sources')
+  t.same(serviceSources, [], 'it should return no service sources')
   t.ok(writeFileSyncStub.calledOnce, 'it should update config.modules.json')
-  t.deepEqual(writeFileSyncStub.getCall(0).args[0], 'missing/service_config_path/config.modules.json', 'it should write the update config to the correct location')
-  t.deepEqual(JSON.parse(writeFileSyncStub.getCall(0).args[1]), defaultModulesConfigContent, 'it should update the update config with the correct content')
+  t.same(writeFileSyncStub.getCall(0).args[0], 'missing/service_config_path/config.modules.json', 'it should write the update config to the correct location')
+  t.same(JSON.parse(writeFileSyncStub.getCall(0).args[1]), defaultModulesConfigContent, 'it should update the update config with the correct content')
 
   t.end()
 })
@@ -133,9 +133,9 @@ test('The service has a config.modules.json but no modules are recorded in it', 
 
   const serviceSources = configureModules('exists/service_config_path', 'runner_dir')
 
-  t.deepEqual(serviceSources, [], 'it should return no service sources')
+  t.same(serviceSources, [], 'it should return no service sources')
   t.ok(writeFileSyncStub.calledOnce, 'it should update config.modules.json')
-  t.deepEqual(JSON.parse(writeFileSyncStub.getCall(0).args[1]), defaultModulesConfigContent, 'it should update the update config with the correct content')
+  t.same(JSON.parse(writeFileSyncStub.getCall(0).args[1]), defaultModulesConfigContent, 'it should update the update config with the correct content')
 
   t.end()
 })
@@ -145,7 +145,7 @@ test('The service has a config.modules.json and all the modules are recorded in 
 
   const serviceSources = configureModules('registered/service_config_path', 'runner_dir')
 
-  t.deepEqual(serviceSources, [{ source: 'module:module_a', sourcePath: 'runner_dir/lib/module/module_a', module: 'module_a' }], 'it should add enabled modules to service sources')
+  t.same(serviceSources, [{ source: 'module:module_a', sourcePath: 'runner_dir/lib/module/module_a', module: 'module_a' }], 'it should add enabled modules to service sources')
   t.ok(writeFileSyncStub.notCalled, 'it should not update config.modules.json')
 
   t.end()
@@ -161,9 +161,9 @@ test('The service has a config.modules.json recording modules that do not exist'
 
   const serviceSources = configureModules('additional/service_config_path', 'runner_dir')
 
-  t.deepEqual(serviceSources, [{ source: 'module:module_a', sourcePath: 'runner_dir/lib/module/module_a', module: 'module_a' }], 'it should not add modules to service sources if the modules do not exist even if enabled')
+  t.same(serviceSources, [{ source: 'module:module_a', sourcePath: 'runner_dir/lib/module/module_a', module: 'module_a' }], 'it should not add modules to service sources if the modules do not exist even if enabled')
   t.ok(writeFileSyncStub.calledOnce, 'it should update config.modules.json')
-  t.deepEqual(JSON.parse(writeFileSyncStub.getCall(0).args[1]), expectedModulesConfigContent, 'it should update the update config with the correct content')
+  t.same(JSON.parse(writeFileSyncStub.getCall(0).args[1]), expectedModulesConfigContent, 'it should update the update config with the correct content')
 
   t.end()
 })

--- a/lib/server/sources/load/sources-load-metadata.unit.spec.js
+++ b/lib/server/sources/load/sources-load-metadata.unit.spec.js
@@ -40,11 +40,11 @@ test('When loading metadata from the sources provided', async t => {
   const setServiceSourcesStubArgs = setServiceSourcesStub.getCall(0).args[0]
 
   t.ok(setServiceSourcesStub.calledOnce, 'it should set the metadata locations')
-  t.deepEqual(setServiceSourcesStubArgs, [{ source: 'a', path: '/exists/a/metadata' }], 'it should only register locations to load metadata from that exist')
+  t.same(setServiceSourcesStubArgs, [{ source: 'a', path: '/exists/a/metadata' }], 'it should only register locations to load metadata from that exist')
 
   t.ok(loadServiceDataStub.calledOnce, 'it should load the metadata')
 
-  t.deepEqual(data, 'serviceData', 'it should return the loaded metadata')
+  t.same(data, 'serviceData', 'it should return the loaded metadata')
 
   t.end()
 })

--- a/lib/server/sources/load/sources-load-schemas.unit.spec.js
+++ b/lib/server/sources/load/sources-load-schemas.unit.spec.js
@@ -78,7 +78,7 @@ test('When loading schemas from provided sources', async t => {
   t.equal(loadJsonFileSyncStub.getCall(0).args[0], path.join(serviceSources[0].sourcePath, 'package.json'), 'it should use the correct path to attempt to load the package.json')
 
   t.ok(schemaUtilsStub.calledOnce, 'it should set the schema locations')
-  t.deepEqual(schemaUtilsStubArgs, [{ $idRoot: 'http://schema', path: '/idroot/a' }], 'it should only register locations to load schema from that exist and have a defined $idRoot property')
+  t.same(schemaUtilsStubArgs, [{ $idRoot: 'http://schema', path: '/idroot/a' }], 'it should only register locations to load schema from that exist and have a defined $idRoot property')
   t.ok(schemaUtilsLoadStub.calledOnce, 'it should load the schemas')
   t.equal(schemas, 'schemas', 'it should return the loaded schemas')
 

--- a/lib/server/sources/sources-configure.unit.spec.js
+++ b/lib/server/sources/sources-configure.unit.spec.js
@@ -55,9 +55,9 @@ test('When configuring sources', async t => {
   const { serviceSources } = await configureSources(defaultArgs)
 
   t.ok(configureModulesStub.calledOnce, 'it should determine any module')
-  t.deepEqual(configureModulesStub.getCall(0).args, ['/service_path/metadata/config', '/runner_dir'], 'it should call configureModules with the correct args')
+  t.same(configureModulesStub.getCall(0).args, ['/service_path/metadata/config', '/runner_dir'], 'it should call configureModules with the correct args')
 
-  t.deepEqual(serviceSources, [
+  t.same(serviceSources, [
     { source: 'govuk-frontend', sourcePath: path.resolve(process.env.PWD, 'node_modules/govuk-frontend/govuk') },
     { source: '@ministryofjustice/fb-components', sourcePath: path.resolve(process.env.PWD, 'node_modules/@ministryofjustice/fb-components') },
     { source: 'app', sourcePath: '/app_dir' },

--- a/lib/server/sources/sources-load.unit.spec.js
+++ b/lib/server/sources/sources-load.unit.spec.js
@@ -23,7 +23,7 @@ test('When loading sources', async (t) => {
   t.ok(loadSchemasStub.calledOnceWithExactly(serviceSources), 'it should use the service sources to load the schemas')
   t.ok(loadMetadataStub.calledOnceWithExactly(serviceSources), 'it should use the service sources to load the metadata')
 
-  t.deepEqual(result, { schemas, serviceData }, 'it should return the loaded schemas and service data')
+  t.same(result, { schemas, serviceData }, 'it should return the loaded schemas and service data')
 
   t.end()
 })

--- a/lib/service-data/runtime/get-runtime-data.unit.spec.js
+++ b/lib/service-data/runtime/get-runtime-data.unit.spec.js
@@ -67,7 +67,7 @@ test('Transforming the edit-time instances into run-time instances', async (t) =
   t.ok(injectRepeatablePagesInjectSub.calledWith(mockPropagateShowInstances), 'calls inject')
   t.ok(internationalizeRoutesi18nUrlsStub.calledWith(mockRepeatableInstances), 'calls i18nUrls')
 
-  t.deepEqual(runtimeData, expected, 'transforms the source instances')
+  t.same(runtimeData, expected, 'transforms the source instances')
 
   t.end()
 })

--- a/lib/service-data/runtime/load-json.unit.spec.js
+++ b/lib/service-data/runtime/load-json.unit.spec.js
@@ -74,9 +74,9 @@ test('When no source property is passed', function (t) {
       path: path1
     }])
     .catch(e => {
-      t.equals(e.name, 'LoadJSONError', 'throws a LoadJSONError')
-      t.equals(e.code, 'ENOSOURCE', 'returns ‘ENOSOURCE’')
-      t.equals(e.message, 'No source specified', 'returns the correct message')
+      t.equal(e.name, 'LoadJSONError', 'throws a LoadJSONError')
+      t.equal(e.code, 'ENOSOURCE', 'returns ‘ENOSOURCE’')
+      t.equal(e.message, 'No source specified', 'returns the correct message')
     })
 })
 
@@ -88,9 +88,9 @@ test('When no path property is passed', function (t) {
       source: 'source1'
     }])
     .catch(e => {
-      t.equals(e.name, 'LoadJSONError', 'throws a LoadJSONError')
-      t.equals(e.code, 'ENOPATH', 'returns ‘ENOPATH’')
-      t.equals(e.message, 'No path specified', 'returns the correct message')
+      t.equal(e.name, 'LoadJSONError', 'throws a LoadJSONError')
+      t.equal(e.code, 'ENOPATH', 'returns ‘ENOPATH’')
+      t.equal(e.message, 'No path specified', 'returns the correct message')
     })
 })
 
@@ -100,9 +100,9 @@ test('When null is passed instead of a source object', function (t) {
   jsonLoader
     .load([null])
     .catch(e => {
-      t.equals(e.name, 'LoadJSONError', 'throws a LoadJSONError')
-      t.equals(e.code, 'EWRONGTYPE', 'returns ‘EWRONGTYPE’')
-      t.equals(e.message, '"null" is not an object', 'returns the correct message')
+      t.equal(e.name, 'LoadJSONError', 'throws a LoadJSONError')
+      t.equal(e.code, 'EWRONGTYPE', 'returns ‘EWRONGTYPE’')
+      t.equal(e.message, '"null" is not an object', 'returns the correct message')
     })
 })
 
@@ -112,9 +112,9 @@ test('When undefined is passed instead of a source object', function (t) {
   jsonLoader
     .load([undefined])
     .catch(e => {
-      t.equals(e.name, 'LoadJSONError', 'throws a LoadJSONError')
-      t.equals(e.code, 'EWRONGTYPE', 'returns ‘EWRONGTYPE’')
-      t.equals(e.message, '"undefined" is not an object', 'returns the correct message')
+      t.equal(e.name, 'LoadJSONError', 'throws a LoadJSONError')
+      t.equal(e.code, 'EWRONGTYPE', 'returns ‘EWRONGTYPE’')
+      t.equal(e.message, '"undefined" is not an object', 'returns the correct message')
     })
 })
 
@@ -124,9 +124,9 @@ test('When a string is passed instead of a source object', function (t) {
   jsonLoader
     .load(['/path'])
     .catch(e => {
-      t.equals(e.name, 'LoadJSONError', 'throws a LoadJSONError')
-      t.equals(e.code, 'EWRONGTYPE', 'returns ‘EWRONGTYPE’')
-      t.equals(e.message, '"string" is not an object', 'returns the correct message')
+      t.equal(e.name, 'LoadJSONError', 'throws a LoadJSONError')
+      t.equal(e.code, 'EWRONGTYPE', 'returns ‘EWRONGTYPE’')
+      t.equal(e.message, '"string" is not an object', 'returns the correct message')
     })
 })
 
@@ -136,9 +136,9 @@ test('When a number is passed instead of a source object', function (t) {
   jsonLoader
     .load([2])
     .catch(e => {
-      t.equals(e.name, 'LoadJSONError', 'throws a LoadJSONError')
-      t.equals(e.code, 'EWRONGTYPE', 'returns ‘EWRONGTYPE’')
-      t.equals(e.message, '"number" is not an object', 'returns the correct message')
+      t.equal(e.name, 'LoadJSONError', 'throws a LoadJSONError')
+      t.equal(e.code, 'EWRONGTYPE', 'returns ‘EWRONGTYPE’')
+      t.equal(e.message, '"number" is not an object', 'returns the correct message')
     })
 })
 
@@ -148,9 +148,9 @@ test('When an array is passed instead of a source object', function (t) {
   jsonLoader
     .load([['/path']])
     .catch(e => {
-      t.equals(e.name, 'LoadJSONError', 'throws a LoadJSONError')
-      t.equals(e.code, 'EWRONGTYPE', 'returns ‘EWRONGTYPE’')
-      t.equals(e.message, '"array" is not an object', 'returns the correct message')
+      t.equal(e.name, 'LoadJSONError', 'throws a LoadJSONError')
+      t.equal(e.code, 'EWRONGTYPE', 'returns ‘EWRONGTYPE’')
+      t.equal(e.message, '"array" is not an object', 'returns the correct message')
     })
 })
 
@@ -160,9 +160,9 @@ test('When loading the json from a source that does not exist', function (t) {
   jsonLoader
     .load([nonexistentLocation])
     .catch(e => {
-      t.equals(e.name, 'LoadJSONError', 'throws a LoadJSONError')
-      t.equals(e.code, 'EPATHDOESNOTEXIST', 'returns ‘EPATHDOESNOTEXIST’')
-      t.equals(e.message, 'Path "no/such/location" not found', 'returns the correct message')
+      t.equal(e.name, 'LoadJSONError', 'throws a LoadJSONError')
+      t.equal(e.code, 'EPATHDOESNOTEXIST', 'returns ‘EPATHDOESNOTEXIST’')
+      t.equal(e.message, 'Path "no/such/location" not found', 'returns the correct message')
     })
 })
 
@@ -175,8 +175,8 @@ test('When loading unreadable json', function (t) {
   jsonLoader
     .load([sourceUnreadable])
     .catch(e => {
-      t.equals(e.name, 'Error', 'throws an Error')
-      t.equals(e.code, 'EACCES', 'returns ‘ENOENT’')
+      t.equal(e.name, 'Error', 'throws an Error')
+      t.equal(e.code, 'EACCES', 'returns ‘ENOENT’')
     })
     .then(() => {
       // make file readable again
@@ -190,8 +190,8 @@ test('When loading invalid json', function (t) {
   jsonLoader
     .load([sourceInvalid])
     .catch(e => {
-      t.equals(e.name, 'JSONError', 'throws an JSONError')
-      t.equals(e.fileName, 'data/sourceinvalid/invalid.json', 'returns the invalid file path')
+      t.equal(e.name, 'JSONError', 'throws an JSONError')
+      t.equal(e.fileName, 'data/sourceinvalid/invalid.json', 'returns the invalid file path')
     })
 })
 
@@ -201,8 +201,8 @@ test('When loading duplicate sources', function (t) {
   jsonLoader
     .load([source1, source1])
     .catch(e => {
-      t.equals(e.name, 'LoadJSONError', 'throws a LoadJSONError')
-      t.equals(e.code, 'EDUPLICATESOURCES', 'returns ‘correct’')
+      t.equal(e.name, 'LoadJSONError', 'throws a LoadJSONError')
+      t.equal(e.code, 'EDUPLICATESOURCES', 'returns ‘correct’')
       t.deepEquals(e.data, {
         sources: [
           'source1',

--- a/lib/service-data/runtime/merge-instances.unit.spec.js
+++ b/lib/service-data/runtime/merge-instances.unit.spec.js
@@ -22,7 +22,7 @@ test('Merging sources', (t) => {
   const input = require(path.resolve('data/merge/sources-a.json'))
   const expected = require(path.resolve('data/merge/expected-a.json'))
 
-  t.deepEqual(merge(input), expected, 'returns the expected instances with annotations')
+  t.same(merge(input), expected, 'returns the expected instances with annotations')
 
   t.end()
 })

--- a/lib/service-data/runtime/propagate-categories.unit.spec.js
+++ b/lib/service-data/runtime/propagate-categories.unit.spec.js
@@ -21,7 +21,7 @@ test('When propagating categories from an instance’s schema', function (t) {
   const instances = propagate(input, schemas)
 
   const foo = getNestedInstance(instances, 'foo')
-  t.deepEqual(foo.$page, true, 'it should set the $[category] property of instances')
+  t.same(foo.$page, true, 'it should set the $[category] property of instances')
 
   t.end()
 })

--- a/lib/service-data/runtime/propagate-show.unit.spec.js
+++ b/lib/service-data/runtime/propagate-show.unit.spec.js
@@ -13,7 +13,7 @@ test('When propagating the show properties', function (t) {
   const expected = getTestData('expected-a')
   const instances = propagate(input)
 
-  t.deepEqual(instances, expected, 'it should do so correctly')
+  t.same(instances, expected, 'it should do so correctly')
 
   t.end()
 })

--- a/lib/service-data/runtime/propagate-steps.unit.spec.js
+++ b/lib/service-data/runtime/propagate-steps.unit.spec.js
@@ -29,33 +29,33 @@ test('When adding _parent properties to step instances', async t => {
   t.ok(parentValues, 'it should set the correct _parent values')
 
   t.equal(instances.topA.namePrefix, 'namespaceA')
-  t.deepEqual(instances.topA.$namespaces, ['namespaceA'])
+  t.same(instances.topA.$namespaces, ['namespaceA'])
   t.equal(instances.topA.url, '/top-a')
   t.equal(instances.stepA.namePrefix, 'namespaceA')
-  t.deepEqual(instances.stepA.$namespaces, ['namespaceA'])
+  t.same(instances.stepA.$namespaces, ['namespaceA'])
   t.equal(instances.stepA.url, '/top-a/step-a')
   t.equal(instances.stepC.namePrefix, 'namespaceA.namespaceC[{namespaceC}]')
-  t.deepEqual(instances.stepC.$namespaces, ['namespaceA', 'namespaceC'])
+  t.same(instances.stepC.$namespaces, ['namespaceA', 'namespaceC'])
   t.equal(instances.stepC.url, '/top-a/step-a/step-c/:namespaceC')
   t.equal(instances.stepB.namePrefix, undefined)
   t.equal(instances.stepB.url, '/step-b')
   t.equal(instances.topB.namePrefix, undefined)
-  t.deepEqual(instances.topB.$namespaces, undefined)
+  t.same(instances.topB.$namespaces, undefined)
   t.equal(instances.topB.url, '/topB')
   t.equal(instances.stepZ.namePrefix, 'namespaceZ')
-  t.deepEqual(instances.stepZ.$namespaces, ['namespaceZ'])
+  t.same(instances.stepZ.$namespaces, ['namespaceZ'])
   t.equal(instances.stepZ.url, '/topB/step-z')
   t.equal(instances.topD.url, '/topD', 'it should use the page id if url is missing')
   t.equal(instances.topE.url, '/top-e/:namespaceE')
   t.equal(instances.topE.namePrefix, 'namespaceE[{namespaceE}]')
-  t.deepEqual(instances.topE.$namespaces, ['namespaceE'])
+  t.same(instances.topE.$namespaces, ['namespaceE'])
   t.equal(instances.stepF.url, '/top-e/:namespaceE/step-f')
   t.equal(instances.stepF.namePrefix, 'namespaceE[{namespaceE}].namespaceF')
-  t.deepEqual(instances.stepF.$namespaces, ['namespaceE', 'namespaceF'])
+  t.same(instances.stepF.$namespaces, ['namespaceE', 'namespaceF'])
 
   t.equal(instances.mountedG.url, '/top-a/mount-g')
   t.equal(instances.mountedG.namePrefix, 'namespaceA')
-  t.deepEqual(instances.mountedG.$namespaces, ['namespaceA'])
+  t.same(instances.mountedG.$namespaces, ['namespaceA'])
   t.equal(instances.root.url, '/')
   t.equal(instances.mountOnRoot.url, '/mount-on-root')
 
@@ -72,11 +72,11 @@ test('When a step is referenced by multiple parent pages', async t => {
   t.equal(error.name, 'PageHasParentError', 'it should return a PageHasParentError')
   t.equal(error.data.step, 'stepA', 'it should return the duplicated step')
   const eInstances = error.data.instances
-  t.notDeepEqual(eInstances.stepA, badData.stepA, 'it should have altered the duplicated step')
+  t.notSame(eInstances.stepA, badData.stepA, 'it should have altered the duplicated step')
   delete eInstances.stepA
   const badDataClone = cloneDeep(badData)
   delete badDataClone.stepA
-  t.deepEqual(eInstances, badDataClone, 'it should not have altered the parent pages')
+  t.same(eInstances, badDataClone, 'it should not have altered the parent pages')
 })
 
 test('When processing step instances for section headings', async t => {
@@ -116,7 +116,7 @@ test('When propagating a repeatable instance without a namespace', async t => {
   const error = t.throws(() => propagate(input), 'should throw an error')
   t.equal(error.name, 'PageRepeatableNamespaceError', 'it should throw an error')
   t.equal(error.message, 'repeatableA is repeatable but has no namespace', 'it should report the id of the page without the namespace as the error message')
-  t.deepEqual(error.data, expectedErrorData, 'it should return the instances processed so far as the data property of the error object')
+  t.same(error.data, expectedErrorData, 'it should return the instances processed so far as the data property of the error object')
 })
 
 test('When a single step is missing', async t => {

--- a/lib/service-data/service-data.unit.spec.js
+++ b/lib/service-data/service-data.unit.spec.js
@@ -204,8 +204,8 @@ test('When the service schemas have been set', t => {
   }
   setServiceSchemas(schemas)
 
-  t.deepEqual(getServiceSchemas(), schemas, 'getServiceSchemas should return all the schemas')
-  t.deepEqual(getServiceSchema('a'), schemas.a, 'getServiceSchema should return the individual schema requested')
+  t.same(getServiceSchemas(), schemas, 'getServiceSchemas should return all the schemas')
+  t.same(getServiceSchema('a'), schemas.a, 'getServiceSchema should return the individual schema requested')
 
   let error
   try {
@@ -214,24 +214,24 @@ test('When the service schemas have been set', t => {
     error = e
   }
 
-  t.equals(error.name, 'ServiceDataError', 'setServiceSchemas should throw an error if an attempt is made to set the schemas again')
-  t.equals(error.message, 'Attempt to set frozen service schemas', 'setServiceSchemas should return the correct error message')
-  t.equals(error.code, 'ESERVICESCHEMASFROZEN', 'setServiceSchemas should return the correct error code')
+  t.equal(error.name, 'ServiceDataError', 'setServiceSchemas should throw an error if an attempt is made to set the schemas again')
+  t.equal(error.message, 'Attempt to set frozen service schemas', 'setServiceSchemas should return the correct error message')
+  t.equal(error.code, 'ESERVICESCHEMASFROZEN', 'setServiceSchemas should return the correct error code')
 
-  t.deepEqual(getServiceSchemas(), schemas, 'getServiceSchemas should still return all the original schemas after a failed attempt to set the schemas')
+  t.same(getServiceSchemas(), schemas, 'getServiceSchemas should still return all the original schemas after a failed attempt to set the schemas')
 
-  t.deepEqual(getSchemaCategories(), {
+  t.same(getSchemaCategories(), {
     rock: ['a', 'b'],
     paper: ['b']
   }, 'it should return the correct schema categories')
 
-  t.deepEqual(getSchemaNameByCategory('rock'), ['a', 'b'], 'getSchemaNameByCategory should return the correct schema names for a category')
+  t.same(getSchemaNameByCategory('rock'), ['a', 'b'], 'getSchemaNameByCategory should return the correct schema names for a category')
 
-  t.deepEqual(getSchemaNameByCategory('scissors'), [], 'getSchemaNameByCategory should return an empty array if the category has no schemas')
+  t.same(getSchemaNameByCategory('scissors'), [], 'getSchemaNameByCategory should return an empty array if the category has no schemas')
 
-  t.deepEqual(getSchemaPropertyAllowableTypes('b', 'bnested'), ['c'], 'getSchemaPropertyAllowableTypes should return correct allowable types for a property')
+  t.same(getSchemaPropertyAllowableTypes('b', 'bnested'), ['c'], 'getSchemaPropertyAllowableTypes should return correct allowable types for a property')
 
-  t.deepEqual(getSchemaPropertyAllowableTypes('c', 'cnested'), ['a', 'b'], 'getSchemaPropertyAllowableTypes should return correct allowable types for a property that resolves to a definition')
+  t.same(getSchemaPropertyAllowableTypes('c', 'cnested'), ['a', 'b'], 'getSchemaPropertyAllowableTypes should return correct allowable types for a property that resolves to a definition')
 
   t.end()
 })
@@ -252,7 +252,7 @@ test('When the service sources have been set', t => {
 
   setServiceSources(cloneDeep(sourceObjs))
 
-  t.deepEqual(getServiceSources(), sourceObjs, 'getServiceSources should return all the sources')
+  t.same(getServiceSources(), sourceObjs, 'getServiceSources should return all the sources')
 
   let error
   try {
@@ -261,11 +261,11 @@ test('When the service sources have been set', t => {
     error = e
   }
 
-  t.equals(error.name, 'ServiceDataError', 'setServiceSources should throw an error if an attempt is made to set the sources again')
-  t.equals(error.message, 'Attempt to set frozen service sources', 'setServiceSources should return the correct error message')
-  t.equals(error.code, 'ESERVICESOURCESFROZEN', 'setServiceSources should return the correct error code')
+  t.equal(error.name, 'ServiceDataError', 'setServiceSources should throw an error if an attempt is made to set the sources again')
+  t.equal(error.message, 'Attempt to set frozen service sources', 'setServiceSources should return the correct error message')
+  t.equal(error.code, 'ESERVICESOURCESFROZEN', 'setServiceSources should return the correct error code')
 
-  t.deepEqual(getServiceSources(), sourceObjs, 'getServiceSources should still return all the original sources after a failed attempt to set the sources')
+  t.same(getServiceSources(), sourceObjs, 'getServiceSources should still return all the original sources after a failed attempt to set the sources')
   t.end()
 })
 
@@ -304,13 +304,13 @@ test('When the service instances have been set', t => {
   setServiceInstances(cloneDeep(instances))
   const timestampA = getTimestamp()
   t.ok(timestampA, 'getTimestamp should return a timestamp value')
-  t.deepEqual(getServiceInstances(), instances, 'getServiceInstances should return all the instances')
-  t.deepEqual(getInstance('a'), instances.a, 'getInstance should return the individual instance requested')
-  t.deepEqual(getInstance('b'), instances.b, 'getInstance should return the individual instance requested (part 2)')
-  t.deepEqual(getInstance('c'), undefined, 'getInstance should return undefined if individual instance requested does not exist')
-  t.deepEqual(getSourceInstance('a', 'service'), instances.sourceInstances.data.service.a, 'getSourceInstance should return the individual instance requested')
-  t.deepEqual(getSourceInstance('b', 'core'), instances.sourceInstances.data.core.b, 'getSourceInstance should return the individual instance requested (part 2)')
-  t.deepEqual(getSourceInstance('c', 'service'), undefined, 'getSourceInstance should return undefined if individual instance requested does not exist')
+  t.same(getServiceInstances(), instances, 'getServiceInstances should return all the instances')
+  t.same(getInstance('a'), instances.a, 'getInstance should return the individual instance requested')
+  t.same(getInstance('b'), instances.b, 'getInstance should return the individual instance requested (part 2)')
+  t.same(getInstance('c'), undefined, 'getInstance should return undefined if individual instance requested does not exist')
+  t.same(getSourceInstance('a', 'service'), instances.sourceInstances.data.service.a, 'getSourceInstance should return the individual instance requested')
+  t.same(getSourceInstance('b', 'core'), instances.sourceInstances.data.core.b, 'getSourceInstance should return the individual instance requested (part 2)')
+  t.same(getSourceInstance('c', 'service'), undefined, 'getSourceInstance should return undefined if individual instance requested does not exist')
 
   const newInstances = {
     a: {
@@ -344,13 +344,13 @@ test('When the service instances have been set', t => {
   setServiceInstances(cloneDeep(newInstances), true)
   const timestampB = getTimestamp()
   t.notEqual(timestampA, timestampB, 'getTimestamp should return a changed timestamp value')
-  t.deepEqual(getInstance('a'), newInstances.a, 'getInstance should return the individual instance requested')
-  t.deepEqual(getInstance('b'), undefined, 'getInstance should return the individual instance requested (part 2)')
-  t.deepEqual(getInstance('c'), newInstances.c, 'getInstance should return undefined if individual instance requested')
-  t.deepEqual(getSourceInstance('a', 'core'), newInstances.sourceInstances.data.core.a, 'getSourceInstance should return the individual instance requested')
-  t.deepEqual(getSourceInstance('c', 'service'), newInstances.sourceInstances.data.service.c, 'getSourceInstance should return the individual instance requested (part 2)')
-  t.deepEqual(getSourceInstance('b', 'service'), undefined, 'getSourceInstance should return undefined if individual instance requested does not exist')
-  t.deepEqual(getSourceInstance('b', 'missing'), undefined, 'getSourceInstance should return undefined if source does not exist')
+  t.same(getInstance('a'), newInstances.a, 'getInstance should return the individual instance requested')
+  t.same(getInstance('b'), undefined, 'getInstance should return the individual instance requested (part 2)')
+  t.same(getInstance('c'), newInstances.c, 'getInstance should return undefined if individual instance requested')
+  t.same(getSourceInstance('a', 'core'), newInstances.sourceInstances.data.core.a, 'getSourceInstance should return the individual instance requested')
+  t.same(getSourceInstance('c', 'service'), newInstances.sourceInstances.data.service.c, 'getSourceInstance should return the individual instance requested (part 2)')
+  t.same(getSourceInstance('b', 'service'), undefined, 'getSourceInstance should return undefined if individual instance requested does not exist')
+  t.same(getSourceInstance('b', 'missing'), undefined, 'getSourceInstance should return undefined if source does not exist')
 
   let error
   try {
@@ -361,11 +361,11 @@ test('When the service instances have been set', t => {
 
   const timestampC = getTimestamp()
   t.equal(timestampB, timestampC, 'getTimestamp should return an unchanged timestamp value')
-  t.equals(error.name, 'ServiceDataError', 'setServiceInstances should throw an error if an attempt is made to set the schemas again')
-  t.equals(error.message, 'Attempt to set frozen service data', 'setServiceInstances should return the correct error message')
-  t.equals(error.code, 'ESERVICEDATAFROZEN', 'setServiceInstances should return the correct error code')
+  t.equal(error.name, 'ServiceDataError', 'setServiceInstances should throw an error if an attempt is made to set the schemas again')
+  t.equal(error.message, 'Attempt to set frozen service data', 'setServiceInstances should return the correct error message')
+  t.equal(error.code, 'ESERVICEDATAFROZEN', 'setServiceInstances should return the correct error code')
 
-  t.deepEqual(getServiceInstances(), newInstances, 'getServiceSchemas should still return all the original schemas after a failed attempt to set the schemas')
+  t.same(getServiceInstances(), newInstances, 'getServiceSchemas should still return all the original schemas after a failed attempt to set the schemas')
 
   t.end()
 })
@@ -441,9 +441,9 @@ const instances = {
 test('When getInstance is invoked', t => {
   const getServiceInstancesStub = getStubbedServiceInstances()
 
-  t.deepEqual(getInstance('a'), instances.a, 'it should return top level instance if an instance exists')
-  t.deepEqual(getInstance('b'), instances.a.components[0], 'it should return nested instance if an instance exists')
-  t.deepEqual(getInstance('c'), instances.a.components[0].items[0], 'it should return deeper nested instance if an instance exists')
+  t.same(getInstance('a'), instances.a, 'it should return top level instance if an instance exists')
+  t.same(getInstance('b'), instances.a.components[0], 'it should return nested instance if an instance exists')
+  t.same(getInstance('c'), instances.a.components[0].items[0], 'it should return deeper nested instance if an instance exists')
   t.equal(getInstance('d'), undefined, 'it should return undefined if no instance exists')
 
   getServiceInstancesStub.restore()
@@ -459,12 +459,12 @@ test('When getDiscreteInstance is invoked', t => {
     }
   })
 
-  t.deepEqual(getDiscreteInstance('a'), instances.a, 'it should return top level instance if top level instance matched')
-  t.deepEqual(getDiscreteInstance('b'), instances.a, 'it should return top level instance if a nested instance matched')
-  t.deepEqual(getDiscreteInstance('c'), instances.a, 'it should return top level instance if a deeper nested instance matched')
+  t.same(getDiscreteInstance('a'), instances.a, 'it should return top level instance if top level instance matched')
+  t.same(getDiscreteInstance('b'), instances.a, 'it should return top level instance if a nested instance matched')
+  t.same(getDiscreteInstance('c'), instances.a, 'it should return top level instance if a deeper nested instance matched')
   t.equal(getDiscreteInstance('d'), undefined, 'it should return undefined if no instance exists')
 
-  t.deepEqual(getDiscreteInstance('n'), instances.m, 'it should return correct top level instance')
+  t.same(getDiscreteInstance('n'), instances.m, 'it should return correct top level instance')
 
   getServiceInstancesStub.restore()
   getSourceInstanceStub.restore()
@@ -475,7 +475,7 @@ test('When getInstanceProperty is invoked', t => {
   const getServiceInstancesStub = getStubbedServiceInstances()
 
   t.equal(getInstanceProperty('a', '_id'), 'a', 'it should return the property of top level instance ')
-  t.deepEqual(getInstanceProperty('b', 'items'), instances.a.components[0].items, 'it should return property of a nested instance')
+  t.same(getInstanceProperty('b', 'items'), instances.a.components[0].items, 'it should return property of a nested instance')
   t.equal(getInstanceProperty('c', '_type'), 'deepnested', 'it should return the property of a deeper nested instance')
   t.equal(getInstanceProperty('c', 'monkey'), undefined, 'it should return undefined if property does not exist')
   t.equal(getInstanceProperty('c', 'monkey', 'defaultValue'), 'defaultValue', 'it should return any default value if property does not exist')
@@ -525,10 +525,10 @@ const sourceInstances = {
 test('When getSourceInstance is invoked', t => {
   const getSourceInstancesStub = getStubbedSourceInstances()
 
-  t.deepEqual(getSourceInstance('a', 'service'), sourceInstances.service.a, 'it should return top level instance if an instance exists')
-  t.deepEqual(getSourceInstance('b', 'service'), sourceInstances.service.a.components[0], 'it should return nested instance if an instance exists')
-  t.deepEqual(getSourceInstance('c', 'service'), sourceInstances.service.a.components[0].items[0], 'it should return deeper nested instance if an instance exists')
-  t.deepEqual(getSourceInstance('n', 'service'), sourceInstances.service.m.items[0], 'it should the correct source instance rather than any expanded one')
+  t.same(getSourceInstance('a', 'service'), sourceInstances.service.a, 'it should return top level instance if an instance exists')
+  t.same(getSourceInstance('b', 'service'), sourceInstances.service.a.components[0], 'it should return nested instance if an instance exists')
+  t.same(getSourceInstance('c', 'service'), sourceInstances.service.a.components[0].items[0], 'it should return deeper nested instance if an instance exists')
+  t.same(getSourceInstance('n', 'service'), sourceInstances.service.m.items[0], 'it should the correct source instance rather than any expanded one')
   t.equal(getSourceInstance('d', 'service'), undefined, 'it should return undefined if no instance exists')
   t.equal(getSourceInstance('a', 'missing'), undefined, 'it should return undefined if no source data exists')
 
@@ -550,9 +550,9 @@ test('When getDiscreteInstance is invoked', t => {
     }
   })
 
-  t.deepEqual(getSourceDiscreteInstance('a', 'service'), sourceInstances.service.a, 'it should return top level instance if top level instance matched')
-  t.deepEqual(getSourceDiscreteInstance('b', 'service'), sourceInstances.service.a, 'it should return top level instance if a nested instance matched')
-  t.deepEqual(getSourceDiscreteInstance('c', 'service'), sourceInstances.service.a, 'it should return top level instance if a deeper nested instance matched')
+  t.same(getSourceDiscreteInstance('a', 'service'), sourceInstances.service.a, 'it should return top level instance if top level instance matched')
+  t.same(getSourceDiscreteInstance('b', 'service'), sourceInstances.service.a, 'it should return top level instance if a nested instance matched')
+  t.same(getSourceDiscreteInstance('c', 'service'), sourceInstances.service.a, 'it should return top level instance if a deeper nested instance matched')
   t.equal(getSourceDiscreteInstance('d', 'service'), undefined, 'it should return undefined if no instance exists')
   t.equal(getSourceDiscreteInstance('a', 'missing'), undefined, 'it should return undefined if no source data exists')
 
@@ -566,7 +566,7 @@ test('When getSourceInstanceProperty is invoked', t => {
   const getSourceInstancesStub = getStubbedSourceInstances()
 
   t.equal(getSourceInstanceProperty('a', '_id', 'service'), 'a', 'it should return the property of top level instance ')
-  t.deepEqual(getSourceInstanceProperty('b', 'items', 'service'), sourceInstances.service.a.components[0].items, 'it should return property of a nested instance')
+  t.same(getSourceInstanceProperty('b', 'items', 'service'), sourceInstances.service.a.components[0].items, 'it should return property of a nested instance')
   t.equal(getSourceInstanceProperty('c', '_type', 'service'), 'deepnested', 'it should return the property of a deeper nested instance')
   t.equal(getSourceInstanceProperty('c', 'monkey', 'service'), undefined, 'it should return undefined if property does not exist')
   t.equal(getSourceInstanceProperty('c', 'monkey', 'service', 'defaultValue'), 'defaultValue', 'it should return any default value if property does not exist')
@@ -593,7 +593,7 @@ test('When setInstance is invoked on a discrete instance', t => {
       t.equal(res, true, 'it should successfully write the instance')
       const args = writeFileAtomicStub.getCall(0).args
       t.equal(args[0], '/service-path/metadata/component/a.json', 'it should write to the correct path name')
-      t.deepEqual(args[1], { _id: 'a', _type: 'foo' }, 'it should write the correct instance data')
+      t.same(args[1], { _id: 'a', _type: 'foo' }, 'it should write the correct instance data')
     })
 
   getServiceInstancesStub.restore()
@@ -615,7 +615,7 @@ test('When setInstance is invoked on a nested instance', t => {
       t.equal(res, true, 'it should successfully write the file')
       const args = writeFileAtomicStub.getCall(0).args
       t.equal(args[0], '/service-path/metadata/component/a.json', 'it should write to the correct path name')
-      t.deepEqual(args[1], { _id: 'a', _type: 'discrete', components: [{ _id: 'b', _type: 'middle' }] }, 'it should write the correct instance data')
+      t.same(args[1], { _id: 'a', _type: 'discrete', components: [{ _id: 'b', _type: 'middle' }] }, 'it should write the correct instance data')
     })
 
   getServiceInstancesStub.restore()
@@ -634,7 +634,7 @@ test('When setInstance is invoked and the write fails', t => {
     _type: 'foo'
   })
     .catch(err => {
-      t.deepEqual(err, { message: 'Something went wrong' }, 'it should reject the promise with the error')
+      t.same(err, { message: 'Something went wrong' }, 'it should reject the promise with the error')
     })
 
   getServiceInstancesStub.restore()
@@ -721,7 +721,7 @@ test('When setting a property on an instance', t => {
       const args = writeFileAtomicStub.getCall(0).args
       t.equal(args[0], '/service-path/metadata/component/a.json', 'it should write to the correct path name')
       const b = jp.query(args[1], '$..[?(@._id === "b")]')[0]
-      t.deepEqual(b.newProp, 'newValue', 'it should set the value on the instance')
+      t.same(b.newProp, 'newValue', 'it should set the value on the instance')
     })
 
   setInstanceProperty({ _id: 'b' }, 'newProp', 'newValue')
@@ -730,7 +730,7 @@ test('When setting a property on an instance', t => {
       const args = writeFileAtomicStub.getCall(0).args
       t.equal(args[0], '/service-path/metadata/component/a.json', 'it should write to the correct path name when passed an instance instead of an id')
       const b = jp.query(args[1], '$..[?(@._id === "b")]')[0]
-      t.deepEqual(b.newProp, 'newValue', 'it should set the value on the instance data when passed an instance instead of an id')
+      t.same(b.newProp, 'newValue', 'it should set the value on the instance data when passed an instance instead of an id')
     })
 
   setInstanceProperty(undefined, 'newProp', 'newValue')
@@ -780,7 +780,7 @@ test('When createInstance is invoked as to make a discrete instance', t => {
       t.equal(res, true, 'it should successfully write the instance')
       const args = writeFileAtomicStub.getCall(0).args
       t.equal(args[0], '/service-path/metadata/component/z.json', 'it should write to the correct path name')
-      t.deepEqual(args[1], { _id: 'z', _type: 'foo' }, 'it should write the correct instance data')
+      t.same(args[1], { _id: 'z', _type: 'foo' }, 'it should write the correct instance data')
     })
 
   getServiceInstancesStub.restore()
@@ -829,7 +829,7 @@ test('When createInstance is invoked to make a nested instance', t => {
       t.equal(res, true, 'it should successfully write the instance')
       const args = writeFileAtomicStub.getCall(0).args
       t.equal(args[0], '/service-path/metadata/component/a.json', 'it should write to the correct path name')
-      t.deepEqual(args[1], expectedA, 'it should write the correct instance data')
+      t.same(args[1], expectedA, 'it should write the correct instance data')
     })
 
   const expectedB = {
@@ -867,7 +867,7 @@ test('When createInstance is invoked to make a nested instance', t => {
       t.equal(res, true, 'it should successfully write the instance')
       const args = writeFileAtomicStub.getCall(1).args
       t.equal(args[0], '/service-path/metadata/component/a.json', 'it should write to the correct path name')
-      t.deepEqual(args[1], expectedB, 'it should write the correct nested instance data')
+      t.same(args[1], expectedB, 'it should write the correct nested instance data')
     })
 
   const expectedUnshift = {
@@ -906,7 +906,7 @@ test('When createInstance is invoked to make a nested instance', t => {
       t.equal(res, true, 'it should successfully write the instance')
       const args = writeFileAtomicStub.getCall(2).args
       t.equal(args[0], '/service-path/metadata/component/a.json', 'it should write to the correct path name')
-      t.deepEqual(args[1], expectedUnshift, 'it should write the correct nested instance data')
+      t.same(args[1], expectedUnshift, 'it should write the correct nested instance data')
     })
 
   const expectedEmpty = {
@@ -946,7 +946,7 @@ test('When createInstance is invoked to make a nested instance', t => {
       t.equal(res, true, 'it should successfully write the instance')
       const args = writeFileAtomicStub.getCall(3).args
       t.equal(args[0], '/service-path/metadata/component/a.json', 'it should write to the correct path name')
-      t.deepEqual(args[1], expectedEmpty, 'it should write the correct nested instance data')
+      t.same(args[1], expectedEmpty, 'it should write the correct nested instance data')
     })
 
   getServiceInstancesStub.restore()
@@ -994,7 +994,7 @@ test('When createInstance is invoked and the write fails', t => {
     _type: 'foo'
   })
     .catch(err => {
-      t.deepEqual(err, { message: 'Something went wrong' }, 'it should reject the promise with the error')
+      t.same(err, { message: 'Something went wrong' }, 'it should reject the promise with the error')
     })
 
   getServiceInstancesStub.restore()
@@ -1155,7 +1155,7 @@ test('When expanding an instance', t => {
 
   const addErrorStub = stub()
 
-  t.deepEqual(expandInstance({
+  t.same(expandInstance({
     _id: 'expando',
     _type: 'expandoType',
     _isa: 'inherit'
@@ -1167,7 +1167,7 @@ test('When expanding an instance', t => {
     label: 'inherited label'
   }, 'it should merge the values from the inherited instance')
 
-  t.deepEqual(expandInstance({
+  t.same(expandInstance({
     _id: 'expando',
     _type: 'expandoType',
     _isa: 'inherit',
@@ -1180,7 +1180,7 @@ test('When expanding an instance', t => {
     label: 'overridden label'
   }, 'it should honour values already set in the instance')
 
-  t.deepEqual(expandInstance({
+  t.same(expandInstance({
     _id: 'expando',
     _type: 'expandoType',
     _isa: 'missing',
@@ -1194,7 +1194,7 @@ test('When expanding an instance', t => {
   t.equal(addErrorStub.calledOnceWithExactly('instance.isa.source.missing', 'instance'), true, 'it should register that the source for the instance referenced cannot be found')
   addErrorStub.resetHistory()
 
-  t.deepEqual(expandInstance({
+  t.same(expandInstance({
     _id: 'expando',
     _type: 'expandoType',
     _isa: 'nonexistent',

--- a/lib/service-data/specification/schema-utils.unit.spec.js
+++ b/lib/service-data/specification/schema-utils.unit.spec.js
@@ -14,7 +14,7 @@ test('When loading schemas from a single path and $idRoot', t => {
 
   const expected = require(path.resolve('./data/service-data/specification/expected/specs-a-expected.json'))
   load().then(schemas => {
-    t.deepEqual(schemas, expected, 'it should return the correctly expanded and dereferenced schemas')
+    t.same(schemas, expected, 'it should return the correctly expanded and dereferenced schemas')
   })
 })
 
@@ -35,7 +35,7 @@ test('When loading schemas from multiple paths and $idRoots', t => {
 
   const expected = require(path.resolve('./data/service-data/specification/expected/specs-b-expected.json'))
   load().then(schemas => {
-    t.deepEqual(schemas, expected, 'it should return the correctly expanded and dereferenced schemas')
+    t.same(schemas, expected, 'it should return the correctly expanded and dereferenced schemas')
   })
 })
 
@@ -49,7 +49,7 @@ test('When loading schemas with conflicting property values', t => {
 
   const expected = require(path.resolve('./data/service-data/specification/expected/specs-overrides-expected.json'))
   load().then(schemas => {
-    t.deepEqual(schemas, expected, 'it should return the schemas with correctly overridden properties')
+    t.same(schemas, expected, 'it should return the schemas with correctly overridden properties')
   })
 })
 

--- a/lib/service-data/specification/validate-schema.unit.spec.js
+++ b/lib/service-data/specification/validate-schema.unit.spec.js
@@ -113,7 +113,7 @@ test('Validating files that are expected to be valid against a schema but which 
   t.ok(second.path.includes(`${sourcePath}/definition.data.invalid._type.json`), 'returns the path for `definition.data.invalid._type.json`')
   t.ok(third.path.includes(`${sourcePath}/definition.data.invalid.double.error.json`), 'returns the path for `definition.data.invalid.double.error.json`')
 
-  t.deepEqual(transformPaths(result), expected, 'returns the errors')
+  t.same(transformPaths(result), expected, 'returns the errors')
 
   t.end()
 })
@@ -137,7 +137,7 @@ test('Validating files that are expected to be invalid against a schema but whic
   t.ok(one.path.includes(`${sourcePath}/definition.data.json`), 'returns the path for `definition.data.json`')
   t.ok(two.path.includes(`${sourcePath}/definition.data.optional.json`), 'returns the path for `definition.data.optional.json`')
 
-  t.deepEqual(transformPaths(result), expected, 'returns the errors')
+  t.same(transformPaths(result), expected, 'returns the errors')
 
   t.end()
 })
@@ -182,7 +182,7 @@ test('Validating against a schema and encountering more than one error', async (
     const result = await validateSchema('definition.data', { specs, valid: doubleError })
     const expected = require(path.join(path.resolve('./data/service-data/specification/expected/specs-expected-double.error.json')))
 
-    t.deepEqual(transformPaths(result), expected, 'returns all errors')
+    t.same(transformPaths(result), expected, 'returns all errors')
   }
 
   {
@@ -193,7 +193,7 @@ test('Validating against a schema and encountering more than one error', async (
     const result = await validateSchema('definition.data', { specs, valid: doubleError, allErrors: false })
     const expected = require(path.join(path.resolve('./data/service-data/specification/expected/specs-expected-double.error.show-first.json')))
 
-    t.deepEqual(transformPaths(result), expected, 'returns the first error')
+    t.same(transformPaths(result), expected, 'returns the first error')
   }
 
   t.end()

--- a/lib/spec/mock-express-middleware.js
+++ b/lib/spec/mock-express-middleware.js
@@ -25,19 +25,19 @@ external.invoke = (middleware, t, options) => {
   })
 
   const assertNextCalled = (called = true) => {
-    t.is(res.calledNext, called, `next middleware should${called ? '' : ' not'} be called`)
+    t.equal(res.calledNext, called, `next middleware should${called ? '' : ' not'} be called`)
   }
   const assertStatusCode = (expected, description) => {
     const code = res.statusCode
-    t.is(code, expected, description || `response status code should be ${code}`)
+    t.equal(code, expected, description || `response status code should be ${code}`)
   }
   const assertBody = (expected, description) => {
     const body = res._responseData.toString()
-    t.is(body, expected, description || `response body should be ${body}`)
+    t.equal(body, expected, description || `response body should be ${body}`)
   }
   const assertJSON = (expected, description) => {
     const json = JSON.parse(res._responseData.toString())
-    t.deepEqual(json, expected, description || `response json should be ${JSON.stringify(json)}`)
+    t.same(json, expected, description || `response json should be ${JSON.stringify(json)}`)
   }
   const assertHeaders = (headers) => {
     const resHeaders = res._headers

--- a/lib/submission/compose-email-body.unit.spec.js
+++ b/lib/submission/compose-email-body.unit.spec.js
@@ -16,12 +16,12 @@ test('supplying a invlid email type will thow an error', function (t) {
 })
 
 test('Composing the default email body for Team recipient', function (t) {
-  t.equals(composeEmailBody({}, 'en', emailTypes.TEAM), 'Please find an application attached', 'returns the default string')
+  t.equal(composeEmailBody({}, 'en', emailTypes.TEAM), 'Please find an application attached', 'returns the default string')
   t.end()
 })
 
 test('Composing the default email body for User recipient', function (t) {
-  t.equals(composeEmailBody({}, 'en', emailTypes.USER), 'A copy of your application is attached', 'returns the default string')
+  t.equal(composeEmailBody({}, 'en', emailTypes.USER), 'A copy of your application is attached', 'returns the default string')
   t.end()
 })
 
@@ -29,7 +29,7 @@ test('Composing the email body with variables in the content', function (t) {
   const editorDefinedBody = 'Dear {fullname}. A copy of your IoJ application is attached.'
   getInstancePropertyStub.withArgs('service', 'emailTemplateUser').returns(editorDefinedBody)
 
-  t.equals(composeEmailBody({ fullname: 'Bob' }, 'en', emailTypes.USER), 'Dear Bob. A copy of your IoJ application is attached.', 'returns the formated string')
+  t.equal(composeEmailBody({ fullname: 'Bob' }, 'en', emailTypes.USER), 'Dear Bob. A copy of your IoJ application is attached.', 'returns the formated string')
   t.end()
 })
 
@@ -37,6 +37,6 @@ test('Composing the email body with variables in the content', function (t) {
   const editorDefinedBody = '{fullname} has submitted a new applcation'
   getInstancePropertyStub.withArgs('service', 'emailTemplateTeam').returns(editorDefinedBody)
 
-  t.equals(composeEmailBody({ fullname: 'ALice' }, 'en', emailTypes.TEAM), 'ALice has submitted a new applcation', 'returns the formated string')
+  t.equal(composeEmailBody({ fullname: 'ALice' }, 'en', emailTypes.TEAM), 'ALice has submitted a new applcation', 'returns the formated string')
   t.end()
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,15 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@ampproject/remapping": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
+      "integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
+      "requires": {
+        "@jridgewell/gen-mapping": "^0.1.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
     "@apidevtools/json-schema-ref-parser": {
       "version": "9.0.7",
       "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.7.tgz",
@@ -22,54 +31,201 @@
         "@babel/highlight": "^7.8.3"
       }
     },
-    "@babel/generator": {
-      "version": "7.9.4",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.4.tgz",
-      "integrity": "sha512-rjP8ahaDy/ouhrvCoU1E5mqaitWrxwuNGU+dy1EpaoK48jZay4MdkskKGIMHLZNewg8sAsqpGSREJwP0zH3YQA==",
+    "@babel/compat-data": {
+      "version": "7.20.10",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.20.10.tgz",
+      "integrity": "sha512-sEnuDPpOJR/fcafHMjpcpGN5M2jbUGUHwmuWKM/YdPzeEDJg8bgmbcWQFUfE32MQjti1koACvoPVsDe8Uq+idg=="
+    },
+    "@babel/core": {
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.20.7.tgz",
+      "integrity": "sha512-t1ZjCluspe5DW24bn2Rr1CDb2v9rn/hROtg9a2tmd0+QYf4bsloYfLQzjG4qHPNMhWtKdGC33R5AxGR2Af2cBw==",
       "requires": {
-        "@babel/types": "^7.9.0",
-        "jsesc": "^2.5.1",
-        "lodash": "^4.17.13",
-        "source-map": "^0.5.0"
+        "@ampproject/remapping": "^2.1.0",
+        "@babel/code-frame": "^7.18.6",
+        "@babel/generator": "^7.20.7",
+        "@babel/helper-compilation-targets": "^7.20.7",
+        "@babel/helper-module-transforms": "^7.20.7",
+        "@babel/helpers": "^7.20.7",
+        "@babel/parser": "^7.20.7",
+        "@babel/template": "^7.20.7",
+        "@babel/traverse": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.1",
+        "semver": "^6.3.0"
       },
       "dependencies": {
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        "@babel/code-frame": {
+          "version": "7.18.6",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
+          "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
+          "requires": {
+            "@babel/highlight": "^7.18.6"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.19.1",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
+          "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w=="
+        },
+        "@babel/highlight": {
+          "version": "7.18.6",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
+          "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.18.6",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "json5": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.2.tgz",
+          "integrity": "sha512-46Tk9JiOL2z7ytNQWFLpj99RZkVgeHf87yGQKsIkaPz1qSH9UczKH1rO7K3wgRselo0tYMUNfecYpm/p1vC7tQ=="
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
       }
     },
-    "@babel/helper-function-name": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
-      "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
+    "@babel/generator": {
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.7.tgz",
+      "integrity": "sha512-7wqMOJq8doJMZmP4ApXTzLxSr7+oO2jroJURrVEp6XShrQUObV8Tq/D0NCcoYg2uHqUrjzO0zwBjoYzelxK+sw==",
       "requires": {
-        "@babel/helper-get-function-arity": "^7.8.3",
-        "@babel/template": "^7.8.3",
-        "@babel/types": "^7.8.3"
+        "@babel/types": "^7.20.7",
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "jsesc": "^2.5.1"
+      },
+      "dependencies": {
+        "@jridgewell/gen-mapping": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+          "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+          "requires": {
+            "@jridgewell/set-array": "^1.0.1",
+            "@jridgewell/sourcemap-codec": "^1.4.10",
+            "@jridgewell/trace-mapping": "^0.3.9"
+          }
+        }
       }
     },
-    "@babel/helper-get-function-arity": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
-      "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+    "@babel/helper-compilation-targets": {
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.7.tgz",
+      "integrity": "sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==",
       "requires": {
-        "@babel/types": "^7.8.3"
+        "@babel/compat-data": "^7.20.5",
+        "@babel/helper-validator-option": "^7.18.6",
+        "browserslist": "^4.21.3",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        }
+      }
+    },
+    "@babel/helper-environment-visitor": {
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
+      "integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg=="
+    },
+    "@babel/helper-function-name": {
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz",
+      "integrity": "sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==",
+      "requires": {
+        "@babel/template": "^7.18.10",
+        "@babel/types": "^7.19.0"
+      }
+    },
+    "@babel/helper-hoist-variables": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
+      "integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
+      "requires": {
+        "@babel/types": "^7.18.6"
+      }
+    },
+    "@babel/helper-module-imports": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
+      "integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
+      "requires": {
+        "@babel/types": "^7.18.6"
+      }
+    },
+    "@babel/helper-module-transforms": {
+      "version": "7.20.11",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.20.11.tgz",
+      "integrity": "sha512-uRy78kN4psmji1s2QtbtcCSaj/LILFDp0f/ymhpQH5QY3nljUZCaNWz9X1dEj/8MBdBEFECs7yRhKn8i7NjZgg==",
+      "requires": {
+        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-module-imports": "^7.18.6",
+        "@babel/helper-simple-access": "^7.20.2",
+        "@babel/helper-split-export-declaration": "^7.18.6",
+        "@babel/helper-validator-identifier": "^7.19.1",
+        "@babel/template": "^7.20.7",
+        "@babel/traverse": "^7.20.10",
+        "@babel/types": "^7.20.7"
+      },
+      "dependencies": {
+        "@babel/helper-validator-identifier": {
+          "version": "7.19.1",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
+          "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w=="
+        }
+      }
+    },
+    "@babel/helper-simple-access": {
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.20.2.tgz",
+      "integrity": "sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==",
+      "requires": {
+        "@babel/types": "^7.20.2"
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
-      "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
+      "integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
       "requires": {
-        "@babel/types": "^7.8.3"
+        "@babel/types": "^7.18.6"
       }
+    },
+    "@babel/helper-string-parser": {
+      "version": "7.19.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz",
+      "integrity": "sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw=="
     },
     "@babel/helper-validator-identifier": {
       "version": "7.9.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.0.tgz",
       "integrity": "sha512-6G8bQKjOh+of4PV/ThDm/rRqlU7+IGoJuofpagU5GlEl29Vv0RGqqt86ZGRV8ZuSOY3o+8yXl5y782SMcG7SHw=="
+    },
+    "@babel/helper-validator-option": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz",
+      "integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw=="
+    },
+    "@babel/helpers": {
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.20.7.tgz",
+      "integrity": "sha512-PBPjs5BppzsGaxHQCDKnZ6Gd9s6xl8bBCluz3vEInLGRJmnZan4F6BYCeqtyXqkk4W5IlPmjK4JlOuZkpJ3xZA==",
+      "requires": {
+        "@babel/template": "^7.20.7",
+        "@babel/traverse": "^7.20.7",
+        "@babel/types": "^7.20.7"
+      }
     },
     "@babel/highlight": {
       "version": "7.9.0",
@@ -82,44 +238,102 @@
       }
     },
     "@babel/parser": {
-      "version": "7.9.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.4.tgz",
-      "integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA=="
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.7.tgz",
+      "integrity": "sha512-T3Z9oHybU+0vZlY9CiDSJQTD5ZapcW18ZctFMi0MOAl/4BjFF4ul7NVSARLdbGO5vDqy9eQiGTV0LtKfvCYvcg=="
     },
     "@babel/template": {
-      "version": "7.8.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
-      "integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.20.7.tgz",
+      "integrity": "sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==",
       "requires": {
-        "@babel/code-frame": "^7.8.3",
-        "@babel/parser": "^7.8.6",
-        "@babel/types": "^7.8.6"
+        "@babel/code-frame": "^7.18.6",
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.18.6",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
+          "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
+          "requires": {
+            "@babel/highlight": "^7.18.6"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.19.1",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
+          "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w=="
+        },
+        "@babel/highlight": {
+          "version": "7.18.6",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
+          "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.18.6",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        }
       }
     },
     "@babel/traverse": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.0.tgz",
-      "integrity": "sha512-jAZQj0+kn4WTHO5dUZkZKhbFrqZE7K5LAQ5JysMnmvGij+wOdr+8lWqPeW0BcF4wFwrEXXtdGO7wcV6YPJcf3w==",
+      "version": "7.20.10",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.10.tgz",
+      "integrity": "sha512-oSf1juCgymrSez8NI4A2sr4+uB/mFd9MXplYGPEBnfAuWmmyeVcHa6xLPiaRBcXkcb/28bgxmQLTVwFKE1yfsg==",
       "requires": {
-        "@babel/code-frame": "^7.8.3",
-        "@babel/generator": "^7.9.0",
-        "@babel/helper-function-name": "^7.8.3",
-        "@babel/helper-split-export-declaration": "^7.8.3",
-        "@babel/parser": "^7.9.0",
-        "@babel/types": "^7.9.0",
+        "@babel/code-frame": "^7.18.6",
+        "@babel/generator": "^7.20.7",
+        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-function-name": "^7.19.0",
+        "@babel/helper-hoist-variables": "^7.18.6",
+        "@babel/helper-split-export-declaration": "^7.18.6",
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
         "debug": "^4.1.0",
-        "globals": "^11.1.0",
-        "lodash": "^4.17.13"
+        "globals": "^11.1.0"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.18.6",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
+          "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
+          "requires": {
+            "@babel/highlight": "^7.18.6"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.19.1",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
+          "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w=="
+        },
+        "@babel/highlight": {
+          "version": "7.18.6",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
+          "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.18.6",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        }
       }
     },
     "@babel/types": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.0.tgz",
-      "integrity": "sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.7.tgz",
+      "integrity": "sha512-69OnhBxSSgK0OzTJai4kyPDiKTIe3j+ctaHdIGVbRahTLAT7L3R9oeXHC2aVSuGYt3cVnoAMDmOCgJ2yaiLMvg==",
       "requires": {
-        "@babel/helper-validator-identifier": "^7.9.0",
-        "lodash": "^4.17.13",
+        "@babel/helper-string-parser": "^7.19.4",
+        "@babel/helper-validator-identifier": "^7.19.1",
         "to-fast-properties": "^2.0.0"
+      },
+      "dependencies": {
+        "@babel/helper-validator-identifier": {
+          "version": "7.19.1",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
+          "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w=="
+        }
       }
     },
     "@eslint/eslintrc": {
@@ -216,6 +430,93 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
+    },
+    "@istanbuljs/load-nyc-config": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+      "requires": {
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+        },
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
+        }
+      }
+    },
+    "@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA=="
+    },
+    "@jridgewell/gen-mapping": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
+      "integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
+      "requires": {
+        "@jridgewell/set-array": "^1.0.0",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "@jridgewell/resolve-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w=="
+    },
+    "@jridgewell/set-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw=="
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
+      "integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
+      "requires": {
+        "@jridgewell/resolve-uri": "3.1.0",
+        "@jridgewell/sourcemap-codec": "1.4.14"
+      }
     },
     "@jsdevtools/ono": {
       "version": "7.1.3",
@@ -418,6 +719,37 @@
         "fastq": "^1.6.0"
       }
     },
+    "@npmcli/fs": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-3.1.0.tgz",
+      "integrity": "sha512-7kZUAaLscfgbwBQRbvdMYaZOWyMEcPTH/tJjnyAWJ/dvvs9Ef+CERx/qJb9GExJpl1qipaDGn7KqHnFGGixd0w==",
+      "requires": {
+        "semver": "^7.3.5"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
+    },
     "@promster/express": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/@promster/express/-/express-4.1.11.tgz",
@@ -587,6 +919,11 @@
         "defer-to-connect": "^2.0.0"
       }
     },
+    "@tootallnate/once": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A=="
+    },
     "@types/cacheable-request": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.2.tgz",
@@ -707,6 +1044,25 @@
         "debug": "4"
       }
     },
+    "agentkeepalive": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.2.1.tgz",
+      "integrity": "sha512-Zn4cw2NEqd+9fiSVWMscnjyQ1a8Yfoc5oBajLeo5w+YBHgDUcEBY2hS4YpTz6iN5f/2zQiktcuM6tS8x1p9dpA==",
+      "requires": {
+        "debug": "^4.1.0",
+        "depd": "^1.1.2",
+        "humanize-ms": "^1.2.1"
+      }
+    },
+    "aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "requires": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      }
+    },
     "ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -732,9 +1088,9 @@
       }
     },
     "anymatch": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
-      "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
       "requires": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -746,22 +1102,17 @@
       "integrity": "sha1-HjRA6RXwsSA9I3SOeO3XubW0PlY="
     },
     "append-transform": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-1.0.0.tgz",
-      "integrity": "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-2.0.0.tgz",
+      "integrity": "sha512-7yeyCEurROLQJFv5Xj4lEGTy0borxepjFv1g22oAdqFu//SrAlDl1O1Nxx15SH1RoliUml6p8dwJW9jvZughhg==",
       "requires": {
-        "default-require-extensions": "^2.0.0"
+        "default-require-extensions": "^3.0.0"
       }
     },
     "archy": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
       "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw=="
-    },
-    "arg": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
     },
     "argparse": {
       "version": "1.0.10",
@@ -1159,14 +1510,6 @@
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
-    "asn1": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-      "requires": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
     "asn1.js": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
@@ -1214,39 +1557,22 @@
         }
       }
     },
-    "assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-    },
     "async-hook-domain": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/async-hook-domain/-/async-hook-domain-1.1.3.tgz",
-      "integrity": "sha512-ZovMxSbADV3+biB7oR1GL5lGyptI24alp0LWHlmz1OFc5oL47pz3EiIF6nXOkDW7yLqih4NtsiYduzdDW0i+Wg==",
-      "requires": {
-        "source-map-support": "^0.5.11"
-      }
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/async-hook-domain/-/async-hook-domain-2.0.4.tgz",
+      "integrity": "sha512-14LjCmlK1PK8eDtTezR6WX8TMaYNIzBIsd2D1sGoGjgx0BuNMMoSdk7i/drlbtamy0AWv9yv2tkB+ASdmeqFIw=="
     },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
     },
     "available-typed-arrays": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
       "dev": true
-    },
-    "aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
-    },
-    "aws4": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
-      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
     },
     "babel-runtime": {
       "version": "6.26.0",
@@ -1284,23 +1610,15 @@
         }
       }
     },
-    "bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-      "requires": {
-        "tweetnacl": "^0.14.3"
-      }
-    },
     "binary-extensions": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
-      "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
     },
     "bind-obj-methods": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/bind-obj-methods/-/bind-obj-methods-2.0.0.tgz",
-      "integrity": "sha512-3/qRXczDi2Cdbz6jE+W3IflJOutRVica8frpBn14de1mBOkzDo+6tY33kNhvkw54Kn3PzRRD2VnGbGPcTAk4sw=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bind-obj-methods/-/bind-obj-methods-3.0.0.tgz",
+      "integrity": "sha512-nLEaaz3/sEzNSyPWRsN9HNsqwk1AUyECtGj+XwGdIi3xABnEqecvXtIJ0wehQXuuER5uZ/5fTs2usONgYjG+iw=="
     },
     "bintrees": {
       "version": "1.0.1",
@@ -1406,11 +1724,6 @@
       "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
       "dev": true
     },
-    "browser-process-hrtime": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
-      "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow=="
-    },
     "browserify-aes": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
@@ -1504,6 +1817,17 @@
       "dev": true,
       "requires": {
         "pako": "~1.0.5"
+      }
+    },
+    "browserslist": {
+      "version": "4.21.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
+      "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
+      "requires": {
+        "caniuse-lite": "^1.0.30001400",
+        "electron-to-chromium": "^1.4.251",
+        "node-releases": "^2.0.6",
+        "update-browserslist-db": "^1.0.9"
       }
     },
     "buffer": {
@@ -1606,6 +1930,74 @@
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
     },
+    "cacache": {
+      "version": "17.0.4",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-17.0.4.tgz",
+      "integrity": "sha512-Z/nL3gU+zTUjz5pCA5vVjYM8pmaw2kxM7JEiE0fv3w77Wj+sFbi70CrBruUWH0uNcEdvLDixFpgA2JM4F4DBjA==",
+      "requires": {
+        "@npmcli/fs": "^3.1.0",
+        "fs-minipass": "^3.0.0",
+        "glob": "^8.0.1",
+        "lru-cache": "^7.7.1",
+        "minipass": "^4.0.0",
+        "minipass-collect": "^1.0.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "p-map": "^4.0.0",
+        "promise-inflight": "^1.0.1",
+        "ssri": "^10.0.0",
+        "tar": "^6.1.11",
+        "unique-filename": "^3.0.0"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "glob": {
+          "version": "8.0.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
+          "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^5.0.1",
+            "once": "^1.3.0"
+          }
+        },
+        "lru-cache": {
+          "version": "7.14.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.1.tgz",
+          "integrity": "sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA=="
+        },
+        "minimatch": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.2.tgz",
+          "integrity": "sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==",
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        },
+        "minipass": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.0.0.tgz",
+          "integrity": "sha512-g2Uuh2jEKoht+zvO6vJqXmYpflPqzRBT+Th2h01DKh5z7wbY/AZ2gCQ78cP70YoHPyFdY30YBV5WxgLOEwOykw==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
+    },
     "cacheable-lookup": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-2.0.1.tgz",
@@ -1630,24 +2022,25 @@
       }
     },
     "caching-transform": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-3.0.2.tgz",
-      "integrity": "sha512-Mtgcv3lh3U0zRii/6qVgQODdPA4G3zhG+jtbCWj39RXuUFTMzH0vcdMtaJS1jPowd+It2Pqr6y3NJMQqOqCE2w==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-4.0.0.tgz",
+      "integrity": "sha512-kpqOvwXnjjN44D89K5ccQC+RUrsy7jB/XLlRrx0D7/2HNcTPqzsb6XgYoErwko6QsV184CA2YgS1fxDiiDZMWA==",
       "requires": {
-        "hasha": "^3.0.0",
-        "make-dir": "^2.0.0",
-        "package-hash": "^3.0.0",
-        "write-file-atomic": "^2.4.2"
+        "hasha": "^5.0.0",
+        "make-dir": "^3.0.0",
+        "package-hash": "^4.0.0",
+        "write-file-atomic": "^3.0.0"
       },
       "dependencies": {
         "write-file-atomic": {
-          "version": "2.4.3",
-          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
-          "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+          "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
           "requires": {
-            "graceful-fs": "^4.1.11",
             "imurmurhash": "^0.1.4",
-            "signal-exit": "^3.0.2"
+            "is-typedarray": "^1.0.0",
+            "signal-exit": "^3.0.2",
+            "typedarray-to-buffer": "^3.1.5"
           }
         }
       }
@@ -1677,10 +2070,10 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
     },
-    "caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    "caniuse-lite": {
+      "version": "1.0.30001441",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001441.tgz",
+      "integrity": "sha512-OyxRR4Vof59I3yGWXws6i908EtGbMzVUi3ganaZQHmydk1iwDhRnvaPG2WaR0KcqrDFKrxVZHULT396LEPhXfg=="
     },
     "chalk": {
       "version": "2.4.2",
@@ -1703,19 +2096,24 @@
       }
     },
     "chokidar": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.1.tgz",
-      "integrity": "sha512-4QYCEWOcK3OJrxwvyyAOxFuhpvOVCYkr33LPfFNBjAD/w3sEzWsp2BUOkI4l9bHvWioAd0rc6NlHUOEaWkTeqg==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
       "requires": {
-        "anymatch": "~3.1.1",
+        "anymatch": "~3.1.2",
         "braces": "~3.0.2",
-        "fsevents": "~2.1.2",
-        "glob-parent": "~5.1.0",
+        "fsevents": "~2.3.2",
+        "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
-        "readdirp": "~3.3.0"
+        "readdirp": "~3.6.0"
       }
+    },
+    "chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
     },
     "cipher-base": {
       "version": "1.0.4",
@@ -1726,6 +2124,11 @@
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
+    },
+    "clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="
     },
     "cliui": {
       "version": "5.0.0",
@@ -1774,6 +2177,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -1988,19 +2392,9 @@
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
     },
     "convert-source-map": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
-      "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
-      "requires": {
-        "safe-buffer": "~5.1.1"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        }
-      }
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
     },
     "cookie": {
       "version": "0.3.1",
@@ -2053,37 +2447,6 @@
       "requires": {
         "object-assign": "^4",
         "vary": "^1"
-      }
-    },
-    "coveralls": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.1.0.tgz",
-      "integrity": "sha512-sHxOu2ELzW8/NC1UP5XVLbZDzO4S3VxfFye3XYCznopHy02YjNkHcj5bKaVw2O7hVaBdBjEdQGpie4II1mWhuQ==",
-      "requires": {
-        "js-yaml": "^3.13.1",
-        "lcov-parse": "^1.0.0",
-        "log-driver": "^1.2.7",
-        "minimist": "^1.2.5",
-        "request": "^2.88.2"
-      }
-    },
-    "cp-file": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/cp-file/-/cp-file-6.2.0.tgz",
-      "integrity": "sha512-fmvV4caBnofhPe8kOcitBwSn2f39QLjnAnGq3gO9dfd75mUytzKNZB1hde6QHunW2Rt+OwuBOMc3i1tNElbszA==",
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "make-dir": "^2.0.0",
-        "nested-error-stacks": "^2.0.0",
-        "pify": "^4.0.1",
-        "safe-buffer": "^5.0.1"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
-        }
       }
     },
     "create-ecdh": {
@@ -2190,14 +2553,6 @@
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
       "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw=="
     },
-    "dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "requires": {
-        "assert-plus": "^1.0.0"
-      }
-    },
     "date-fns": {
       "version": "2.28.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
@@ -2297,18 +2652,11 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
     "default-require-extensions": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
-      "integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-3.0.1.tgz",
+      "integrity": "sha512-eXTJmRbm2TIt9MgWTsOH1wEuhew6XGZcMeGKCtLedIg/NCsg1iBePXkceTdK4Fii7pzmN9tGsZhKzZ4h7O/fxw==",
       "requires": {
-        "strip-bom": "^3.0.0"
-      },
-      "dependencies": {
-        "strip-bom": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
-        }
+        "strip-bom": "^4.0.0"
       }
     },
     "defer-to-connect": {
@@ -2334,13 +2682,13 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
     },
     "depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-      "dev": true
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
     },
     "des.js": {
       "version": "1.0.1",
@@ -2385,11 +2733,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
-    },
-    "diff-frag": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/diff-frag/-/diff-frag-1.0.1.tgz",
-      "integrity": "sha512-6/v2PC/6UTGcWPPetb9acL8foberUg/CtPdALeJUdD1B/weHNvzftoo00gYznqHGRhHEbykUGzqfG9RWOSr5yw=="
     },
     "diffie-hellman": {
       "version": "5.0.3",
@@ -2488,15 +2831,6 @@
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
     },
-    "ecc-jsbn": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-      "requires": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
-      }
-    },
     "ecdsa-sig-formatter": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
@@ -2509,6 +2843,11 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
+    "electron-to-chromium": {
+      "version": "1.4.284",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
+      "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA=="
     },
     "elliptic": {
       "version": "6.5.4",
@@ -2543,6 +2882,26 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
+    "encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "optional": true,
+      "requires": {
+        "iconv-lite": "^0.6.2"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.6.3",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+          "optional": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        }
+      }
+    },
     "end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -2555,6 +2914,11 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
       "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w=="
+    },
+    "err-code": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="
     },
     "error-ex": {
       "version": "1.3.2",
@@ -3306,11 +3670,6 @@
       "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
       "dev": true
     },
-    "esm": {
-      "version": "3.2.25",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
-    },
     "espree": {
       "version": "9.4.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
@@ -3543,16 +3902,6 @@
         "basic-auth": "^2.0.1"
       }
     },
-    "extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-    },
-    "extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
-    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3647,13 +3996,13 @@
       }
     },
     "find-cache-dir": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
-      "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
       "requires": {
         "commondir": "^1.0.1",
-        "make-dir": "^2.0.0",
-        "pkg-dir": "^3.0.0"
+        "make-dir": "^3.0.2",
+        "pkg-dir": "^4.1.0"
       }
     },
     "find-up": {
@@ -3696,21 +4045,6 @@
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
     },
-    "flow-parser": {
-      "version": "0.138.0",
-      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.138.0.tgz",
-      "integrity": "sha512-LFnTyjrv39UvCWl8NOcpByr/amj8a5k5z7isO2wv4T43nNrUnHQwX3rarTz9zcpHXkDAQv6X4MfQ4ZzJUptpbw=="
-    },
-    "flow-remove-types": {
-      "version": "2.138.0",
-      "resolved": "https://registry.npmjs.org/flow-remove-types/-/flow-remove-types-2.138.0.tgz",
-      "integrity": "sha512-gWZYpCAcpX5SD7j1S5DrWLWm+ir5LXkkRTrCokTdO5aW6M1cqQmHN5lxwoQTqkP8PfgXI8ILD810TL9CvexpgA==",
-      "requires": {
-        "flow-parser": "^0.138.0",
-        "pirates": "^3.0.2",
-        "vlq": "^0.2.1"
-      }
-    },
     "for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -3721,46 +4055,12 @@
       }
     },
     "foreground-child": {
-      "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
-      "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
+      "integrity": "sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==",
       "requires": {
-        "cross-spawn": "^4",
-        "signal-exit": "^3.0.0"
-      },
-      "dependencies": {
-        "cross-spawn": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-          "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
-          "requires": {
-            "lru-cache": "^4.0.1",
-            "which": "^1.2.9"
-          }
-        },
-        "which": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-          "requires": {
-            "isexe": "^2.0.0"
-          }
-        }
-      }
-    },
-    "forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
-    },
-    "form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^3.0.2"
       }
     },
     "formidable": {
@@ -3797,10 +4097,38 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
+    "fromentries": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz",
+      "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg=="
+    },
     "fs-exists-cached": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-exists-cached/-/fs-exists-cached-1.0.0.tgz",
       "integrity": "sha512-kSxoARUDn4F2RPXX48UXnaFKwVU7Ivd/6qpzZL29MCDmr9sTvybv4gFCp+qaI4fM9m0z9fgz/yJvi56GAz+BZg=="
+    },
+    "fs-minipass": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.0.tgz",
+      "integrity": "sha512-EUojgQaSPy6sxcqcZgQv6TVF6jiKvurji3AxhAivs/Ep4O1UpS8TusaxpybfFHZ2skRhLqzk6WR8nqNYIMMDeA==",
+      "requires": {
+        "minipass": "^4.0.0"
+      },
+      "dependencies": {
+        "minipass": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.0.0.tgz",
+          "integrity": "sha512-g2Uuh2jEKoht+zvO6vJqXmYpflPqzRBT+Th2h01DKh5z7wbY/AZ2gCQ78cP70YoHPyFdY30YBV5WxgLOEwOykw==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -3808,9 +4136,9 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
-      "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "optional": true
     },
     "function-bind": {
@@ -3819,9 +4147,9 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "function-loop": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/function-loop/-/function-loop-1.0.2.tgz",
-      "integrity": "sha512-Iw4MzMfS3udk/rqxTiDDCllhGwlOrsr50zViTOO/W6lS/9y6B1J0BD2VZzrnWUYBJsl3aeqjgR5v7bWWhZSYbA=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/function-loop/-/function-loop-2.0.1.tgz",
+      "integrity": "sha512-ktIR+O6i/4h+j/ZhZJNdzeI4i9lEPeEK6UPR2EVyTVBqOwcU3Za9xYKLH64ZR9HmcROyRrOkizNyjjtWJzDDkQ=="
     },
     "function.prototype.name": {
       "version": "1.1.5",
@@ -4504,6 +4832,11 @@
         }
       }
     },
+    "gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="
+    },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -4522,8 +4855,7 @@
     "get-package-type": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
-      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
-      "dev": true
+      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q=="
     },
     "get-stream": {
       "version": "5.2.0",
@@ -4570,14 +4902,6 @@
           "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
           "dev": true
         }
-      }
-    },
-    "getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "requires": {
-        "assert-plus": "^1.0.0"
       }
     },
     "glob": {
@@ -4839,20 +5163,6 @@
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
       "dev": true
     },
-    "har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
-    },
-    "har-validator": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-      "requires": {
-        "ajv": "^6.12.3",
-        "har-schema": "^2.0.0"
-      }
-    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -5005,11 +5315,19 @@
       }
     },
     "hasha": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/hasha/-/hasha-3.0.0.tgz",
-      "integrity": "sha1-UqMvq4Vp1BymmmH/GiFPjrfIvTk=",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.2.tgz",
+      "integrity": "sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==",
       "requires": {
-        "is-stream": "^1.0.1"
+        "is-stream": "^2.0.0",
+        "type-fest": "^0.8.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
+        }
       }
     },
     "he": {
@@ -5068,14 +5386,14 @@
         }
       }
     },
-    "http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+    "http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
       "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
       }
     },
     "https-browserify": {
@@ -5091,6 +5409,14 @@
       "requires": {
         "agent-base": "6",
         "debug": "4"
+      }
+    },
+    "humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "requires": {
+        "ms": "^2.0.0"
       }
     },
     "iconv-lite": {
@@ -5127,6 +5453,11 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+    },
+    "indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
     },
     "inflight": {
       "version": "1.0.6",
@@ -5176,6 +5507,11 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
       "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA=="
+    },
+    "ip": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
+      "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
     },
     "ipaddr.js": {
       "version": "1.9.1",
@@ -5271,6 +5607,11 @@
         "is-extglob": "^2.1.1"
       }
     },
+    "is-lambda": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
+      "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ=="
+    },
     "is-map": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
@@ -5360,9 +5701,9 @@
       }
     },
     "is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="
     },
     "is-string": {
       "version": "1.0.5",
@@ -5475,6 +5816,11 @@
         }
       }
     },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+    },
     "isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -5485,36 +5831,28 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
-    "isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
-    },
     "istanbul-lib-coverage": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
-      "integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA=="
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
+      "integrity": "sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw=="
     },
     "istanbul-lib-hook": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-2.0.7.tgz",
-      "integrity": "sha512-vrRztU9VRRFDyC+aklfLoeXyNdTfga2EI3udDGn4cZ6fpSXpHLV9X6CHvfoMCPtggg8zvDDmC4b9xfu0z6/llA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-3.0.0.tgz",
+      "integrity": "sha512-Pt/uge1Q9s+5VAZ+pCo16TYMWPBIl+oaNIjgLQxcX0itS6ueeaA+pEfThZpH8WxhFgCiEb8sAJY6MdUKgiIWaQ==",
       "requires": {
-        "append-transform": "^1.0.0"
+        "append-transform": "^2.0.0"
       }
     },
     "istanbul-lib-instrument": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
-      "integrity": "sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
+      "integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
       "requires": {
-        "@babel/generator": "^7.4.0",
-        "@babel/parser": "^7.4.3",
-        "@babel/template": "^7.4.0",
-        "@babel/traverse": "^7.4.3",
-        "@babel/types": "^7.4.0",
-        "istanbul-lib-coverage": "^2.0.5",
-        "semver": "^6.0.0"
+        "@babel/core": "^7.7.5",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.0.0",
+        "semver": "^6.3.0"
       },
       "dependencies": {
         "semver": {
@@ -5525,114 +5863,84 @@
       }
     },
     "istanbul-lib-processinfo": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-1.0.0.tgz",
-      "integrity": "sha512-FY0cPmWa4WoQNlvB8VOcafiRoB5nB+l2Pz2xGuXHRSy1KM8QFOYfz/rN+bGMCAeejrY3mrpF5oJHcN0s/garCg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.3.tgz",
+      "integrity": "sha512-NkwHbo3E00oybX6NGJi6ar0B29vxyvNwoC7eJ4G4Yq28UfY758Hgn/heV8VRFhevPED4LXfFz0DQ8z/0kw9zMg==",
       "requires": {
         "archy": "^1.0.0",
-        "cross-spawn": "^6.0.5",
-        "istanbul-lib-coverage": "^2.0.3",
-        "rimraf": "^2.6.3",
-        "uuid": "^3.3.2"
+        "cross-spawn": "^7.0.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "p-map": "^3.0.0",
+        "rimraf": "^3.0.0",
+        "uuid": "^8.3.2"
       },
       "dependencies": {
-        "cross-spawn": {
-          "version": "6.0.5",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+        "p-map": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
+          "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
           "requires": {
-            "nice-try": "^1.0.4",
-            "path-key": "^2.0.1",
-            "semver": "^5.5.0",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
+            "aggregate-error": "^3.0.0"
           }
-        },
-        "path-key": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
         },
         "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
           "requires": {
             "glob": "^7.1.3"
-          }
-        },
-        "shebang-command": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-          "requires": {
-            "shebang-regex": "^1.0.0"
-          }
-        },
-        "shebang-regex": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
-        },
-        "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
-        },
-        "which": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-          "requires": {
-            "isexe": "^2.0.0"
           }
         }
       }
     },
     "istanbul-lib-report": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
-      "integrity": "sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+      "integrity": "sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==",
       "requires": {
-        "istanbul-lib-coverage": "^2.0.5",
-        "make-dir": "^2.1.0",
-        "supports-color": "^6.1.0"
-      }
-    },
-    "istanbul-lib-source-maps": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
-      "integrity": "sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==",
-      "requires": {
-        "debug": "^4.1.1",
-        "istanbul-lib-coverage": "^2.0.5",
-        "make-dir": "^2.1.0",
-        "rimraf": "^2.6.3",
-        "source-map": "^0.6.1"
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^3.0.0",
+        "supports-color": "^7.1.0"
       },
       "dependencies": {
-        "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "requires": {
-            "glob": "^7.1.3"
+            "has-flag": "^4.0.0"
           }
         }
       }
     },
-    "istanbul-reports": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.7.tgz",
-      "integrity": "sha512-uu1F/L1o5Y6LzPVSVZXNOoD/KXpJue9aeLRd0sM9uMXfZvzomB0WxVamWb5ue8kA2vVWEmW7EG+A5n3f1kqHKg==",
+    "istanbul-lib-source-maps": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
       "requires": {
-        "html-escaper": "^2.0.0"
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      }
+    },
+    "istanbul-reports": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.5.tgz",
+      "integrity": "sha512-nUsEMa9pBt/NOHqbcbeJEgqIlY/K7rVWUX6Lql2orY5e9roQOthbR3vtY4zzf2orPELg80fnxxk9zUyPlgwD1w==",
+      "requires": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
       }
     },
     "jackspeak": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-1.4.1.tgz",
-      "integrity": "sha512-npN8f+M4+IQ8xD3CcWi3U62VQwKlT3Tj4GxbdT/fYTmeogD9eBF9OFdpoFG/VPNoshRjPUijdkp/p2XrzUHaVg==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-1.4.2.tgz",
+      "integrity": "sha512-GHeGTmnuaHnvS+ZctRB01bfxARuu9wW83ENbuiweu07SFcVlZrJpcshSre/keGT7YGBhLHg/+rXCNSrsEHKU4Q==",
       "requires": {
         "cliui": "^7.0.4"
       },
@@ -5733,11 +6041,6 @@
         "esprima": "^4.0.0"
       }
     },
-    "jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
-    },
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -5752,11 +6055,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
-    },
-    "json-schema": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
     },
     "json-schema-compare": {
       "version": "0.2.2",
@@ -5794,11 +6092,6 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
-    },
-    "json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json5": {
       "version": "1.0.1",
@@ -5870,17 +6163,6 @@
         "semver": "^5.6.0"
       }
     },
-    "jsprim": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
-      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
-      "requires": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.4.0",
-        "verror": "1.10.0"
-      }
-    },
     "just-extend": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
@@ -5914,11 +6196,6 @@
         "json-buffer": "3.0.1"
       }
     },
-    "lcov-parse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-1.0.0.tgz",
-      "integrity": "sha1-6w1GtUER68VhrLTECO+TY73I9+A="
-    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -5926,6 +6203,36 @@
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
+      }
+    },
+    "libtap": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/libtap/-/libtap-1.4.0.tgz",
+      "integrity": "sha512-STLFynswQ2A6W14JkabgGetBNk6INL1REgJ9UeNKw5llXroC2cGLgKTqavv0sl8OLVztLLipVKMcQ7yeUcqpmg==",
+      "requires": {
+        "async-hook-domain": "^2.0.4",
+        "bind-obj-methods": "^3.0.0",
+        "diff": "^4.0.2",
+        "function-loop": "^2.0.1",
+        "minipass": "^3.1.5",
+        "own-or": "^1.0.0",
+        "own-or-env": "^1.0.2",
+        "signal-exit": "^3.0.4",
+        "stack-utils": "^2.0.4",
+        "tap-parser": "^11.0.0",
+        "tap-yaml": "^1.0.0",
+        "tcompare": "^5.0.6",
+        "trivial-deferred": "^1.0.1"
+      },
+      "dependencies": {
+        "minipass": {
+          "version": "3.3.6",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+          "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        }
       }
     },
     "lines-and-columns": {
@@ -6091,31 +6398,24 @@
       "resolved": "https://registry.npmjs.org/lodash.unset/-/lodash.unset-4.5.2.tgz",
       "integrity": "sha1-Nw0dPoW3Kn4bDN8tJyEhMG8j5O0="
     },
-    "log-driver": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
-      "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg=="
-    },
-    "loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "requires": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      }
-    },
     "lowercase-keys": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
       "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="
     },
     "lru-cache": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
+        "yallist": "^3.0.2"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+        }
       }
     },
     "lru_map": {
@@ -6124,25 +6424,67 @@
       "integrity": "sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ=="
     },
     "make-dir": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-      "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
       "requires": {
-        "pify": "^4.0.1",
-        "semver": "^5.6.0"
+        "semver": "^6.0.0"
       },
       "dependencies": {
-        "pify": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
       }
     },
-    "make-error": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
+    "make-fetch-happen": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-11.0.2.tgz",
+      "integrity": "sha512-5n/Pq41w/uZghpdlXAY5kIM85RgJThtTH/NYBRAZ9VUOBWV90USaQjwGrw76fZP3Lj5hl/VZjpVvOaRBMoL/2w==",
+      "requires": {
+        "agentkeepalive": "^4.2.1",
+        "cacache": "^17.0.0",
+        "http-cache-semantics": "^4.1.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "is-lambda": "^1.0.1",
+        "lru-cache": "^7.7.1",
+        "minipass": "^4.0.0",
+        "minipass-collect": "^1.0.2",
+        "minipass-fetch": "^3.0.0",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "negotiator": "^0.6.3",
+        "promise-retry": "^2.0.1",
+        "socks-proxy-agent": "^7.0.0",
+        "ssri": "^10.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "7.14.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.1.tgz",
+          "integrity": "sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA=="
+        },
+        "minipass": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.0.0.tgz",
+          "integrity": "sha512-g2Uuh2jEKoht+zvO6vJqXmYpflPqzRBT+Th2h01DKh5z7wbY/AZ2gCQ78cP70YoHPyFdY30YBV5WxgLOEwOykw==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "negotiator": {
+          "version": "0.6.3",
+          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+          "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
     },
     "make-plural": {
       "version": "4.3.0",
@@ -6224,14 +6566,6 @@
       "integrity": "sha512-S7xYIeWHl2ZUKF7SDeBhGg6rfv5bKxVBdk95s/I7wVF8d+hjLSztJ/B271cnUiF6CAFduEQ5Zn3HYwAjT16DlQ==",
       "requires": {
         "is-plain-obj": "^2.0.0"
-      }
-    },
-    "merge-source-map": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.1.0.tgz",
-      "integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
-      "requires": {
-        "source-map": "^0.6.1"
       }
     },
     "messageformat": {
@@ -6330,6 +6664,80 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
       "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
       "requires": {
+        "yallist": "^4.0.0"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
+    },
+    "minipass-collect": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
+      "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
+      "requires": {
+        "minipass": "^3.0.0"
+      }
+    },
+    "minipass-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-3.0.1.tgz",
+      "integrity": "sha512-t9/wowtf7DYkwz8cfMSt0rMwiyNIBXf5CKZ3S5ZMqRqMYT0oLTp0x1WorMI9WTwvaPg21r1JbFxJMum8JrLGfw==",
+      "requires": {
+        "encoding": "^0.1.13",
+        "minipass": "^4.0.0",
+        "minipass-sized": "^1.0.3",
+        "minizlib": "^2.1.2"
+      },
+      "dependencies": {
+        "minipass": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.0.0.tgz",
+          "integrity": "sha512-g2Uuh2jEKoht+zvO6vJqXmYpflPqzRBT+Th2h01DKh5z7wbY/AZ2gCQ78cP70YoHPyFdY30YBV5WxgLOEwOykw==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
+    },
+    "minipass-flush": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
+      "integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
+      "requires": {
+        "minipass": "^3.0.0"
+      }
+    },
+    "minipass-pipeline": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+      "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
+      "requires": {
+        "minipass": "^3.0.0"
+      }
+    },
+    "minipass-sized": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
+      "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
+      "requires": {
+        "minipass": "^3.0.0"
+      }
+    },
+    "minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "requires": {
+        "minipass": "^3.0.0",
         "yallist": "^4.0.0"
       },
       "dependencies": {
@@ -6623,16 +7031,6 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
       "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
     },
-    "nested-error-stacks": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz",
-      "integrity": "sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug=="
-    },
-    "nice-try": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
-    },
     "nise": {
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.4.tgz",
@@ -6778,10 +7176,18 @@
         }
       }
     },
-    "node-modules-regexp": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
-      "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA="
+    "node-preload": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/node-preload/-/node-preload-0.2.1.tgz",
+      "integrity": "sha512-RM5oyBy45cLEoHqCeh+MNuFAxO0vTFBLskvQbOKnEE7YTTSN4tbN8QWDIPQ6L+WvKsB/qLEGpYe2ZZ9d4W9OIQ==",
+      "requires": {
+        "process-on-spawn": "^1.0.0"
+      }
+    },
+    "node-releases": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.8.tgz",
+      "integrity": "sha512-dFSmB8fFHEH/s81Xi+Y/15DQY6VHW81nXRj86EMSL3lmuTmK1e+aT4wrFCkTbm+gSwkw4KpX+rT/pMM2c1mF+A=="
     },
     "nopt": {
       "version": "2.1.2",
@@ -6831,73 +7237,192 @@
       }
     },
     "nyc": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/nyc/-/nyc-14.1.1.tgz",
-      "integrity": "sha512-OI0vm6ZGUnoGZv/tLdZ2esSVzDwUC88SNs+6JoSOMVxA+gKMB8Tk7jBwgemLx4O40lhhvZCVw1C+OYLOBOPXWw==",
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-15.1.0.tgz",
+      "integrity": "sha512-jMW04n9SxKdKi1ZMGhvUTHBN0EICCRkHemEoE5jm6mTYcqcdas0ATzgUgejlQUHMvpnOZqGB5Xxsv9KxJW1j8A==",
       "requires": {
-        "archy": "^1.0.0",
-        "caching-transform": "^3.0.2",
-        "convert-source-map": "^1.6.0",
-        "cp-file": "^6.2.0",
-        "find-cache-dir": "^2.1.0",
-        "find-up": "^3.0.0",
-        "foreground-child": "^1.5.6",
-        "glob": "^7.1.3",
-        "istanbul-lib-coverage": "^2.0.5",
-        "istanbul-lib-hook": "^2.0.7",
-        "istanbul-lib-instrument": "^3.3.0",
-        "istanbul-lib-report": "^2.0.8",
-        "istanbul-lib-source-maps": "^3.0.6",
-        "istanbul-reports": "^2.2.4",
-        "js-yaml": "^3.13.1",
-        "make-dir": "^2.1.0",
-        "merge-source-map": "^1.1.0",
-        "resolve-from": "^4.0.0",
-        "rimraf": "^2.6.3",
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.2",
+        "caching-transform": "^4.0.0",
+        "convert-source-map": "^1.7.0",
+        "decamelize": "^1.2.0",
+        "find-cache-dir": "^3.2.0",
+        "find-up": "^4.1.0",
+        "foreground-child": "^2.0.0",
+        "get-package-type": "^0.1.0",
+        "glob": "^7.1.6",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-hook": "^3.0.0",
+        "istanbul-lib-instrument": "^4.0.0",
+        "istanbul-lib-processinfo": "^2.0.2",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.0.2",
+        "make-dir": "^3.0.0",
+        "node-preload": "^0.2.1",
+        "p-map": "^3.0.0",
+        "process-on-spawn": "^1.0.0",
+        "resolve-from": "^5.0.0",
+        "rimraf": "^3.0.0",
         "signal-exit": "^3.0.2",
-        "spawn-wrap": "^1.4.2",
-        "test-exclude": "^5.2.3",
-        "uuid": "^3.3.2",
-        "yargs": "^13.2.2",
-        "yargs-parser": "^13.0.0"
+        "spawn-wrap": "^2.0.0",
+        "test-exclude": "^6.0.0",
+        "yargs": "^15.0.2"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "cliui": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^6.2.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "p-map": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
+          "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+          "requires": {
+            "aggregate-error": "^3.0.0"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+        },
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
+        },
         "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
           "requires": {
             "glob": "^7.1.3"
           }
         },
-        "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
         },
         "yargs": {
-          "version": "13.3.2",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
-          "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+          "version": "15.4.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+          "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
           "requires": {
-            "cliui": "^5.0.0",
-            "find-up": "^3.0.0",
+            "cliui": "^6.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^4.1.0",
             "get-caller-file": "^2.0.1",
             "require-directory": "^2.1.1",
             "require-main-filename": "^2.0.0",
             "set-blocking": "^2.0.0",
-            "string-width": "^3.0.0",
+            "string-width": "^4.2.0",
             "which-module": "^2.0.0",
             "y18n": "^4.0.0",
-            "yargs-parser": "^13.1.2"
+            "yargs-parser": "^18.1.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
           }
         }
       }
-    },
-    "oauth-sign": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
     },
     "object-assign": {
       "version": "4.1.1",
@@ -7195,20 +7720,15 @@
       "integrity": "sha512-gjcpUc3clBf9+210TRaDWbf+rZZZEshZ+DlXMRCeAjp0xhTrnQsKHypIy1J3d5hKdUzj69t708EHtU8P6bUn0A==",
       "dev": true
     },
-    "os-homedir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
-    },
     "own-or": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/own-or/-/own-or-1.0.0.tgz",
       "integrity": "sha512-NfZr5+Tdf6MB8UI9GLvKRs4cXY8/yB0w3xtt84xFdWy8hkGjn+JFc60VhzS/hFRfbyxFcGYMTjnF4Me+RbbqrA=="
     },
     "own-or-env": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/own-or-env/-/own-or-env-1.0.1.tgz",
-      "integrity": "sha512-y8qULRbRAlL6x2+M0vIe7jJbJx/kmUTzYonRAa2ayesR2qWLswninkVyeJe4x3IEXhdgoNodzjQRKAoEs6Fmrw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/own-or-env/-/own-or-env-1.0.2.tgz",
+      "integrity": "sha512-NQ7v0fliWtK7Lkb+WdFqe6ky9XAzYmlkXthQrBbzlYbmFKoAYbDDcwmOm6q8kOuwSRXW8bdL5ORksploUJmWgw==",
       "requires": {
         "own-or": "^1.0.0"
       }
@@ -7247,6 +7767,14 @@
         "p-limit": "^2.0.0"
       }
     },
+    "p-map": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+      "requires": {
+        "aggregate-error": "^3.0.0"
+      }
+    },
     "p-timeout": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
@@ -7261,12 +7789,12 @@
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
     },
     "package-hash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-3.0.0.tgz",
-      "integrity": "sha512-lOtmukMDVvtkL84rJHI7dpTYq+0rli8N2wlnqUcBuDWCfVhRUfOmnR9SsoHFMLpACvEV60dX7rd0rFaYDZI+FA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-4.0.0.tgz",
+      "integrity": "sha512-whdkPIooSu/bASggZ96BWVvZTRMOFxnyUG5PnTSGKoJE2gd5mbVNmR2Nj20QFzxYYgAXpoqC+AiXzl+UMRh7zQ==",
       "requires": {
         "graceful-fs": "^4.1.15",
-        "hasha": "^3.0.0",
+        "hasha": "^5.0.0",
         "lodash.flattendeep": "^4.4.0",
         "release-zalgo": "^1.0.0"
       }
@@ -7344,14 +7872,6 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
       "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw=="
     },
-    "path-type": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-      "requires": {
-        "pify": "^3.0.0"
-      }
-    },
     "pbkdf2": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz",
@@ -7365,35 +7885,59 @@
         "sha.js": "^2.4.8"
       }
     },
-    "performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    "picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
     },
     "picomatch": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
     },
     "pify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
       "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
     },
-    "pirates": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/pirates/-/pirates-3.0.2.tgz",
-      "integrity": "sha512-c5CgUJq6H2k6MJz72Ak1F5sN9n9wlSlJyEnwvpm9/y3WB4E3pHBDT2c6PEiS1vyJvq2bUxUAIu0EGf8Cx4Ic7Q==",
-      "requires": {
-        "node-modules-regexp": "^1.0.0"
-      }
-    },
     "pkg-dir": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
-      "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
       "requires": {
-        "find-up": "^3.0.0"
+        "find-up": "^4.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+        }
       }
     },
     "preact": {
@@ -7417,6 +7961,14 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
+    "process-on-spawn": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.0.0.tgz",
+      "integrity": "sha512-1WsPDsUSMmZH5LeMLegqkPDrsGgsWwk1Exipy2hvB0o/F0ASzbpIctSCcZIK1ykJvtTJULEH+20WOFjMvGnCTg==",
+      "requires": {
+        "fromentries": "^1.2.0"
+      }
+    },
     "prom-client": {
       "version": "12.0.0",
       "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-12.0.0.tgz",
@@ -7425,14 +7977,18 @@
         "tdigest": "^0.1.1"
       }
     },
-    "prop-types": {
-      "version": "15.7.2",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+    "promise-inflight": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+      "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g=="
+    },
+    "promise-retry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
       "requires": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.8.1"
+        "err-code": "^2.0.2",
+        "retry": "^0.12.0"
       }
     },
     "proxy-addr": {
@@ -7454,16 +8010,6 @@
         "module-not-found-error": "^1.0.1",
         "resolve": "^1.11.1"
       }
-    },
-    "pseudomap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
-    },
-    "psl": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.7.0.tgz",
-      "integrity": "sha512-5NsSEDv8zY70ScRnOTn7bK7eanl2MvFrOrS/R6x+dBt5g1ghnj9Zv90kO8GwT8gxcu2ANyFprnFYB85IogIJOQ=="
     },
     "public-encrypt": {
       "version": "4.0.3",
@@ -7566,21 +8112,6 @@
         }
       }
     },
-    "react": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
-      }
-    },
-    "react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-    },
     "read-pkg": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-4.0.1.tgz",
@@ -7589,43 +8120,6 @@
         "normalize-package-data": "^2.3.2",
         "parse-json": "^4.0.0",
         "pify": "^3.0.0"
-      }
-    },
-    "read-pkg-up": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
-      "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
-      "requires": {
-        "find-up": "^3.0.0",
-        "read-pkg": "^3.0.0"
-      },
-      "dependencies": {
-        "load-json-file": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^4.0.0",
-            "pify": "^3.0.0",
-            "strip-bom": "^3.0.0"
-          }
-        },
-        "read-pkg": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-          "requires": {
-            "load-json-file": "^4.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^3.0.0"
-          }
-        },
-        "strip-bom": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
-        }
       }
     },
     "readable-stream": {
@@ -7640,11 +8134,11 @@
       }
     },
     "readdirp": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.3.0.tgz",
-      "integrity": "sha512-zz0pAkSPOXXm1viEwygWIPSPkcBYjW1xU5j/JBh5t9bGCJwa6f9+BJa6VaB2g+b55yVrmXzqkyLf4xaWYM0IkQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "requires": {
-        "picomatch": "^2.0.7"
+        "picomatch": "^2.2.1"
       }
     },
     "rechoir": {
@@ -7830,63 +8324,6 @@
         }
       }
     },
-    "request": {
-      "version": "2.88.2",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-      "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      },
-      "dependencies": {
-        "qs": {
-          "version": "6.5.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
-        },
-        "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
-        }
-      }
-    },
-    "request-promise-core": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
-      "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
-      "requires": {
-        "lodash": "^4.17.19"
-      }
-    },
-    "request-promise-native": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
-      "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
-      "requires": {
-        "request-promise-core": "1.1.4",
-        "stealthy-require": "^1.1.1",
-        "tough-cookie": "^2.3.3"
-      }
-    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -7908,7 +8345,8 @@
     "resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true
     },
     "responselike": {
       "version": "2.0.0",
@@ -7926,6 +8364,11 @@
       "requires": {
         "through": "~2.3.4"
       }
+    },
+    "retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="
     },
     "reusify": {
       "version": "1.0.4",
@@ -8214,9 +8657,9 @@
       }
     },
     "signal-exit": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
     },
     "sinon": {
       "version": "12.0.1",
@@ -8255,6 +8698,30 @@
         }
       }
     },
+    "smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="
+    },
+    "socks": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
+      "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
+      "requires": {
+        "ip": "^2.0.0",
+        "smart-buffer": "^4.2.0"
+      }
+    },
+    "socks-proxy-agent": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-7.0.0.tgz",
+      "integrity": "sha512-Fgl0YPZ902wEsAyiQ+idGd1A7rSFx/ayC1CQVMw5P+EQx2V0SgpGtf6OKFhVjPflPUl9YMmEOnmfjCdMUsygww==",
+      "requires": {
+        "agent-base": "^6.0.2",
+        "debug": "^4.3.3",
+        "socks": "^2.6.2"
+      }
+    },
     "sort-keys": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-4.2.0.tgz",
@@ -8269,9 +8736,9 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "source-map-support": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -8283,40 +8750,24 @@
       "integrity": "sha1-YvXpRmmBwbeW3Fkpk34RycaSG9A="
     },
     "spawn-wrap": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.4.3.tgz",
-      "integrity": "sha512-IgB8md0QW/+tWqcavuFgKYR/qIRvJkRLPJDFaoXtLLUaVcCDK0+HeFTkmQHj3eprcYhc+gOl0aEA1w7qZlYezw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-2.0.0.tgz",
+      "integrity": "sha512-EeajNjfN9zMnULLwhZZQU3GWBoFNkbngTUPfaawT4RkMiviTxcX0qfhVbGey39mfctfDHkWtuecgQ8NJcyQWHg==",
       "requires": {
-        "foreground-child": "^1.5.6",
-        "mkdirp": "^0.5.0",
-        "os-homedir": "^1.0.1",
-        "rimraf": "^2.6.2",
+        "foreground-child": "^2.0.0",
+        "is-windows": "^1.0.2",
+        "make-dir": "^3.0.0",
+        "rimraf": "^3.0.0",
         "signal-exit": "^3.0.2",
-        "which": "^1.3.0"
+        "which": "^2.0.1"
       },
       "dependencies": {
-        "mkdirp": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-          "requires": {
-            "minimist": "^1.2.5"
-          }
-        },
         "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
           "requires": {
             "glob": "^7.1.3"
-          }
-        },
-        "which": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-          "requires": {
-            "isexe": "^2.0.0"
           }
         }
       }
@@ -8354,26 +8805,33 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
-    "sshpk": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+    "ssri": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-10.0.1.tgz",
+      "integrity": "sha512-WVy6di9DlPOeBWEjMScpNipeSX2jIZBGEn5Uuo8Q7aIuFEuDX0pw8RxcOjlD1TWP4obi24ki7m/13+nFpcbXrw==",
       "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
+        "minipass": "^4.0.0"
+      },
+      "dependencies": {
+        "minipass": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.0.0.tgz",
+          "integrity": "sha512-g2Uuh2jEKoht+zvO6vJqXmYpflPqzRBT+Th2h01DKh5z7wbY/AZ2gCQ78cP70YoHPyFdY30YBV5WxgLOEwOykw==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
       }
     },
     "stack-utils": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.3.tgz",
-      "integrity": "sha512-WldO+YmqhEpjp23eHZRhOT1NQF51STsbxZ+/AdpFD+EhheFxAe5d0WoK4DQVJkSHacPrJJX3OqRAl9CgHf78pg==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
       "requires": {
         "escape-string-regexp": "^2.0.0"
       },
@@ -8397,11 +8855,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
-    },
-    "stealthy-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
     },
     "stream-browserify": {
       "version": "2.0.2",
@@ -8749,248 +9202,218 @@
       "dev": true
     },
     "tap": {
-      "version": "14.11.0",
-      "resolved": "https://registry.npmjs.org/tap/-/tap-14.11.0.tgz",
-      "integrity": "sha512-z8qnNFVyIjLh/bNoTLFRkEk09XZUDAZbCkz/BjvHHly3ao5H+y60gPnedALfheEjA6dA4tpp/mrKq2NWlMuq0A==",
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/tap/-/tap-16.3.2.tgz",
+      "integrity": "sha512-4MWMObR8unbv5gAHHVW9F0MNk3opQMnLusSWvt4KBAnKmkwpBRKIfNF64fimQbcR4y9a7U9ISV7pCldlV3J8Pw==",
       "requires": {
-        "@types/react": "^16.9.16",
-        "async-hook-domain": "^1.1.3",
-        "bind-obj-methods": "^2.0.0",
-        "browser-process-hrtime": "^1.0.0",
+        "@isaacs/import-jsx": "^4.0.1",
+        "@types/react": "^17.0.52",
         "chokidar": "^3.3.0",
-        "color-support": "^1.1.0",
-        "coveralls": "^3.0.11",
-        "diff": "^4.0.1",
-        "esm": "^3.2.25",
         "findit": "^2.0.0",
-        "flow-remove-types": "^2.112.0",
-        "foreground-child": "^1.3.3",
+        "foreground-child": "^2.0.0",
         "fs-exists-cached": "^1.0.0",
-        "function-loop": "^1.0.2",
-        "glob": "^7.1.6",
-        "import-jsx": "^3.1.0",
-        "ink": "^2.6.0",
+        "glob": "^7.2.3",
+        "ink": "^3.2.0",
         "isexe": "^2.0.0",
-        "istanbul-lib-processinfo": "^1.0.0",
-        "jackspeak": "^1.4.0",
-        "minipass": "^3.1.1",
-        "mkdirp": "^0.5.4",
-        "nyc": "^14.1.1",
+        "istanbul-lib-processinfo": "^2.0.3",
+        "jackspeak": "^1.4.2",
+        "libtap": "^1.4.0",
+        "minipass": "^3.3.4",
+        "mkdirp": "^1.0.4",
+        "nyc": "^15.1.0",
         "opener": "^1.5.1",
-        "own-or": "^1.0.0",
-        "own-or-env": "^1.0.1",
-        "react": "^16.12.0",
-        "rimraf": "^2.7.1",
-        "signal-exit": "^3.0.0",
+        "react": "^17.0.2",
+        "rimraf": "^3.0.0",
+        "signal-exit": "^3.0.6",
         "source-map-support": "^0.5.16",
-        "stack-utils": "^1.0.3",
-        "tap-mocha-reporter": "^5.0.0",
-        "tap-parser": "^10.0.1",
-        "tap-yaml": "^1.0.0",
-        "tcompare": "^3.0.0",
-        "treport": "^1.0.2",
-        "trivial-deferred": "^1.0.1",
-        "ts-node": "^8.5.2",
-        "typescript": "^3.7.2",
-        "which": "^2.0.2",
-        "write-file-atomic": "^3.0.1",
-        "yaml": "^1.7.2",
-        "yapool": "^1.0.0"
+        "tap-mocha-reporter": "^5.0.3",
+        "tap-parser": "^11.0.2",
+        "tap-yaml": "^1.0.2",
+        "tcompare": "^5.0.7",
+        "treport": "^3.0.4",
+        "which": "^2.0.2"
       },
       "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.10.4",
+        "@ampproject/remapping": {
+          "version": "2.1.2",
           "bundled": true,
           "requires": {
-            "@babel/highlight": "^7.10.4"
+            "@jridgewell/trace-mapping": "^0.3.0"
           }
         },
-        "@babel/core": {
-          "version": "7.10.5",
+        "@babel/code-frame": {
+          "version": "7.16.7",
           "bundled": true,
           "requires": {
-            "@babel/code-frame": "^7.10.4",
-            "@babel/generator": "^7.10.5",
-            "@babel/helper-module-transforms": "^7.10.5",
-            "@babel/helpers": "^7.10.4",
-            "@babel/parser": "^7.10.5",
-            "@babel/template": "^7.10.4",
-            "@babel/traverse": "^7.10.5",
-            "@babel/types": "^7.10.5",
+            "@babel/highlight": "^7.16.7"
+          }
+        },
+        "@babel/compat-data": {
+          "version": "7.17.7",
+          "bundled": true
+        },
+        "@babel/core": {
+          "version": "7.17.8",
+          "bundled": true,
+          "requires": {
+            "@ampproject/remapping": "^2.1.0",
+            "@babel/code-frame": "^7.16.7",
+            "@babel/generator": "^7.17.7",
+            "@babel/helper-compilation-targets": "^7.17.7",
+            "@babel/helper-module-transforms": "^7.17.7",
+            "@babel/helpers": "^7.17.8",
+            "@babel/parser": "^7.17.8",
+            "@babel/template": "^7.16.7",
+            "@babel/traverse": "^7.17.3",
+            "@babel/types": "^7.17.0",
             "convert-source-map": "^1.7.0",
             "debug": "^4.1.0",
-            "gensync": "^1.0.0-beta.1",
+            "gensync": "^1.0.0-beta.2",
             "json5": "^2.1.2",
-            "lodash": "^4.17.19",
-            "resolve": "^1.3.2",
-            "semver": "^5.4.1",
-            "source-map": "^0.5.0"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.5.7",
-              "bundled": true
-            }
+            "semver": "^6.3.0"
           }
         },
         "@babel/generator": {
-          "version": "7.10.5",
+          "version": "7.17.7",
           "bundled": true,
           "requires": {
-            "@babel/types": "^7.10.5",
+            "@babel/types": "^7.17.0",
             "jsesc": "^2.5.1",
             "source-map": "^0.5.0"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.5.7",
-              "bundled": true
-            }
           }
         },
         "@babel/helper-annotate-as-pure": {
-          "version": "7.10.4",
+          "version": "7.16.7",
           "bundled": true,
           "requires": {
-            "@babel/types": "^7.10.4"
+            "@babel/types": "^7.16.7"
           }
         },
-        "@babel/helper-builder-react-jsx": {
-          "version": "7.10.4",
+        "@babel/helper-compilation-targets": {
+          "version": "7.17.7",
           "bundled": true,
           "requires": {
-            "@babel/helper-annotate-as-pure": "^7.10.4",
-            "@babel/types": "^7.10.4"
+            "@babel/compat-data": "^7.17.7",
+            "@babel/helper-validator-option": "^7.16.7",
+            "browserslist": "^4.17.5",
+            "semver": "^6.3.0"
           }
         },
-        "@babel/helper-builder-react-jsx-experimental": {
-          "version": "7.10.5",
+        "@babel/helper-environment-visitor": {
+          "version": "7.16.7",
           "bundled": true,
           "requires": {
-            "@babel/helper-annotate-as-pure": "^7.10.4",
-            "@babel/helper-module-imports": "^7.10.4",
-            "@babel/types": "^7.10.5"
+            "@babel/types": "^7.16.7"
           }
         },
         "@babel/helper-function-name": {
-          "version": "7.10.4",
+          "version": "7.16.7",
           "bundled": true,
           "requires": {
-            "@babel/helper-get-function-arity": "^7.10.4",
-            "@babel/template": "^7.10.4",
-            "@babel/types": "^7.10.4"
+            "@babel/helper-get-function-arity": "^7.16.7",
+            "@babel/template": "^7.16.7",
+            "@babel/types": "^7.16.7"
           }
         },
         "@babel/helper-get-function-arity": {
-          "version": "7.10.4",
+          "version": "7.16.7",
           "bundled": true,
           "requires": {
-            "@babel/types": "^7.10.4"
+            "@babel/types": "^7.16.7"
           }
         },
-        "@babel/helper-member-expression-to-functions": {
-          "version": "7.10.5",
+        "@babel/helper-hoist-variables": {
+          "version": "7.16.7",
           "bundled": true,
           "requires": {
-            "@babel/types": "^7.10.5"
+            "@babel/types": "^7.16.7"
           }
         },
         "@babel/helper-module-imports": {
-          "version": "7.10.4",
+          "version": "7.16.7",
           "bundled": true,
           "requires": {
-            "@babel/types": "^7.10.4"
+            "@babel/types": "^7.16.7"
           }
         },
         "@babel/helper-module-transforms": {
-          "version": "7.10.5",
+          "version": "7.17.7",
           "bundled": true,
           "requires": {
-            "@babel/helper-module-imports": "^7.10.4",
-            "@babel/helper-replace-supers": "^7.10.4",
-            "@babel/helper-simple-access": "^7.10.4",
-            "@babel/helper-split-export-declaration": "^7.10.4",
-            "@babel/template": "^7.10.4",
-            "@babel/types": "^7.10.5",
-            "lodash": "^4.17.19"
-          }
-        },
-        "@babel/helper-optimise-call-expression": {
-          "version": "7.10.4",
-          "bundled": true,
-          "requires": {
-            "@babel/types": "^7.10.4"
+            "@babel/helper-environment-visitor": "^7.16.7",
+            "@babel/helper-module-imports": "^7.16.7",
+            "@babel/helper-simple-access": "^7.17.7",
+            "@babel/helper-split-export-declaration": "^7.16.7",
+            "@babel/helper-validator-identifier": "^7.16.7",
+            "@babel/template": "^7.16.7",
+            "@babel/traverse": "^7.17.3",
+            "@babel/types": "^7.17.0"
           }
         },
         "@babel/helper-plugin-utils": {
-          "version": "7.10.4",
+          "version": "7.16.7",
           "bundled": true
         },
-        "@babel/helper-replace-supers": {
-          "version": "7.10.4",
-          "bundled": true,
-          "requires": {
-            "@babel/helper-member-expression-to-functions": "^7.10.4",
-            "@babel/helper-optimise-call-expression": "^7.10.4",
-            "@babel/traverse": "^7.10.4",
-            "@babel/types": "^7.10.4"
-          }
-        },
         "@babel/helper-simple-access": {
-          "version": "7.10.4",
+          "version": "7.17.7",
           "bundled": true,
           "requires": {
-            "@babel/template": "^7.10.4",
-            "@babel/types": "^7.10.4"
+            "@babel/types": "^7.17.0"
           }
         },
         "@babel/helper-split-export-declaration": {
-          "version": "7.10.4",
+          "version": "7.16.7",
           "bundled": true,
           "requires": {
-            "@babel/types": "^7.10.4"
+            "@babel/types": "^7.16.7"
           }
         },
         "@babel/helper-validator-identifier": {
-          "version": "7.10.4",
+          "version": "7.16.7",
+          "bundled": true
+        },
+        "@babel/helper-validator-option": {
+          "version": "7.16.7",
           "bundled": true
         },
         "@babel/helpers": {
-          "version": "7.10.4",
+          "version": "7.17.8",
           "bundled": true,
           "requires": {
-            "@babel/template": "^7.10.4",
-            "@babel/traverse": "^7.10.4",
-            "@babel/types": "^7.10.4"
+            "@babel/template": "^7.16.7",
+            "@babel/traverse": "^7.17.3",
+            "@babel/types": "^7.17.0"
           }
         },
         "@babel/highlight": {
-          "version": "7.10.4",
+          "version": "7.16.10",
           "bundled": true,
           "requires": {
-            "@babel/helper-validator-identifier": "^7.10.4",
+            "@babel/helper-validator-identifier": "^7.16.7",
             "chalk": "^2.0.0",
             "js-tokens": "^4.0.0"
           }
         },
         "@babel/parser": {
-          "version": "7.10.5",
+          "version": "7.17.8",
           "bundled": true
         },
         "@babel/plugin-proposal-object-rest-spread": {
-          "version": "7.10.4",
+          "version": "7.17.3",
           "bundled": true,
           "requires": {
-            "@babel/helper-plugin-utils": "^7.10.4",
-            "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
-            "@babel/plugin-transform-parameters": "^7.10.4"
+            "@babel/compat-data": "^7.17.0",
+            "@babel/helper-compilation-targets": "^7.16.7",
+            "@babel/helper-plugin-utils": "^7.16.7",
+            "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+            "@babel/plugin-transform-parameters": "^7.16.7"
           }
         },
         "@babel/plugin-syntax-jsx": {
-          "version": "7.10.4",
+          "version": "7.16.7",
           "bundled": true,
           "requires": {
-            "@babel/helper-plugin-utils": "^7.10.4"
+            "@babel/helper-plugin-utils": "^7.16.7"
           }
         },
         "@babel/plugin-syntax-object-rest-spread": {
@@ -9001,92 +9424,130 @@
           }
         },
         "@babel/plugin-transform-destructuring": {
-          "version": "7.10.4",
+          "version": "7.17.7",
           "bundled": true,
           "requires": {
-            "@babel/helper-plugin-utils": "^7.10.4"
+            "@babel/helper-plugin-utils": "^7.16.7"
           }
         },
         "@babel/plugin-transform-parameters": {
-          "version": "7.10.5",
+          "version": "7.16.7",
           "bundled": true,
           "requires": {
-            "@babel/helper-get-function-arity": "^7.10.4",
-            "@babel/helper-plugin-utils": "^7.10.4"
+            "@babel/helper-plugin-utils": "^7.16.7"
           }
         },
         "@babel/plugin-transform-react-jsx": {
-          "version": "7.10.4",
+          "version": "7.17.3",
           "bundled": true,
           "requires": {
-            "@babel/helper-builder-react-jsx": "^7.10.4",
-            "@babel/helper-builder-react-jsx-experimental": "^7.10.4",
-            "@babel/helper-plugin-utils": "^7.10.4",
-            "@babel/plugin-syntax-jsx": "^7.10.4"
+            "@babel/helper-annotate-as-pure": "^7.16.7",
+            "@babel/helper-module-imports": "^7.16.7",
+            "@babel/helper-plugin-utils": "^7.16.7",
+            "@babel/plugin-syntax-jsx": "^7.16.7",
+            "@babel/types": "^7.17.0"
           }
         },
         "@babel/template": {
-          "version": "7.10.4",
+          "version": "7.16.7",
           "bundled": true,
           "requires": {
-            "@babel/code-frame": "^7.10.4",
-            "@babel/parser": "^7.10.4",
-            "@babel/types": "^7.10.4"
+            "@babel/code-frame": "^7.16.7",
+            "@babel/parser": "^7.16.7",
+            "@babel/types": "^7.16.7"
           }
         },
         "@babel/traverse": {
-          "version": "7.10.5",
+          "version": "7.17.3",
           "bundled": true,
           "requires": {
-            "@babel/code-frame": "^7.10.4",
-            "@babel/generator": "^7.10.5",
-            "@babel/helper-function-name": "^7.10.4",
-            "@babel/helper-split-export-declaration": "^7.10.4",
-            "@babel/parser": "^7.10.5",
-            "@babel/types": "^7.10.5",
+            "@babel/code-frame": "^7.16.7",
+            "@babel/generator": "^7.17.3",
+            "@babel/helper-environment-visitor": "^7.16.7",
+            "@babel/helper-function-name": "^7.16.7",
+            "@babel/helper-hoist-variables": "^7.16.7",
+            "@babel/helper-split-export-declaration": "^7.16.7",
+            "@babel/parser": "^7.17.3",
+            "@babel/types": "^7.17.0",
             "debug": "^4.1.0",
-            "globals": "^11.1.0",
-            "lodash": "^4.17.19"
+            "globals": "^11.1.0"
           }
         },
         "@babel/types": {
-          "version": "7.10.5",
+          "version": "7.17.0",
           "bundled": true,
           "requires": {
-            "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.19",
+            "@babel/helper-validator-identifier": "^7.16.7",
             "to-fast-properties": "^2.0.0"
           }
         },
-        "@types/color-name": {
-          "version": "1.1.1",
+        "@isaacs/import-jsx": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "@babel/core": "^7.5.5",
+            "@babel/plugin-proposal-object-rest-spread": "^7.5.5",
+            "@babel/plugin-transform-destructuring": "^7.5.0",
+            "@babel/plugin-transform-react-jsx": "^7.3.0",
+            "caller-path": "^3.0.1",
+            "find-cache-dir": "^3.2.0",
+            "make-dir": "^3.0.2",
+            "resolve-from": "^3.0.0",
+            "rimraf": "^3.0.0"
+          }
+        },
+        "@jridgewell/resolve-uri": {
+          "version": "3.0.5",
           "bundled": true
         },
+        "@jridgewell/sourcemap-codec": {
+          "version": "1.4.11",
+          "bundled": true
+        },
+        "@jridgewell/trace-mapping": {
+          "version": "0.3.4",
+          "bundled": true,
+          "requires": {
+            "@jridgewell/resolve-uri": "^3.0.3",
+            "@jridgewell/sourcemap-codec": "^1.4.10"
+          }
+        },
         "@types/prop-types": {
-          "version": "15.7.3",
+          "version": "15.7.4",
           "bundled": true
         },
         "@types/react": {
-          "version": "16.9.43",
+          "version": "17.0.52",
           "bundled": true,
           "requires": {
             "@types/prop-types": "*",
-            "csstype": "^2.2.0"
+            "@types/scheduler": "*",
+            "csstype": "^3.0.2"
           }
+        },
+        "@types/scheduler": {
+          "version": "0.16.2",
+          "bundled": true
         },
         "@types/yoga-layout": {
           "version": "1.9.2",
           "bundled": true
         },
         "ansi-escapes": {
-          "version": "4.3.1",
+          "version": "4.3.2",
           "bundled": true,
           "requires": {
-            "type-fest": "^0.11.0"
+            "type-fest": "^0.21.3"
+          },
+          "dependencies": {
+            "type-fest": {
+              "version": "0.21.3",
+              "bundled": true
+            }
           }
         },
         "ansi-regex": {
-          "version": "5.0.0",
+          "version": "5.0.1",
           "bundled": true
         },
         "ansi-styles": {
@@ -9100,10 +9561,6 @@
           "version": "0.3.2",
           "bundled": true
         },
-        "arrify": {
-          "version": "2.0.1",
-          "bundled": true
-        },
         "astral-regex": {
           "version": "2.0.0",
           "bundled": true
@@ -9112,22 +9569,49 @@
           "version": "4.0.0",
           "bundled": true
         },
-        "caller-callsite": {
-          "version": "2.0.0",
+        "balanced-match": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
           "bundled": true,
           "requires": {
-            "callsites": "^2.0.0"
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "browserslist": {
+          "version": "4.20.2",
+          "bundled": true,
+          "requires": {
+            "caniuse-lite": "^1.0.30001317",
+            "electron-to-chromium": "^1.4.84",
+            "escalade": "^3.1.1",
+            "node-releases": "^2.0.2",
+            "picocolors": "^1.0.0"
+          }
+        },
+        "caller-callsite": {
+          "version": "4.1.0",
+          "bundled": true,
+          "requires": {
+            "callsites": "^3.1.0"
           }
         },
         "caller-path": {
-          "version": "2.0.0",
+          "version": "3.0.1",
           "bundled": true,
           "requires": {
-            "caller-callsite": "^2.0.0"
+            "caller-callsite": "^4.1.0"
           }
         },
         "callsites": {
-          "version": "2.0.0",
+          "version": "3.1.0",
+          "bundled": true
+        },
+        "caniuse-lite": {
+          "version": "1.0.30001319",
           "bundled": true
         },
         "cardinal": {
@@ -9151,6 +9635,10 @@
           "version": "2.0.0",
           "bundled": true
         },
+        "cli-boxes": {
+          "version": "2.2.1",
+          "bundled": true
+        },
         "cli-cursor": {
           "version": "3.1.0",
           "bundled": true,
@@ -9166,6 +9654,13 @@
             "string-width": "^4.2.0"
           }
         },
+        "code-excerpt": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "convert-to-spaces": "^1.0.1"
+          }
+        },
         "color-convert": {
           "version": "1.9.3",
           "bundled": true,
@@ -9177,32 +9672,46 @@
           "version": "1.1.3",
           "bundled": true
         },
+        "commondir": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
         "convert-source-map": {
-          "version": "1.7.0",
+          "version": "1.8.0",
           "bundled": true,
           "requires": {
             "safe-buffer": "~5.1.1"
-          },
-          "dependencies": {
-            "safe-buffer": {
-              "version": "5.1.2",
-              "bundled": true
-            }
           }
         },
+        "convert-to-spaces": {
+          "version": "1.0.2",
+          "bundled": true
+        },
         "csstype": {
-          "version": "2.6.11",
+          "version": "3.0.11",
           "bundled": true
         },
         "debug": {
-          "version": "4.1.1",
+          "version": "4.3.4",
           "bundled": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
+        },
+        "electron-to-chromium": {
+          "version": "1.4.89",
+          "bundled": true
         },
         "emoji-regex": {
           "version": "8.0.0",
+          "bundled": true
+        },
+        "escalade": {
+          "version": "3.1.1",
           "bundled": true
         },
         "escape-string-regexp": {
@@ -9217,9 +9726,42 @@
           "version": "1.1.2",
           "bundled": true
         },
-        "gensync": {
-          "version": "1.0.0-beta.1",
+        "find-cache-dir": {
+          "version": "3.3.2",
+          "bundled": true,
+          "requires": {
+            "commondir": "^1.0.1",
+            "make-dir": "^3.0.2",
+            "pkg-dir": "^4.1.0"
+          }
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "bundled": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
           "bundled": true
+        },
+        "gensync": {
+          "version": "1.0.0-beta.2",
+          "bundled": true
+        },
+        "glob": {
+          "version": "7.2.3",
+          "bundled": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.1.1",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
         },
         "globals": {
           "version": "11.12.0",
@@ -9229,52 +9771,60 @@
           "version": "3.0.0",
           "bundled": true
         },
-        "import-jsx": {
-          "version": "3.1.0",
+        "indent-string": {
+          "version": "4.0.0",
+          "bundled": true
+        },
+        "inflight": {
+          "version": "1.0.6",
           "bundled": true,
           "requires": {
-            "@babel/core": "^7.5.5",
-            "@babel/plugin-proposal-object-rest-spread": "^7.5.5",
-            "@babel/plugin-transform-destructuring": "^7.5.0",
-            "@babel/plugin-transform-react-jsx": "^7.3.0",
-            "caller-path": "^2.0.0",
-            "resolve-from": "^3.0.0"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
+        "inherits": {
+          "version": "2.0.4",
+          "bundled": true
+        },
         "ink": {
-          "version": "2.7.1",
+          "version": "3.2.0",
           "bundled": true,
           "requires": {
             "ansi-escapes": "^4.2.1",
-            "arrify": "^2.0.1",
-            "auto-bind": "^4.0.0",
-            "chalk": "^3.0.0",
+            "auto-bind": "4.0.0",
+            "chalk": "^4.1.0",
+            "cli-boxes": "^2.2.0",
             "cli-cursor": "^3.1.0",
             "cli-truncate": "^2.1.0",
+            "code-excerpt": "^3.0.0",
+            "indent-string": "^4.0.0",
             "is-ci": "^2.0.0",
-            "lodash.throttle": "^4.1.1",
-            "log-update": "^3.0.0",
-            "prop-types": "^15.6.2",
-            "react-reconciler": "^0.24.0",
-            "scheduler": "^0.18.0",
+            "lodash": "^4.17.20",
+            "patch-console": "^1.0.0",
+            "react-devtools-core": "^4.19.1",
+            "react-reconciler": "^0.26.2",
+            "scheduler": "^0.20.2",
             "signal-exit": "^3.0.2",
             "slice-ansi": "^3.0.0",
-            "string-length": "^3.1.0",
+            "stack-utils": "^2.0.2",
+            "string-width": "^4.2.2",
+            "type-fest": "^0.12.0",
             "widest-line": "^3.1.0",
             "wrap-ansi": "^6.2.0",
-            "yoga-layout-prebuilt": "^1.9.3"
+            "ws": "^7.5.5",
+            "yoga-layout-prebuilt": "^1.9.6"
           },
           "dependencies": {
             "ansi-styles": {
-              "version": "4.2.1",
+              "version": "4.3.0",
               "bundled": true,
               "requires": {
-                "@types/color-name": "^1.1.1",
                 "color-convert": "^2.0.1"
               }
             },
             "chalk": {
-              "version": "3.0.0",
+              "version": "4.1.2",
               "bundled": true,
               "requires": {
                 "ansi-styles": "^4.1.0",
@@ -9297,7 +9847,7 @@
               "bundled": true
             },
             "supports-color": {
-              "version": "7.1.0",
+              "version": "7.2.0",
               "bundled": true,
               "requires": {
                 "has-flag": "^4.0.0"
@@ -9325,97 +9875,19 @@
           "bundled": true
         },
         "json5": {
-          "version": "2.1.3",
+          "version": "2.2.1",
+          "bundled": true
+        },
+        "locate-path": {
+          "version": "5.0.0",
           "bundled": true,
           "requires": {
-            "minimist": "^1.2.5"
+            "p-locate": "^4.1.0"
           }
         },
         "lodash": {
-          "version": "4.17.19",
+          "version": "4.17.21",
           "bundled": true
-        },
-        "lodash.throttle": {
-          "version": "4.1.1",
-          "bundled": true
-        },
-        "log-update": {
-          "version": "3.4.0",
-          "bundled": true,
-          "requires": {
-            "ansi-escapes": "^3.2.0",
-            "cli-cursor": "^2.1.0",
-            "wrap-ansi": "^5.0.0"
-          },
-          "dependencies": {
-            "ansi-escapes": {
-              "version": "3.2.0",
-              "bundled": true
-            },
-            "ansi-regex": {
-              "version": "4.1.0",
-              "bundled": true
-            },
-            "cli-cursor": {
-              "version": "2.1.0",
-              "bundled": true,
-              "requires": {
-                "restore-cursor": "^2.0.0"
-              }
-            },
-            "emoji-regex": {
-              "version": "7.0.3",
-              "bundled": true
-            },
-            "is-fullwidth-code-point": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "mimic-fn": {
-              "version": "1.2.0",
-              "bundled": true
-            },
-            "onetime": {
-              "version": "2.0.1",
-              "bundled": true,
-              "requires": {
-                "mimic-fn": "^1.0.0"
-              }
-            },
-            "restore-cursor": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "onetime": "^2.0.0",
-                "signal-exit": "^3.0.2"
-              }
-            },
-            "string-width": {
-              "version": "3.1.0",
-              "bundled": true,
-              "requires": {
-                "emoji-regex": "^7.0.1",
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^5.1.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "5.2.0",
-              "bundled": true,
-              "requires": {
-                "ansi-regex": "^4.1.0"
-              }
-            },
-            "wrap-ansi": {
-              "version": "5.1.0",
-              "bundled": true,
-              "requires": {
-                "ansi-styles": "^3.2.0",
-                "string-width": "^3.0.0",
-                "strip-ansi": "^5.0.0"
-              }
-            }
-          }
         },
         "loose-envify": {
           "version": "1.4.0",
@@ -9424,79 +9896,125 @@
             "js-tokens": "^3.0.0 || ^4.0.0"
           }
         },
+        "make-dir": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "semver": "^6.0.0"
+          }
+        },
         "mimic-fn": {
           "version": "2.1.0",
           "bundled": true
         },
-        "minimist": {
-          "version": "1.2.5",
-          "bundled": true
+        "minimatch": {
+          "version": "3.1.2",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
         },
         "minipass": {
-          "version": "3.1.3",
+          "version": "3.3.4",
           "bundled": true,
           "requires": {
             "yallist": "^4.0.0"
-          },
-          "dependencies": {
-            "yallist": {
-              "version": "4.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-          "requires": {
-            "minimist": "^1.2.5"
           }
         },
         "ms": {
           "version": "2.1.2",
           "bundled": true
         },
+        "node-releases": {
+          "version": "2.0.2",
+          "bundled": true
+        },
         "object-assign": {
           "version": "4.1.1",
           "bundled": true
         },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
         "onetime": {
-          "version": "5.1.0",
+          "version": "5.1.2",
           "bundled": true,
           "requires": {
             "mimic-fn": "^2.1.0"
           }
         },
-        "path-parse": {
-          "version": "1.0.6",
-          "bundled": true
-        },
-        "prop-types": {
-          "version": "15.7.2",
+        "p-limit": {
+          "version": "2.3.0",
           "bundled": true,
           "requires": {
-            "loose-envify": "^1.4.0",
-            "object-assign": "^4.1.1",
-            "react-is": "^16.8.1"
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "bundled": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "bundled": true
+        },
+        "patch-console": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "bundled": true
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "picocolors": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "pkg-dir": {
+          "version": "4.2.0",
+          "bundled": true,
+          "requires": {
+            "find-up": "^4.0.0"
           }
         },
         "punycode": {
           "version": "2.1.1",
           "bundled": true
         },
-        "react-is": {
-          "version": "16.13.1",
-          "bundled": true
+        "react": {
+          "version": "17.0.2",
+          "bundled": true,
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "react-devtools-core": {
+          "version": "4.24.1",
+          "bundled": true,
+          "requires": {
+            "shell-quote": "^1.6.1",
+            "ws": "^7"
+          }
         },
         "react-reconciler": {
-          "version": "0.24.0",
+          "version": "0.26.2",
           "bundled": true,
           "requires": {
             "loose-envify": "^1.1.0",
             "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "scheduler": "^0.18.0"
+            "scheduler": "^0.20.2"
           }
         },
         "redeyed": {
@@ -9504,13 +10022,6 @@
           "bundled": true,
           "requires": {
             "esprima": "~4.0.0"
-          }
-        },
-        "resolve": {
-          "version": "1.17.0",
-          "bundled": true,
-          "requires": {
-            "path-parse": "^1.0.6"
           }
         },
         "resolve-from": {
@@ -9526,15 +10037,18 @@
           }
         },
         "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "version": "3.0.2",
+          "bundled": true,
           "requires": {
             "glob": "^7.1.3"
           }
         },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "bundled": true
+        },
         "scheduler": {
-          "version": "0.18.0",
+          "version": "0.20.2",
           "bundled": true,
           "requires": {
             "loose-envify": "^1.1.0",
@@ -9542,11 +10056,15 @@
           }
         },
         "semver": {
-          "version": "5.7.1",
+          "version": "6.3.0",
+          "bundled": true
+        },
+        "shell-quote": {
+          "version": "1.7.3",
           "bundled": true
         },
         "signal-exit": {
-          "version": "3.0.3",
+          "version": "3.0.7",
           "bundled": true
         },
         "slice-ansi": {
@@ -9559,10 +10077,9 @@
           },
           "dependencies": {
             "ansi-styles": {
-              "version": "4.2.1",
+              "version": "4.3.0",
               "bundled": true,
               "requires": {
-                "@types/color-name": "^1.1.1",
                 "color-convert": "^2.0.1"
               }
             },
@@ -9579,45 +10096,37 @@
             }
           }
         },
-        "string-length": {
-          "version": "3.1.0",
+        "source-map": {
+          "version": "0.5.7",
+          "bundled": true
+        },
+        "stack-utils": {
+          "version": "2.0.5",
           "bundled": true,
           "requires": {
-            "astral-regex": "^1.0.0",
-            "strip-ansi": "^5.2.0"
+            "escape-string-regexp": "^2.0.0"
           },
           "dependencies": {
-            "ansi-regex": {
-              "version": "4.1.0",
+            "escape-string-regexp": {
+              "version": "2.0.0",
               "bundled": true
-            },
-            "astral-regex": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "strip-ansi": {
-              "version": "5.2.0",
-              "bundled": true,
-              "requires": {
-                "ansi-regex": "^4.1.0"
-              }
             }
           }
         },
         "string-width": {
-          "version": "4.2.0",
+          "version": "4.2.3",
           "bundled": true,
           "requires": {
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.0"
+            "strip-ansi": "^6.0.1"
           }
         },
         "strip-ansi": {
-          "version": "6.0.0",
+          "version": "6.0.1",
           "bundled": true,
           "requires": {
-            "ansi-regex": "^5.0.0"
+            "ansi-regex": "^5.0.1"
           }
         },
         "supports-color": {
@@ -9628,19 +10137,19 @@
           }
         },
         "tap-parser": {
-          "version": "10.0.1",
+          "version": "11.0.2",
           "bundled": true,
           "requires": {
             "events-to-array": "^1.0.1",
-            "minipass": "^3.0.0",
+            "minipass": "^3.1.6",
             "tap-yaml": "^1.0.0"
           }
         },
         "tap-yaml": {
-          "version": "1.0.0",
+          "version": "1.0.2",
           "bundled": true,
           "requires": {
-            "yaml": "^1.5.0"
+            "yaml": "^1.10.2"
           }
         },
         "to-fast-properties": {
@@ -9648,24 +10157,23 @@
           "bundled": true
         },
         "treport": {
-          "version": "1.0.2",
+          "version": "3.0.4",
           "bundled": true,
           "requires": {
+            "@isaacs/import-jsx": "^4.0.1",
             "cardinal": "^2.1.1",
             "chalk": "^3.0.0",
-            "import-jsx": "^3.1.0",
-            "ink": "^2.6.0",
+            "ink": "^3.2.0",
             "ms": "^2.1.2",
-            "string-length": "^3.1.0",
-            "tap-parser": "^10.0.1",
+            "tap-parser": "^11.0.0",
+            "tap-yaml": "^1.0.0",
             "unicode-length": "^2.0.2"
           },
           "dependencies": {
             "ansi-styles": {
-              "version": "4.2.1",
+              "version": "4.3.0",
               "bundled": true,
               "requires": {
-                "@types/color-name": "^1.1.1",
                 "color-convert": "^2.0.1"
               }
             },
@@ -9693,7 +10201,7 @@
               "bundled": true
             },
             "supports-color": {
-              "version": "7.1.0",
+              "version": "7.2.0",
               "bundled": true,
               "requires": {
                 "has-flag": "^4.0.0"
@@ -9702,7 +10210,7 @@
           }
         },
         "type-fest": {
-          "version": "0.11.0",
+          "version": "0.12.0",
           "bundled": true
         },
         "unicode-length": {
@@ -9743,10 +10251,9 @@
           },
           "dependencies": {
             "ansi-styles": {
-              "version": "4.2.1",
+              "version": "4.3.0",
               "bundled": true,
               "requires": {
-                "@types/color-name": "^1.1.1",
                 "color-convert": "^2.0.1"
               }
             },
@@ -9763,23 +10270,24 @@
             }
           }
         },
-        "write-file-atomic": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
-          "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
-          "requires": {
-            "imurmurhash": "^0.1.4",
-            "is-typedarray": "^1.0.0",
-            "signal-exit": "^3.0.2",
-            "typedarray-to-buffer": "^3.1.5"
-          }
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "ws": {
+          "version": "7.5.7",
+          "bundled": true
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "bundled": true
         },
         "yaml": {
-          "version": "1.10.0",
+          "version": "1.10.2",
           "bundled": true
         },
         "yoga-layout-prebuilt": {
-          "version": "1.9.6",
+          "version": "1.10.0",
           "bundled": true,
           "requires": {
             "@types/yoga-layout": "1.9.2"
@@ -9788,16 +10296,16 @@
       }
     },
     "tap-mocha-reporter": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/tap-mocha-reporter/-/tap-mocha-reporter-5.0.1.tgz",
-      "integrity": "sha512-1knFWOwd4khx/7uSEnUeaP9IPW3w+sqTgJMhrwah6t46nZ8P25atOKAjSvVDsT67lOPu0nfdOqUwoyKn+3E5pA==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/tap-mocha-reporter/-/tap-mocha-reporter-5.0.3.tgz",
+      "integrity": "sha512-6zlGkaV4J+XMRFkN0X+yuw6xHbE9jyCZ3WUKfw4KxMyRGOpYSRuuQTRJyWX88WWuLdVTuFbxzwXhXuS2XE6o0g==",
       "requires": {
         "color-support": "^1.1.0",
         "debug": "^4.1.1",
         "diff": "^4.0.1",
         "escape-string-regexp": "^2.0.0",
         "glob": "^7.0.5",
-        "tap-parser": "^10.0.0",
+        "tap-parser": "^11.0.0",
         "tap-yaml": "^1.0.0",
         "unicode-length": "^2.0.2"
       },
@@ -9810,21 +10318,31 @@
       }
     },
     "tap-parser": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-10.1.0.tgz",
-      "integrity": "sha512-FujQeciDaOiOvaIVGS1Rpb0v4R6XkOjvWCWowlz5oKuhPkEJ8U6pxgqt38xuzYhPt8dWEnfHn2jqpZdJEkW7pA==",
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-11.0.2.tgz",
+      "integrity": "sha512-6qGlC956rcORw+fg7Fv1iCRAY8/bU9UabUAhs3mXRH6eRmVZcNPLheSXCYaVaYeSwx5xa/1HXZb1537YSvwDZg==",
       "requires": {
         "events-to-array": "^1.0.1",
-        "minipass": "^3.0.0",
+        "minipass": "^3.1.6",
         "tap-yaml": "^1.0.0"
+      },
+      "dependencies": {
+        "minipass": {
+          "version": "3.3.6",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+          "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        }
       }
     },
     "tap-yaml": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/tap-yaml/-/tap-yaml-1.0.0.tgz",
-      "integrity": "sha512-Rxbx4EnrWkYk0/ztcm5u3/VznbyFJpyXO12dDBHKWiDVxy7O2Qw6MRrwO5H6Ww0U5YhRY/4C/VzWmFPhBQc4qQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tap-yaml/-/tap-yaml-1.0.2.tgz",
+      "integrity": "sha512-GegASpuqBnRNdT1U+yuUPZ8rEU64pL35WPBpCISWwff4dErS2/438barz7WFJl4Nzh3Y05tfPidZnH+GaV1wMg==",
       "requires": {
-        "yaml": "^1.5.0"
+        "yaml": "^1.10.2"
       }
     },
     "tape": {
@@ -9902,12 +10420,58 @@
         }
       }
     },
-    "tcompare": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/tcompare/-/tcompare-3.0.4.tgz",
-      "integrity": "sha512-Q3TitMVK59NyKgQyFh+857wTAUE329IzLDehuPgU4nF5e8g+EUQ+yUbjUy1/6ugiNnXztphT+NnqlCXolv9P3A==",
+    "tar": {
+      "version": "6.1.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.13.tgz",
+      "integrity": "sha512-jdIBIN6LTIe2jqzay/2vtYLlBHa3JF42ot3h1dW8Q0PaAG4v8rm0cvpVePtau5C6OKXGGcgO9q2AMNSWxiLqKw==",
       "requires": {
-        "diff-frag": "^1.0.1"
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^4.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "dependencies": {
+        "fs-minipass": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+          "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+          "requires": {
+            "minipass": "^3.0.0"
+          },
+          "dependencies": {
+            "minipass": {
+              "version": "3.3.6",
+              "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+              "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+              "requires": {
+                "yallist": "^4.0.0"
+              }
+            }
+          }
+        },
+        "minipass": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.0.0.tgz",
+          "integrity": "sha512-g2Uuh2jEKoht+zvO6vJqXmYpflPqzRBT+Th2h01DKh5z7wbY/AZ2gCQ78cP70YoHPyFdY30YBV5WxgLOEwOykw==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
+    },
+    "tcompare": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/tcompare/-/tcompare-5.0.7.tgz",
+      "integrity": "sha512-d9iddt6YYGgyxJw5bjsN7UJUO1kGOtjSlNy/4PoGYAjQS5pAT/hzIoLf1bZCw+uUxRmZJh7Yy1aA7xKVRT9B4w==",
+      "requires": {
+        "diff": "^4.0.2"
       }
     },
     "tdigest": {
@@ -9919,14 +10483,13 @@
       }
     },
     "test-exclude": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.2.3.tgz",
-      "integrity": "sha512-M+oxtseCFO3EDtAaGH7iiej3CBkzXqFMbzqYAACdzKui4eZA+pq3tZEwChvOdNfa7xxy8BfbmgJSIr43cC/+2g==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
       "requires": {
-        "glob": "^7.1.3",
-        "minimatch": "^3.0.4",
-        "read-pkg-up": "^4.0.0",
-        "require-main-filename": "^2.0.0"
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
       }
     },
     "text-table": {
@@ -9979,15 +10542,6 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
     },
-    "tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-      "requires": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      }
-    },
     "tree-kill": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
@@ -10002,18 +10556,6 @@
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-6.0.4.tgz",
       "integrity": "sha512-ZtU9zgSnn8DcAxDZY1DJF8rnxsen8M0IVkO7dVB5fTEOVs7o/0RA4V6i99PIg99bpX81Sgb0FCLjQqD5Ufz3rQ=="
-    },
-    "ts-node": {
-      "version": "8.10.2",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.10.2.tgz",
-      "integrity": "sha512-ISJJGgkIpDdBhWVu3jufsWpK3Rzo7bdiIXJjQc0ynKxVOVcg2oIrf2H2cejminGrptVc6q6/uynAHNCuWGbpVA==",
-      "requires": {
-        "arg": "^4.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "source-map-support": "^0.5.17",
-        "yn": "3.1.1"
-      }
     },
     "tsconfig-paths": {
       "version": "3.14.1",
@@ -10045,19 +10587,6 @@
       "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
       "integrity": "sha512-JVa5ijo+j/sOoHGjw0sxw734b1LhBkQ3bvUGNdxnVXDCX81Yx7TFgnZygxrIIWn23hbfTaMYLwRmAxFyDuFmIw==",
       "dev": true
-    },
-    "tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "type-check": {
       "version": "0.3.2",
@@ -10101,11 +10630,6 @@
         "is-typedarray": "^1.0.0"
       }
     },
-    "typescript": {
-      "version": "3.9.7",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw=="
-    },
     "uc.micro": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
@@ -10142,33 +10666,42 @@
       }
     },
     "unicode-length": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/unicode-length/-/unicode-length-2.0.2.tgz",
-      "integrity": "sha512-Ph/j1VbS3/r77nhoY2WU0GWGjVYOHL3xpKp0y/Eq2e5r0mT/6b649vm7KFO6RdAdrZkYLdxphYVgvODxPB+Ebg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/unicode-length/-/unicode-length-2.1.0.tgz",
+      "integrity": "sha512-4bV582zTV9Q02RXBxSUMiuN/KHo5w4aTojuKTNT96DIKps/SIawFp7cS5Mu25VuY1AioGXrmYyzKZUzh8OqoUw==",
       "requires": {
-        "punycode": "^2.0.0",
-        "strip-ansi": "^3.0.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        }
+        "punycode": "^2.0.0"
+      }
+    },
+    "unique-filename": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-3.0.0.tgz",
+      "integrity": "sha512-afXhuC55wkAmZ0P18QsVE6kp8JaxrEokN2HGIoIVv2ijHQd419H0+6EigAFcIzXeMIkcIkNBpB3L/DXB3cTS/g==",
+      "requires": {
+        "unique-slug": "^4.0.0"
+      }
+    },
+    "unique-slug": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-4.0.0.tgz",
+      "integrity": "sha512-WrcA6AyEfqDX5bWige/4NQfPZMtASNVxdmWR76WESYQVAACSgWcR6e9i0mofqqBxYFtL4oAxPIptY73/0YE1DQ==",
+      "requires": {
+        "imurmurhash": "^0.1.4"
       }
     },
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="
+    },
+    "update-browserslist-db": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
+      "integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
+      "requires": {
+        "escalade": "^3.1.1",
+        "picocolors": "^1.0.0"
+      }
     },
     "uri-js": {
       "version": "4.4.0",
@@ -10276,21 +10809,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
-    },
-    "verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
-      }
-    },
-    "vlq": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
-      "integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow=="
     },
     "vm-browserify": {
       "version": "1.1.2",
@@ -10424,19 +10942,14 @@
       "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ=="
     },
     "yallist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yaml": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
-      "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg=="
-    },
-    "yapool": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/yapool/-/yapool-1.0.0.tgz",
-      "integrity": "sha1-9pPymjFbUNmp2iZGp6ZkXJaYW2o="
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
     },
     "yargs": {
       "version": "17.6.2",
@@ -10546,11 +11059,6 @@
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
       }
-    },
-    "yn": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "lodash.get": "^4.4.2",
     "lodash.set": "^4.3.2",
     "lodash.unset": "^4.5.2",
+    "make-fetch-happen": "^11.0.2",
     "markdown": "^0.5.0",
     "markdown-it": "^13.0.1",
     "messageformat": "^2.3.0",
@@ -88,12 +89,11 @@
     "prom-client": "^12.0.0",
     "proxyquire": "^2.1.3",
     "replace-in-file": "^6.3.5",
-    "request-promise-native": "^1.0.8",
     "shelljs": "^0.8.5",
     "shorthash": "0.0.2",
     "sort-keys": "^4.2.0",
     "striptags": "^3.2.0",
-    "tap": "^14.11.0",
+    "tap": "^16.3.2",
     "type-is": "^1.6.18",
     "uuid": "^8.3.2",
     "write-file-atomic": "^5.0.0",
@@ -115,5 +115,8 @@
   },
   "_moduleAliases": {
     "~/fb-runner-node": "./lib"
+  },
+  "tap": {
+    "check-coverage": false
   }
 }


### PR DESCRIPTION
This PR solely focusses on bumping `tap` and fixing the deprecation warnings as a result.

91 of the changed files are changing `tap`'s built-in methods to their new variant (e.g. `is` to `same`, `deepEqual` to `same`).

2 of the files are `package.lock`, and `package-lock.json`.

The final file (to make 94 changes files) is [lib/middleware/healthcheck/healthcheck.js](https://github.com/ministryofjustice/fb-runner-node/compare/bump-tap?expand=1#diff-e9b7e31328f9dbe31a5d153c2cccb65b3f18ab54210e8a46ce22bc38052b79b0). This replaces `request-promise-native`, which has been deprecated since 2020, to `make-fetch-happen`, a drop-in replacement for `request`.