### PR TITLE
Add checkout step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,6 +144,7 @@ jobs:
   smoke_tests:
     docker: *ecr_image
     steps:
+      - checkout
       - setup_remote_docker: *remote_docker
       - run: *deploy_scripts
       - run:


### PR DESCRIPTION
Failing to clone the deploy scripts from the fb-deploy repo due to issues with the RSA host key for github.
Add the checkout step as this automatically adds the authenticating key required to interact with GitHub.